### PR TITLE
Add an example of using coerce

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,13 +18,13 @@ tt.native:
 tt.byte:
 	ocamlbuild -I src -lib unix $(OCAMLBUILD_MENHIRFLAGS) $(OCAMLBUILD_CFLAGS) tt.byte
 
-smoketest: tt.byte
+smoketest: tt.native brazil.native
 	./tt.native examples/t.tt && \
 	  ./tt.native examples/wild.tt && \
 	  ./tt.native examples/brazil.tt && \
 	  ./tt.native examples/brazilBool.tt && \
-	  ./tt.native examples/evil.tt && \
-	  ./tt.native examples/paths_to_id.tt
+	  ./tt.native examples/paths_to_id.tt && \
+	  ./brazil.native examples/coerce.br
 	@echo
 	@echo "************************"
 	@echo "* Smoke test succeeded *"

--- a/examples/coerce.br
+++ b/examples/coerce.br
@@ -1,0 +1,1 @@
+Definition up : Universe f0 -> Universe f1 := fun x : Universe f0 => (coerce (f1 , x)).


### PR DESCRIPTION
So that if someone else comes a-looking, they won't have to infer the
syntax of "coerce" by guess-and-check and syntax errors with helpful
character indices.

Also, I fixed the smoketest recipe.
