### PR TITLE
Meta level data

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -100,5 +100,5 @@ is a nearby place.
 The GitHub repository is linked to Travis CI. To find out the current build status is
 displayed here:
 
-  [![Build Status](https://api.travis-ci.org/andrejbauer/andromeda.png?branch=master)](https://travis-ci.org/andrejbauer/andromeda)
+  [![Build Status](https://api.travis-ci.org/Andromedans/andromeda.png?branch=master)](https://travis-ci.org/Andromedans/andromeda)
 

--- a/src/andromeda.ml
+++ b/src/andromeda.ml
@@ -151,7 +151,7 @@ let rec exec_cmd base_dir interactive env c =
              | v -> v
        end
      in
-       if interactive then Format.printf "%t@." (Value.print (Environment.used_names env) v) ;
+       if interactive then Format.printf "%t@." (Value.print_value (Environment.used_names env) v) ;
        env
 
   | Syntax.TopBeta xscs ->

--- a/src/nucleus/environment.ml
+++ b/src/nucleus/environment.ml
@@ -185,8 +185,142 @@ let print env ppf =
 
 exception Match_fail
 
-let match_tt_pattern env xvs p ctx e t =
-  assert false
+let rec collect_tt_pattern env xvs (p',_) ctx ((e',_) as e) t =
+  match p', e' with
+    | Syntax.Tt_Anonymous, _ -> xvs
+
+    | Syntax.Tt_Var k, _ ->
+      let v = Value.Term (ctx,e,t) in
+      begin try
+          let v' = List.assoc k xvs in
+          if Value.equal_value v v'
+          then xvs
+          else raise Match_fail
+        with | Not_found ->
+          (k,v) :: xvs
+      end
+
+    | Syntax.Tt_Bound k, _ ->
+      let v' = lookup_bound k env in
+      if Value.equal_value (Value.Term (ctx,e,t)) v'
+      then xvs
+      else raise Match_fail
+
+    | Syntax.Tt_Type, Tt.Type ->
+      xvs
+
+    | Syntax.Tt_Constant x, Tt.Constant (y,lst) ->
+      if lst = [] && Name.eq_ident x y
+      then xvs
+      else raise Match_fail
+
+    | Syntax.Tt_Lambda (x,popt,p), Tt.Lambda ((x',ty)::abs,(te,out)) ->
+      let Tt.Ty t = ty in let _,loc = t in
+      let xvs = match popt with
+        | Some pt -> collect_tt_pattern env xvs pt ctx t (Tt.mk_type_ty ~loc)
+        | None -> xvs
+        in
+      let y, ctx = Context.cone ctx x ty in
+      let yt = Value.Term (ctx, Tt.mk_atom ~loc y, ty) in
+      let env = add_bound x yt env in
+      let te = Tt.mk_lambda ~loc:(snd e) abs te out in
+      let te = Tt.unabstract [y] 0 te in
+      let t = Tt.mk_prod_ty ~loc:(snd e) abs out in
+      let t = Tt.unabstract_ty [y] 0 t in
+      let xvs = collect_tt_pattern env xvs p ctx te t in
+      xvs
+
+    | Syntax.Tt_App (p1,p2), Tt.Spine (te,abs,lst) ->
+      assert false (* TODO *)
+
+    | Syntax.Tt_Prod (x,popt,p), Tt.Prod ((x',ty)::abs,out) ->
+      let Tt.Ty t = ty in let _,loc = t in
+      let xvs = match popt with
+        | Some pt -> collect_tt_pattern env xvs pt ctx t (Tt.mk_type_ty ~loc)
+        | None -> xvs
+        in
+      let y, ctx = Context.cone ctx x ty in
+      let yt = Value.Term (ctx, Tt.mk_atom ~loc y, ty) in
+      let env = add_bound x yt env in
+      let t = Tt.mk_prod ~loc:(snd e) abs out in
+      let t = Tt.unabstract [y] 0 t in
+      let xvs = collect_tt_pattern env xvs p ctx t (Tt.mk_type_ty ~loc:(snd e)) in
+      xvs
+
+    | Syntax.Tt_Eq (p1,p2), Tt.Eq (ty,te1,te2) ->
+      let xvs = collect_tt_pattern env xvs p1 ctx te1 ty in
+      let xvs = collect_tt_pattern env xvs p2 ctx te2 ty in
+      xvs
+
+    | Syntax.Tt_Refl p, Tt.Refl (ty,te) ->
+      let xvs = collect_tt_pattern env xvs p ctx te ty in
+      xvs
+
+    | Syntax.Tt_Inhab, Tt.Inhab _ ->
+      xvs
+
+    | Syntax.Tt_Bracket p, Tt.Bracket (Tt.Ty ty) ->
+      let _,loc = ty in
+      let xvs = collect_tt_pattern env xvs p ctx ty (Tt.mk_type_ty ~loc) in
+      xvs
+
+    | Syntax.Tt_Signature xps, Tt.Signature xts ->
+      let rec fold env xvs ys ctx xps xts =
+        match xps, xts with
+          | [], [] ->
+            xvs
+          | (l,x,p)::xps, (l',x',t)::xts ->
+            if Name.eq_ident l l'
+            then
+              let t = Tt.unabstract_ty ys 0 t in
+              let Tt.Ty t' = t in let (_, loc) = t' in
+              let xvs = collect_tt_pattern env xvs p ctx t' (Tt.mk_type_ty ~loc) in
+              let y, ctx = Context.cone ctx x t in
+              let yt = Value.Term (ctx, Tt.mk_atom ~loc y, t) in
+              let env = add_bound x yt env in
+              fold env xvs (y::ys) ctx xps xts
+            else raise Match_fail
+          | _::_, [] | [], _::_ ->
+            raise Match_fail
+        in
+      fold env xvs [] ctx xps xts
+
+    | Syntax.Tt_Structure xps, Tt.Structure xts ->
+      let rec fold env xvs ys ctx xps xts =
+        match xps, xts with
+          | [], [] ->
+            xvs
+          | (l,x,p)::xps, (l',x',t,te)::xts ->
+            if Name.eq_ident l l'
+            then
+              let t = Tt.unabstract_ty ys 0 t in
+              let te = Tt.unabstract ys 0 te in
+              let xvs = collect_tt_pattern env xvs p ctx te t in
+              let y, ctx = Context.cone ctx x t in
+              let Tt.Ty (_,loc) = t in
+              let yt = Value.Term (ctx, Tt.mk_atom ~loc y, t) in
+              let env = add_bound x yt env in
+              fold env xvs (y::ys) ctx xps xts
+            else raise Match_fail
+          | _::_, [] | [], _::_ ->
+            raise Match_fail
+        in
+      fold env xvs [] ctx xps xts
+
+    | Syntax.Tt_Projection (p,l), Tt.Projection (te,xts,l') ->
+      if Name.eq_ident l l'
+      then
+        let _,loc = e in
+        let xvs = collect_tt_pattern env xvs p ctx te (Tt.mk_signature_ty ~loc xts) in
+        xvs
+      else raise Match_fail
+
+    | (Syntax.Tt_Type | Syntax.Tt_Constant _ | Syntax.Tt_Lambda _ | Syntax.Tt_App _
+        | Syntax.Tt_Prod _ | Syntax.Tt_Eq _ | Syntax.Tt_Refl _ | Syntax.Tt_Inhab
+        | Syntax.Tt_Bracket _ | Syntax.Tt_Signature _ | Syntax.Tt_Structure _
+        | Syntax.Tt_Projection _) , _ ->
+      raise Match_fail
+
 
 let match_pattern env xs p v =
   (* collect values of pattern variables *)
@@ -209,9 +343,11 @@ let match_pattern env xs p v =
        then xvs
        else raise Match_fail
 
-    | Syntax.Patt_Jdg (pe, pt), Value.Term (ctx, e, ((Tt.Ty (t', loc)) as t)) ->
-       let xvs = match_tt_pattern env xvs pt ctx t' (Tt.mk_type_ty ~loc) in
-       match_tt_pattern env xvs pe ctx e t
+    | Syntax.Patt_Jdg (pe, pt), Value.Term (ctx, e, t) ->
+       let Tt.Ty t' = t in
+       let _,loc = t' in
+       let xvs = collect_tt_pattern env xvs pt ctx t' (Tt.mk_type_ty ~loc) in
+       collect_tt_pattern env xvs pe ctx e t
 
     | Syntax.Patt_Tag (tag, ps), Value.Tag (tag', vs) when Name.eq_ident tag tag' ->
        let rec fold xvs = function

--- a/src/nucleus/environment.ml
+++ b/src/nucleus/environment.ml
@@ -314,7 +314,7 @@ let rec collect_tt_pattern env xvs (p',_) ctx ((e',_) as e) t =
         match xps, xts with
           | [], [] ->
             xvs
-          | (l,x,p)::xps, (l',x',t)::xts ->
+          | (l,x,bopt,p)::xps, (l',x',t)::xts ->
             if Name.eq_ident l l'
             then
               let t = Tt.unabstract_ty ys 0 t in
@@ -323,6 +323,18 @@ let rec collect_tt_pattern env xvs (p',_) ctx ((e',_) as e) t =
               let y, ctx = Context.cone ctx x t in
               let yt = Value.Term (ctx, Tt.mk_atom ~loc y, t) in
               let env = add_bound x yt env in
+              let xvs = match bopt with
+                | None -> xvs
+                | Some k ->
+                  begin try
+                    let v' = List.assoc k xvs in
+                    if Value.equal_value yt v'
+                    then xvs
+                    else raise Match_fail
+                  with
+                    | Not_found -> (k,yt)::xvs
+                  end
+                in
               fold env xvs (y::ys) ctx xps xts
             else raise Match_fail
           | _::_, [] | [], _::_ ->
@@ -335,7 +347,7 @@ let rec collect_tt_pattern env xvs (p',_) ctx ((e',_) as e) t =
         match xps, xts with
           | [], [] ->
             xvs
-          | (l,x,p)::xps, (l',x',t,te)::xts ->
+          | (l,x,bopt,p)::xps, (l',x',t,te)::xts ->
             if Name.eq_ident l l'
             then
               let t = Tt.unabstract_ty ys 0 t in
@@ -345,6 +357,18 @@ let rec collect_tt_pattern env xvs (p',_) ctx ((e',_) as e) t =
               let Tt.Ty (_,loc) = t in
               let yt = Value.Term (ctx, Tt.mk_atom ~loc y, t) in
               let env = add_bound x yt env in
+              let xvs = match bopt with
+                | None -> xvs
+                | Some k ->
+                  begin try
+                    let v' = List.assoc k xvs in
+                    if Value.equal_value yt v'
+                    then xvs
+                    else raise Match_fail
+                  with
+                    | Not_found -> (k,yt)::xvs
+                  end
+                in
               fold env xvs (y::ys) ctx xps xts
             else raise Match_fail
           | _::_, [] | [], _::_ ->

--- a/src/nucleus/environment.ml
+++ b/src/nucleus/environment.ml
@@ -206,16 +206,17 @@ let rec collect_tt_pattern env xvs (p',_) ctx ((e',_) as e) t =
   match p', e' with
     | Syntax.Tt_Anonymous, _ -> xvs
 
-    | Syntax.Tt_Var k, _ ->
+    | Syntax.Tt_As (p,k), _ ->
       let v = Value.Term (ctx,e,t) in
-      begin try
+      let xvs = try
           let v' = List.assoc k xvs in
           if Value.equal_value v v'
           then xvs
           else raise Match_fail
         with | Not_found ->
           (k,v) :: xvs
-      end
+        in
+      collect_tt_pattern env xvs p ctx e t
 
     | Syntax.Tt_Bound k, _ ->
       let v' = lookup_bound k env in
@@ -348,14 +349,15 @@ let match_pattern env xs p v =
     match p, v with 
     | Syntax.Patt_Anonymous, _ -> xvs
 
-    | Syntax.Patt_Var k, v ->
-       begin try
+    | Syntax.Patt_As (p,k), v ->
+       let xvs = try
            let v' = List.assoc k xvs in
            if Value.equal_value v v'
            then xvs
            else raise Match_fail
          with Not_found -> (k,v) :: xvs
-       end
+         in
+       collect xvs p v
 
     | Syntax.Patt_Bound k, v ->
        let v' = lookup_bound k env in

--- a/src/nucleus/environment.mli
+++ b/src/nucleus/environment.mli
@@ -73,3 +73,7 @@ val included : string -> t -> bool
 
 (** Print free variables in the environment *)
 val print : t -> Format.formatter -> unit
+
+(** Match a value against a pattern and extend the environment with the
+    matched pattern variables. *)
+val match_pattern : t -> Name.ident list -> Syntax.pattern -> Value.value -> t option

--- a/src/nucleus/eval.ml
+++ b/src/nucleus/eval.ml
@@ -428,7 +428,7 @@ and check env ((c',loc) as c) (((ctx_check, t_check') as t_check) : Judgement.ty
      let t = Judgement.mk_ty ctx t' in
      begin match Equal.inhabit_bracket ~subgoals:true ~loc env t with
            | Some (ctx,_) ->
-              Value.return (ctx, Tt.mk_inhab ~loc)
+              Value.return (ctx, Tt.mk_inhab ~loc t')
            | None -> Error.typing ~loc "do not know how to inhabit %t"
                                   (print_ty env t')
      end

--- a/src/nucleus/eval.ml
+++ b/src/nucleus/eval.ml
@@ -135,6 +135,8 @@ and infer env (c',loc) =
      and v2 = expr env e2 in
        v1 v2
 
+  | Syntax.Match _ -> assert false (* TODO *)
+
   | Syntax.Beta (xscs, c) ->
     beta_bind env xscs >>= (fun env -> infer env c)
 
@@ -303,6 +305,7 @@ and check env ((c',loc) as c) (((ctx_check, t_check') as t_check) : Judgement.ty
   | Syntax.With _
   | Syntax.Typeof _
   | Syntax.Apply _
+  | Syntax.Match _
   | Syntax.Constant _
   | Syntax.Prod _
   | Syntax.Eq _

--- a/src/nucleus/eval.ml
+++ b/src/nucleus/eval.ml
@@ -48,6 +48,10 @@ let rec expr env (e',loc) =
     | Syntax.Function (x, c) ->
        Value.Closure (close x c)
 
+    | Syntax.Tag (t, lst) ->
+       let lst = List.map (expr env) lst in
+       Value.Tag (t, lst)
+
     | Syntax.Handler {Syntax.handler_val; handler_ops; handler_finally} ->
        let handler_val =
          begin match handler_val with
@@ -79,6 +83,7 @@ and expr_term env ((_,loc) as e) =
   | Value.Term et -> et
   | Value.Handler _ -> Error.runtime ~loc "this expression should be a term but is a handler"
   | Value.Closure _ -> Error.runtime ~loc "this expression should be a term but is a closure"
+  | Value.Tag _ -> Error.runtime ~loc "this expression should be a term but is a tag"
 
 (** Evaluate a computation -- infer mode. *)
 and infer env (c',loc) =

--- a/src/nucleus/eval.ml
+++ b/src/nucleus/eval.ml
@@ -141,24 +141,16 @@ and infer env (c',loc) =
 
   | Syntax.Match (e,cases) ->
     let v = expr env e in
-    let rec prematch cases = function
-      | [] ->
-        Value.return (List.rev cases)
-      | (b,p,c)::rem ->
-        case env b p >>= fun p ->
-        prematch ((p,c)::cases) rem
-      in
-    prematch [] cases >>= fun cases ->
-    let rec findcase = function
+    let rec fold = function
       | [] ->
         Error.typing ~loc "No match found for %t" (print_value env v)
-      | (p,c)::rem ->
-        begin match assert false (* TODO *) with
+      | (xs, p, c) :: cases ->
+        begin match Environment.match_pattern env xs p v with
           | Some env -> infer env c
-          | None -> findcase rem
+          | None -> fold cases
         end
       in
-    findcase cases
+    fold cases
 
   | Syntax.Beta (xscs, c) ->
     beta_bind env xscs >>= (fun env -> infer env c)
@@ -729,20 +721,6 @@ and inhabit_bind env xscs =
                (Pattern.print_inhabit_hint [] h)) "," xshs);
       Value.return env
   in fold [] xscs
-
-(** [case env b p] constructs a Pattern.meta from binders [b] and pattern [p] *)
-and case env b p =
-  let rec fold env xts = function
-    | [] ->
-      let xts = List.rev xts in
-      pattern env p >>= fun p ->
-      Value.return (xts, p)
-    | x::rem ->
-      assert false (* TODO *)
-    in
-  fold env [] b
-
-and pattern env (p,loc) = assert false (* TODO *)
 
 and check_ty env c : Judgement.ty Value.result =
   check env c Judgement.ty_ty >>=

--- a/src/nucleus/hint.ml
+++ b/src/nucleus/hint.ml
@@ -34,7 +34,7 @@ let rec of_term env pvars ((e',loc) as e) t =
   let original = pvars, Pattern.Term (e,t) in
   match e' with
 
-  | Tt.Type | Tt.Inhab | Tt.Lambda _ | Tt.Prod _ -> original
+  | Tt.Type | Tt.Inhab _ | Tt.Lambda _ | Tt.Prod _ -> original
 
   | Tt.Atom x -> pvars, Pattern.Atom x
 

--- a/src/nucleus/judgement.ml
+++ b/src/nucleus/judgement.ml
@@ -12,15 +12,17 @@ let mk_ty ctx t = (ctx, t)
 
 let ty_ty = (Context.empty, Tt.typ)
 
-let print_term xs (ctx, e,t) ppf =
-  Format.fprintf ppf "%t@[<hov 2>%s %t@\n    : %t@]"
+let print_term ?max_level xs (ctx, e,t) ppf =
+  Print.print ?max_level ~at_level:100 ppf
+              "%t@[<hov 2>%s %t@ : %t@]"
               (Context.print ctx)
               (Print.char_vdash ())
               (Tt.print_term ~max_level:999 xs e)
               (Tt.print_ty ~max_level:999 xs t)
 
-let print_ty xs (ctx, t) ppf =
-  Print.print ~at_level:0 ppf "%t@[<hov 2>%s %t@\n    type@]"
+let print_ty ?max_level xs (ctx, t) ppf =
+  Print.print ?max_level ~at_level:0 ppf
+              "%t@[<hov 2>%s %t@ type@]"
               (Context.print ctx)
               (Print.char_vdash ())
               (Tt.print_ty ~max_level:999 xs t)

--- a/src/nucleus/judgement.mli
+++ b/src/nucleus/judgement.mli
@@ -20,9 +20,9 @@ val mk_term : Context.t -> Tt.term -> Tt.ty -> term
 val mk_ty : Context.t -> Tt.ty -> ty
 
 (** Print the judgement that something is a term. *)
-val print_term : Name.ident list -> term -> Format.formatter -> unit
+val print_term : ?max_level:int -> Name.ident list -> term -> Format.formatter -> unit
 
 (** Print the judgement that something is a type. *)
-val print_ty : Name.ident list -> ty -> Format.formatter -> unit
+val print_ty : ?max_level:int -> Name.ident list -> ty -> Format.formatter -> unit
 
 

--- a/src/nucleus/pattern.ml
+++ b/src/nucleus/pattern.ml
@@ -63,7 +63,7 @@ let rec term_key_opt (e',loc) =
   | Tt.Prod _ -> Some Key_Prod
   | Tt.Eq _ -> Some Key_Eq
   | Tt.Refl _ -> Some Key_Refl
-  | Tt.Inhab -> Some Key_Inhab
+  | Tt.Inhab _ -> Some Key_Inhab
   | Tt.Bracket _ -> Some Key_Bracket
   | Tt.Signature lst -> Some (Key_Signature (List.length lst))
   | Tt.Structure lst -> Some (Key_Structure (List.length lst))

--- a/src/nucleus/simplify.ml
+++ b/src/nucleus/simplify.ml
@@ -3,7 +3,7 @@
 let is_small (e',_) =
 match e' with
   | Tt.Constant (_, es) -> es = []
-  | Tt.Type | Tt.Inhab | Tt.Bound _ | Tt.Atom _ -> true
+  | Tt.Type | Tt.Inhab _ | Tt.Bound _ | Tt.Atom _ -> true
   | Tt.Lambda _ | Tt.Spine _ | Tt.Prod _ | Tt.Refl _ | Tt.Eq _
   | Tt.Bracket _ | Tt.Signature _ | Tt.Structure _ | Tt.Projection _ -> false
 
@@ -12,7 +12,9 @@ let rec term ((e',loc) as e) =
 
     | Tt.Type -> e
 
-    | Tt.Inhab -> e
+    | Tt.Inhab t ->
+       let t = ty t in
+       Tt.mk_inhab ~loc t
 
     | Tt.Atom _ -> e
 
@@ -176,7 +178,7 @@ and spine ~loc h xts t es =
   | Tt.Spine _
   | Tt.Atom _
   | Tt.Type
-  | Tt.Inhab
+  | Tt.Inhab _
   | Tt.Bracket _
   | Tt.Prod _
   | Tt.Eq _
@@ -204,7 +206,7 @@ and project ~loc te xts p =
     | Tt.Spine _
     | Tt.Atom _
     | Tt.Type
-    | Tt.Inhab
+    | Tt.Inhab _
     | Tt.Bracket _
     | Tt.Prod _
     | Tt.Eq _

--- a/src/nucleus/tt.mli
+++ b/src/nucleus/tt.mli
@@ -59,7 +59,7 @@ and term' = private
   | Refl of ty * term
 
   (** the inhabitant of a bracket type *)
-  | Inhab
+  | Inhab of ty
 
   (** bracket type *)
   | Bracket of ty
@@ -106,7 +106,7 @@ val mk_eq_ty: loc:Location.t -> ty -> term -> term -> ty
 val mk_refl: loc:Location.t -> ty -> term -> term
 val mk_bracket: loc:Location.t -> ty -> term
 val mk_bracket_ty: loc:Location.t -> ty -> ty
-val mk_inhab: loc:Location.t -> term
+val mk_inhab: loc:Location.t -> ty -> term
 val mk_signature : loc:Location.t -> signature -> term
 val mk_signature_ty : loc:Location.t -> signature -> ty
 val mk_structure : loc:Location.t -> structure -> term

--- a/src/nucleus/value.ml
+++ b/src/nucleus/value.ml
@@ -5,6 +5,7 @@ type value =
   | Ty of Judgement.ty
   | Closure of closure
   | Handler of handler
+  | Tag of Name.ident * value list
 
 and closure = value -> value result
 
@@ -31,36 +32,44 @@ let print_closure xs _ ppf =
 let print_handler xs h ppf =
   Print.print ~at_level:0 ppf "<handler>" (* XXX improve in your spare time *)
 
+let print_tag xs t lst ppf =
+  Print.print ~at_level:0 ppf "<must go home>"
+
 let print ?max_level xs v ppf =
   match v with
   | Term e -> Judgement.print_term xs e ppf
   | Ty t -> Judgement.print_ty xs t ppf
   | Closure f -> print_closure xs f ppf
   | Handler h -> print_handler xs h ppf
+  | Tag (t, lst) -> print_tag xs t lst ppf
 
 let as_term ~loc = function
   | Term e -> e
   | Ty _ -> Error.runtime ~loc "expected a term but got a type"
   | Closure _ -> Error.runtime ~loc "expected a term but got a function"
   | Handler _ -> Error.runtime ~loc "expected a term but got a handler"
+  | Tag _  -> assert false
 
 let as_ty ~loc = function
   | Term _ -> Error.runtime ~loc "expected a type but got a term"
   | Ty t -> t
   | Closure _ -> Error.runtime ~loc "expected a type but got a function"
   | Handler _ -> Error.runtime ~loc "expected a type but got a handler"
+  | Tag _  -> assert false
 
 let as_closure ~loc = function
   | Term _ -> Error.runtime ~loc "expected a function but got a term"
   | Ty _ -> Error.runtime ~loc "expected a function but got a type"
   | Closure f -> f
   | Handler _ -> Error.runtime ~loc "expected a function but got a handler"
+  | Tag _  -> assert false
 
 let as_handler ~loc = function
   | Term _ -> Error.runtime ~loc "expected a handler but got a term"
   | Ty _ -> Error.runtime ~loc "expected a handler but got a type"
   | Closure _ -> Error.runtime ~loc "expected a handler but got a function"
   | Handler h -> h
+  | Tag _  -> assert false
 
 let return x = Return x
 

--- a/src/nucleus/value.ml
+++ b/src/nucleus/value.ml
@@ -85,3 +85,6 @@ let to_value ~loc = function
   | Return v -> v
   | Operation (op, _, _) ->
      Error.runtime ~loc "unhandled operation %t" (Name.print_op op)
+
+let equal_value v1 v2 =
+  assert false

--- a/src/nucleus/value.mli
+++ b/src/nucleus/value.mli
@@ -40,7 +40,7 @@ val return_ty : Judgement.ty -> value result
 val bind: 'a result -> ('a -> 'b result)  -> 'b result
 
 (** Pretty-print a value. *)
-val print : ?max_level:int -> Name.ident list -> value -> Format.formatter -> unit
+val print_value : ?max_level:int -> Name.ident list -> value -> Format.formatter -> unit
 
 (** Check that a result is a value and return it, or complain. *)
 val to_value : loc:Location.t -> 'a result -> 'a

--- a/src/nucleus/value.mli
+++ b/src/nucleus/value.mli
@@ -11,6 +11,7 @@ type value =
   | Ty of Judgement.ty
   | Closure of closure
   | Handler of handler
+  | Tag of Name.ident * value list
 
  and closure = value -> value result
 

--- a/src/nucleus/value.mli
+++ b/src/nucleus/value.mli
@@ -44,3 +44,6 @@ val print_value : ?max_level:int -> Name.ident list -> value -> Format.formatter
 
 (** Check that a result is a value and return it, or complain. *)
 val to_value : loc:Location.t -> 'a result -> 'a
+
+(** Check whether two values are equal. *)
+val equal_value: value -> value -> bool

--- a/src/parser/desugar.ml
+++ b/src/parser/desugar.ml
@@ -292,23 +292,17 @@ and handler ~loc constants bound hcs =
   Syntax.Handler (Syntax.{handler_val; handler_ops; handler_finally}), loc
 
 (* Desugar a match case *)
-and case constants bound (xcs, p, c) =
-  let rec fold bound ys = function
+and case constants bound (xs, p, c) =
+  let rec fold bound = function
     | [] ->
-       let ys = List.rev ys
-       and p = pattern constants bound p
+       let p = pattern constants bound p
        and c = comp constants bound c in
-       (ys, p, c)
-    | (x, None) :: xcs ->
-       let bound = add_bound x bound
-       and ys = (x, None) :: ys in
-       fold bound ys xcs
-    | (x, Some t) :: xcs ->
-       let ys = (let t = comp constants bound t in (x, Some t) :: ys)
-       and bound = add_bound x bound in
-       fold bound ys xcs
+       (xs, p, c)
+    | x :: xs ->
+       let bound = add_bound x bound in
+       fold bound xs
   in
-  fold bound [] xcs
+  fold bound xs
 
 and pattern constants bound (p, loc) =
   match p with

--- a/src/parser/desugar.ml
+++ b/src/parser/desugar.ml
@@ -331,7 +331,7 @@ and pattern constants bound varn present (p,loc) =
           if k < varn
           then
             let present = IntSet.add k present in
-            (Syntax.Patt_Var k, loc), present
+            (Syntax.Patt_As ((Syntax.Patt_Anonymous, loc), k), loc), present
           else
             (Syntax.Patt_Bound (k-varn), loc), present
       end
@@ -373,7 +373,7 @@ and tt_pattern constants bound varn lvl present (p,loc) =
           else if k-lvl < varn
           then
             let present = IntSet.add (k-lvl) present in
-            (Syntax.Tt_Var (k-lvl), loc), present
+            (Syntax.Tt_As ((Syntax.Tt_Anonymous, loc), k-lvl), loc), present
           else
             (Syntax.Tt_Bound (k-varn), loc), present
       end

--- a/src/parser/desugar.ml
+++ b/src/parser/desugar.ml
@@ -413,8 +413,15 @@ and tt_pattern constants bound varn lvl present (p,loc) =
           let p,present = tt_pattern constants bound varn lvl present p in
           Some p, present
         in
+      let bopt, present = match Name.index_of_ident x bound with
+        | None -> None, present
+        | Some k ->
+          if k >= lvl && k-lvl < varn
+          then Some (k-lvl), IntSet.add (k-lvl) present
+          else None, present
+        in
       let p, present = tt_pattern constants (add_bound x bound) varn (lvl+1) present p in
-      (Syntax.Tt_Lambda (x,popt,p), loc), present
+      (Syntax.Tt_Lambda (x,bopt,popt,p), loc), present
 
     | Input.Tt_App (p1,p2) ->
       let p1, present = tt_pattern constants bound varn lvl present p1 in
@@ -429,8 +436,15 @@ and tt_pattern constants bound varn lvl present (p,loc) =
           let p,present = tt_pattern constants bound varn lvl present p in
           Some p, present
         in
+      let bopt, present = match Name.index_of_ident x bound with
+        | None -> None, present
+        | Some k ->
+          if k >= lvl && k-lvl < varn
+          then Some (k-lvl), IntSet.add (k-lvl) present
+          else None, present
+        in
       let p, present = tt_pattern constants (add_bound x bound) varn (lvl+1) present p in
-      (Syntax.Tt_Prod (x,popt,p), loc), present
+      (Syntax.Tt_Prod (x,bopt,popt,p), loc), present
 
     | Input.Tt_Eq (p1,p2) ->
       let p1, present = tt_pattern constants bound varn lvl present p1 in

--- a/src/parser/desugar.ml
+++ b/src/parser/desugar.ml
@@ -88,6 +88,9 @@ let rec comp constants bound ((c',loc) as c) =
        and e2 = Syntax.shift_expr k1 k2 e2 in
        w1 @ w2, Syntax.Apply (e1, e2)
 
+    | Input.Match (v,cases) ->
+       assert false (* TODO *)
+
     | Input.Beta (xscs, c) ->
       let xscs = List.map (fun (xs, c) -> xs, comp constants bound c) xscs in
       let c = comp constants bound c in
@@ -349,7 +352,7 @@ and expr constants bound ((e', loc) as e) =
   | (Input.Let _ | Input.Beta _ | Input.Eta _ | Input.Hint _ | Input.Inhabit _ |
      Input.Unhint _ | Input.Bracket _ | Input.Inhab | Input.Ascribe _ | Input.Lambda _ |
      Input.Spine _ | Input.Prod _ | Input.Eq _ | Input.Refl _ | Input.Operation _ |
-     Input.Whnf _ | Input.Apply _ | Input.Handle _ | Input.With _ |
+     Input.Whnf _ | Input.Apply _ | Input.Match _ | Input.Handle _ | Input.With _ |
      Input.Typeof _ | Input.Assume _ | Input.Where _ | Input.Signature _ |
      Input.Structure _ | Input.Projection _) ->
     let x = Name.fresh_candy ()

--- a/src/parser/desugar.ml
+++ b/src/parser/desugar.ml
@@ -305,21 +305,7 @@ and case constants bound (xs, p, c) =
   fold bound xs
 
 and pattern constants bound (p, loc) =
-  match p with
-    | Input.MatchVar x -> 
-       begin
-         match Name.index_of_ident x bound with
-         | Some m -> Syntax.MatchVar m, loc
-         | None -> Error.syntax ~loc "unknown name %t" (Name.print_ident x)
-       end
-    | Input.MatchTag (t, ps) ->
-       let ps = List.map (pattern constants bound) ps in
-       Syntax.MatchTag (t, ps), loc
-    | Input.MatchJdg (c1, c2) ->
-       let c1 = comp constants bound c1
-       and c2 = comp constants bound c1 in
-       Syntax.MatchJdg (c1, c2), loc
-
+  assert false (* TODO *)
 
 (* Make constant as if it were in an expression position *)
 and constant ~loc constants bound x cs =

--- a/src/parser/desugar.ml
+++ b/src/parser/desugar.ml
@@ -469,8 +469,15 @@ and tt_pattern constants bound varn lvl present (p,loc) =
           (Syntax.Tt_Signature xps, loc), present
         | (l,xopt,p)::rem ->
           let x = match xopt with | Some x -> x | None -> l in
+          let bopt, present = match Name.index_of_ident x bound with
+            | None -> None, present
+            | Some k ->
+              if k >= lvl && k-lvl < varn
+              then Some (k-lvl), IntSet.add (k-lvl) present
+              else None, present
+            in
           let p, present = tt_pattern constants bound varn lvl present p in
-          fold (add_bound x bound) (lvl+1) present ((l,x,p)::xps) rem
+          fold (add_bound x bound) (lvl+1) present ((l,x,bopt,p)::xps) rem
         in
       fold bound lvl present [] xps
 
@@ -481,8 +488,15 @@ and tt_pattern constants bound varn lvl present (p,loc) =
           (Syntax.Tt_Structure xps, loc), present
         | (l,xopt,p)::rem ->
           let x = match xopt with | Some x -> x | None -> l in
+          let bopt, present = match Name.index_of_ident x bound with
+            | None -> None, present
+            | Some k ->
+              if k >= lvl && k-lvl < varn
+              then Some (k-lvl), IntSet.add (k-lvl) present
+              else None, present
+            in
           let p, present = tt_pattern constants bound varn lvl present p in
-          fold (add_bound x bound) (lvl+1) present ((l,x,p)::xps) rem
+          fold (add_bound x bound) (lvl+1) present ((l,x,bopt,p)::xps) rem
         in
       fold bound lvl present [] xps
 

--- a/src/parser/input.mli
+++ b/src/parser/input.mli
@@ -5,6 +5,30 @@
     However, we define type aliases for these for better readability.
     There are no de Bruijn indices either. *)
 
+(** Sugared term patterns *)
+type tt_pattern = tt_pattern' * Location.t
+and tt_pattern' =
+  | Tt_Anonymous
+  | Tt_Type
+  | Tt_Name of Name.ident
+  | Tt_Lambda of Name.ident * tt_pattern option * tt_pattern
+  | Tt_App of tt_pattern * tt_pattern
+  | Tt_Prod of Name.ident * tt_pattern option * tt_pattern
+  | Tt_Eq of tt_pattern * tt_pattern
+  | Tt_Refl of tt_pattern
+  | Tt_Inhab
+  | Tt_Bracket of tt_pattern
+  | Tt_Signature of (Name.ident * Name.ident option * tt_pattern) list
+  | Tt_Structure of (Name.ident * Name.ident option * tt_pattern) list
+  | Tt_Projection of tt_pattern * Name.ident
+
+type pattern = pattern' * Location.t
+and pattern' =
+  | Patt_Anonymous
+  | Patt_Name of Name.ident
+  | Patt_Jdg of tt_pattern * tt_pattern
+  | Patt_Tag of Name.ident * pattern list
+
 (** Sugared terms *)
 type term = term' * Location.t
 and term' =
@@ -56,14 +80,8 @@ and handle_case =
   | CaseVal of Name.ident * comp (* val x -> c *)
   | CaseOp of string * Name.ident * Name.ident * comp (* #op x k -> c *)
   | CaseFinally of Name.ident * comp (* finally x -> c *)
-
-and match_case = Name.ident list * match_pattern * comp
-
-and match_pattern = match_pattern' * Location.t
-and match_pattern' =
-  | MatchVar of Name.ident
-  | MatchTag of Name.ident * match_pattern list
-  | MatchJdg of comp * comp
+                                  
+and match_case = Name.ident list * pattern * comp
 
 (** Sugared toplevel commands *)
 type toplevel = toplevel' * Location.t

--- a/src/parser/input.mli
+++ b/src/parser/input.mli
@@ -9,6 +9,7 @@
 type tt_pattern = tt_pattern' * Location.t
 and tt_pattern' =
   | Tt_Anonymous
+  | Tt_As of tt_pattern * Name.ident
   | Tt_Type
   | Tt_Name of Name.ident
   | Tt_Lambda of Name.ident * tt_pattern option * tt_pattern
@@ -25,6 +26,7 @@ and tt_pattern' =
 type pattern = pattern' * Location.t
 and pattern' =
   | Patt_Anonymous
+  | Patt_As of pattern * Name.ident
   | Patt_Name of Name.ident
   | Patt_Jdg of tt_pattern * tt_pattern
   | Patt_Tag of Name.ident * pattern list

--- a/src/parser/input.mli
+++ b/src/parser/input.mli
@@ -19,6 +19,7 @@ and term' =
   | With of expr * comp
   | Apply of expr * expr
   | Tag of Name.ident * comp list
+  | Match of comp * match_case list
   | Let of (Name.ident * comp) list * comp
   | Assume of (Name.ident * comp) * comp
   | Where of comp * expr * comp
@@ -55,6 +56,12 @@ and handle_case =
   | CaseVal of Name.ident * comp (* val x -> c *)
   | CaseOp of string * Name.ident * Name.ident * comp (* #op x k -> c *)
   | CaseFinally of Name.ident * comp (* finally x -> c *)
+
+and match_case = (Name.ident * comp option) list * match_pattern
+
+and match_pattern =
+  | MatchData of Name.ident * match_pattern list
+  | MatchJdg of comp * comp option
 
 (** Sugared toplevel commands *)
 type toplevel = toplevel' * Location.t

--- a/src/parser/input.mli
+++ b/src/parser/input.mli
@@ -57,11 +57,13 @@ and handle_case =
   | CaseOp of string * Name.ident * Name.ident * comp (* #op x k -> c *)
   | CaseFinally of Name.ident * comp (* finally x -> c *)
 
-and match_case = (Name.ident * comp option) list * match_pattern
+and match_case = (Name.ident * comp option) list * match_pattern * comp
 
-and match_pattern =
-  | MatchData of Name.ident * match_pattern list
-  | MatchJdg of comp * comp option
+and match_pattern = match_pattern' * Location.t
+and match_pattern' =
+  | MatchVar of Name.ident
+  | MatchTag of Name.ident * match_pattern list
+  | MatchJdg of comp * comp
 
 (** Sugared toplevel commands *)
 type toplevel = toplevel' * Location.t

--- a/src/parser/input.mli
+++ b/src/parser/input.mli
@@ -18,6 +18,7 @@ and term' =
   | Handle of comp * handle_case list
   | With of expr * comp
   | Apply of expr * expr
+  | Tag of Name.ident * comp list
   | Let of (Name.ident * comp) list * comp
   | Assume of (Name.ident * comp) * comp
   | Where of comp * expr * comp

--- a/src/parser/input.mli
+++ b/src/parser/input.mli
@@ -57,7 +57,7 @@ and handle_case =
   | CaseOp of string * Name.ident * Name.ident * comp (* #op x k -> c *)
   | CaseFinally of Name.ident * comp (* finally x -> c *)
 
-and match_case = (Name.ident * comp option) list * match_pattern * comp
+and match_case = Name.ident list * match_pattern * comp
 
 and match_pattern = match_pattern' * Location.t
 and match_pattern' =

--- a/src/parser/lexer.ml
+++ b/src/parser/lexer.ml
@@ -109,6 +109,7 @@ and token_aux ({ stream; pos_end; end_of_input; line_limit } as lexbuf) =
   | '_'                      -> f (); UNDERSCORE
   | '|'                      -> f (); BAR
   | '@'                      -> f (); APPLY
+  | '\'', name               -> f (); TAG (let s = lexeme lexbuf in String.sub s 1 (String.length s - 1))
   | "->" | 8594 | 10230      -> f (); ARROW
   (* | "=>" | 10233             -> f (); DARROW *)
   | "==" | 8801              -> f (); EQEQ

--- a/src/parser/lexer.ml
+++ b/src/parser/lexer.ml
@@ -29,10 +29,10 @@ let reserved = [
   ("match", MATCH) ;
   ("Parameter", AXIOM) ;
   ("reduce", REDUCE) ;
-  ("forall", FORALL) ;
-  ("∀", FORALL) ;
-  ("Π", FORALL) ;
-  ("∏", FORALL) ;
+  ("forall", PROD) ;
+  ("∀", PROD) ;
+  ("Π", PROD) ;
+  ("∏", PROD) ;
   ("fun", FUNCTION) ;
   ("lambda", LAMBDA) ;
   ("λ", LAMBDA) ;

--- a/src/parser/lexer.ml
+++ b/src/parser/lexer.ml
@@ -26,6 +26,7 @@ let reserved = [
   ("Inhabit", TOPINHABIT) ;
   ("Let", TOPLET) ;
   ("let", LET) ;
+  ("match", MATCH) ;
   ("Parameter", AXIOM) ;
   ("reduce", REDUCE) ;
   ("forall", FORALL) ;
@@ -40,6 +41,8 @@ let reserved = [
   ("Type", TYPE) ;
   ("typeof", TYPEOF) ;
   ("val", VAL) ;
+  ("|-", VDASH) ;
+  ("⊢", VDASH) ;
   ("where", WHERE) ;
   ("with", WITH)
 ]
@@ -111,7 +114,7 @@ and token_aux ({ stream; pos_end; end_of_input; line_limit } as lexbuf) =
   | '@'                      -> f (); APPLY
   | '\'', name               -> f (); TAG (let s = lexeme lexbuf in String.sub s 1 (String.length s - 1))
   | "->" | 8594 | 10230      -> f (); ARROW
-  (* | "=>" | 10233             -> f (); DARROW *)
+  | "=>" | 10233             -> f (); DARROW
   | "==" | 8801              -> f (); EQEQ
   | eof                      -> f (); EOF
   | (name | numeral)         -> f ();

--- a/src/parser/lexer.ml
+++ b/src/parser/lexer.ml
@@ -41,7 +41,6 @@ let reserved = [
   ("Type", TYPE) ;
   ("typeof", TYPEOF) ;
   ("val", VAL) ;
-  ("|-", VDASH) ;
   ("⊢", VDASH) ;
   ("where", WHERE) ;
   ("with", WITH)
@@ -110,6 +109,7 @@ and token_aux ({ stream; pos_end; end_of_input; line_limit } as lexbuf) =
   | '.', name                -> f (); PROJECTION (let s = lexeme lexbuf in String.sub s 1 (String.length s - 1))
   | '.'                      -> f (); g (); DOT
   | '_'                      -> f (); UNDERSCORE
+  | "|-"                     -> f (); VDASH
   | '|'                      -> f (); BAR
   | '@'                      -> f (); APPLY
   | '\'', name               -> f (); TAG (let s = lexeme lexbuf in String.sub s 1 (String.length s - 1))

--- a/src/parser/parser.mly
+++ b/src/parser/parser.mly
@@ -275,6 +275,8 @@ handler_case:
 
 match_case:
   | BAR a=untyped_binder p=pattern DARROW c=term  { (a, p, c) }
+  | BAR LRBRACK p=pattern DARROW c=term  { ([], p, c) }
+  | BAR p=pattern DARROW c=term  { ([], p, c) }
 
 
 (** Pattern matching *)
@@ -312,6 +314,7 @@ plain_equal_tt_pattern:
 
 app_tt_pattern: mark_location(plain_app_tt_pattern) { $1 }
 plain_app_tt_pattern:
+  | p=plain_simple_tt_pattern                 { p }
   | p1=app_tt_pattern p2=simple_tt_pattern    { Tt_App (p1, p2) }
   | REFL p=simple_tt_pattern                  { Tt_Refl p }
 

--- a/src/parser/parser.mly
+++ b/src/parser/parser.mly
@@ -61,6 +61,9 @@
 (* Substitution *)
 %token WHERE
 
+(* Meta-level programming *)
+%token <string> TAG
+
 (* Toplevel directives *)
 %token ENVIRONMENT HELP QUIT
 %token <int> VERBOSITY
@@ -156,6 +159,7 @@ plain_equal_term:
 app_term: mark_location(plain_app_term) { $1 }
 plain_app_term:
   | e=plain_simple_term                             { e }
+  | t=TAG lst=list(simple_term)                     { Tag (Name.make t, lst) }
   | e=simple_term es=nonempty_list(simple_term)     { Spine (e, es) }
   | e1=simple_term APPLY e2=app_term                { Apply (e1, e2) }
   | e1=simple_term p=PROJECTION                     { Projection(e1,Name.make p) }

--- a/src/parser/parser.mly
+++ b/src/parser/parser.mly
@@ -287,6 +287,8 @@ plain_pattern:
   | p=simple_pattern AS x=var_name          { Patt_As (p,x) }
   | t=TAG ps=simple_pattern+                { Patt_Tag (Name.make t, ps) }
   | VDASH e1=tt_pattern COLON e2=tt_pattern { Patt_Jdg (e1, e2) }
+  | VDASH e1=tt_pattern                     { Patt_Jdg (e1, (Tt_Anonymous, snd e1)) }
+
 
 simple_pattern: mark_location(plain_simple_pattern) { $1 }
 plain_simple_pattern:

--- a/src/parser/parser.mly
+++ b/src/parser/parser.mly
@@ -217,6 +217,9 @@ binder:
   | LBRACK lst=separated_nonempty_list(COMMA, maybe_typed_names) RBRACK
       { List.concat lst }
 
+untyped_binder:
+  | LBRACK lst=name* RBRACK       { lst }
+
 maybe_typed_names:
   | xs=name+ COLON t=ty_term  { List.map (fun x -> (x, Some t)) xs }
   | xs=name+                  { List.map (fun x -> (x, None)) xs }
@@ -271,7 +274,7 @@ handler_case:
   | BAR FINALLY x=name ARROW t=term             { CaseFinally (x, t) }
 
 match_case:
-  | BAR a=binder* p=pattern DARROW c=term  { (List.concat a, p, c) }
+  | BAR a=untyped_binder p=pattern DARROW c=term  { (a, p, c) }
 
 pattern: mark_location(plain_pattern) { $1 }
 plain_pattern:

--- a/src/parser/parser.mly
+++ b/src/parser/parser.mly
@@ -159,8 +159,9 @@ plain_equal_term:
 app_term: mark_location(plain_app_term) { $1 }
 plain_app_term:
   | e=plain_simple_term                             { e }
-  | t=TAG lst=list(simple_term)                     { Tag (Name.make t, lst) }
-  | e=simple_term es=nonempty_list(simple_term)     { Spine (e, es) }
+  | e=simple_term es=nonempty_list(simple_term)     { match fst e with
+                                                      | Tag (t, []) -> Tag (t, es)
+                                                      | _ -> Spine (e, es) }
   | e1=simple_term APPLY e2=app_term                { Apply (e1, e2) }
   | e1=simple_term p=PROJECTION                     { Projection(e1,Name.make p) }
   | WHNF t=simple_term                              { Whnf t }
@@ -173,6 +174,7 @@ plain_simple_term:
   | TYPE                                            { Type }
   | LRBRACK                                         { Inhab }
   | x=var_name                                      { Var x }
+  | t=TAG                                           { Tag (Name.make t, []) }
   | LPAREN e=plain_term RPAREN                      { e }
   | LLBRACK e=term RRBRACK                          { Bracket e }
   | LBRACE lst=separated_nonempty_list(COMMA, signature_clause) RBRACE

--- a/src/parser/parser.mly
+++ b/src/parser/parser.mly
@@ -284,6 +284,7 @@ match_case:
 pattern: mark_location(plain_pattern) { $1 }
 plain_pattern:
   | p=plain_simple_pattern                  { p }
+  | p=simple_pattern AS x=var_name          { Patt_As (p,x) }
   | t=TAG ps=simple_pattern+                { Patt_Tag (Name.make t, ps) }
   | VDASH e1=tt_pattern COLON e2=tt_pattern { Patt_Jdg (e1, e2) }
 
@@ -315,6 +316,7 @@ plain_equal_tt_pattern:
 app_tt_pattern: mark_location(plain_app_tt_pattern) { $1 }
 plain_app_tt_pattern:
   | p=plain_simple_tt_pattern                 { p }
+  | p=app_tt_pattern AS x=var_name            { Tt_As (p,x) }
   | p1=app_tt_pattern p2=simple_tt_pattern    { Tt_App (p1, p2) }
   | REFL p=simple_tt_pattern                  { Tt_Refl p }
 

--- a/src/syntax.ml
+++ b/src/syntax.ml
@@ -10,6 +10,7 @@ and expr' =
   | Bound of bound
   | Function of Name.ident * comp
   | Handler of handler
+  | Tag of Name.ident * expr list
 
 (** Desugared types - indistinguishable from expressions *)
 and ty = expr
@@ -226,4 +227,5 @@ and shift_expr k lvl ((e', loc) as e) =
   | Bound m -> if m >= lvl then (Bound (m + k), loc) else e
   | Function (x, c) -> Function (x, shift_comp k (lvl+1) c), loc
   | Handler h -> Handler (shift_handler k lvl h), loc
+  | Tag (t, lst) -> Tag (t, List.map (shift_expr k lvl) lst), loc
   | Type -> e

--- a/src/syntax.ml
+++ b/src/syntax.ml
@@ -19,8 +19,8 @@ and tt_pattern' =
   | Tt_Refl of tt_pattern
   | Tt_Inhab
   | Tt_Bracket of tt_pattern
-  | Tt_Signature of (Name.ident * Name.ident * tt_pattern) list
-  | Tt_Structure of (Name.ident * Name.ident * tt_pattern) list
+  | Tt_Signature of (Name.ident * Name.ident * bound option * tt_pattern) list
+  | Tt_Structure of (Name.ident * Name.ident * bound option * tt_pattern) list
   | Tt_Projection of tt_pattern * Name.ident
 
 type pattern = pattern' * Location.t
@@ -156,9 +156,9 @@ and shift_tt_pattern k lvl ((p',loc) as p) =
         | [] ->
           let xcs = List.rev xcs in
           Tt_Signature xcs, loc
-        | (l,x,c)::rem ->
+        | (l,x,bopt,c)::rem ->
           let c = shift_tt_pattern k lvl c in
-          fold (lvl+1) ((l,x,c)::xcs) rem
+          fold (lvl+1) ((l,x,bopt,c)::xcs) rem
         in
       fold lvl [] xcs
     | Tt_Structure xcs ->
@@ -166,9 +166,9 @@ and shift_tt_pattern k lvl ((p',loc) as p) =
         | [] ->
           let xcs = List.rev xcs in
           Tt_Structure xcs, loc
-        | (l,x,c)::rem ->
+        | (l,x,bopt,c)::rem ->
           let c = shift_tt_pattern k lvl c in
-          fold (lvl+1) ((l,x,c)::xcs) rem
+          fold (lvl+1) ((l,x,bopt,c)::xcs) rem
         in
       fold lvl [] xcs
     | Tt_Projection (c,l) ->

--- a/src/syntax.ml
+++ b/src/syntax.ml
@@ -53,7 +53,7 @@ and handler = {
   handler_finally : (Name.ident * comp) option;
 }
 
-and match_case = (Name.ident * comp option) list * match_pattern * comp
+and match_case = Name.ident list * match_pattern * comp
 
 and match_pattern = match_pattern' * Location.t
 and match_pattern' =
@@ -245,17 +245,15 @@ and shift_expr k lvl ((e', loc) as e) =
   | Type -> e
 
 and shift_case k lvl (xcs, p, c) =
-  let rec fold lvl xcs' = function
+  let rec fold lvl = function
     | [] ->
-      let xcs' = List.rev xcs'
-      and p = shift_pattern k lvl p
+      let p = shift_pattern k lvl p
       and c = shift_comp k lvl c in
-      xcs', p, c
-    | (x,copt) :: xcs ->
-      let copt = (match copt with None -> None | Some c -> Some (shift_comp k lvl c)) in
-      fold (lvl+1) ((x,copt) :: xcs') xcs
+      xcs, p, c
+    | x :: xcs ->
+      fold (lvl+1) xcs
     in
-  fold lvl [] xcs
+  fold lvl xcs
 
 and shift_pattern k lvl ((p', loc) as p) =
   match p' with

--- a/src/syntax.ml
+++ b/src/syntax.ml
@@ -12,9 +12,9 @@ and tt_pattern' =
   | Tt_Bound of bound
   | Tt_Type
   | Tt_Constant of Name.ident
-  | Tt_Lambda of Name.ident * tt_pattern option * tt_pattern
+  | Tt_Lambda of Name.ident * bound option * tt_pattern option * tt_pattern
   | Tt_App of tt_pattern * tt_pattern
-  | Tt_Prod of Name.ident * tt_pattern option * tt_pattern
+  | Tt_Prod of Name.ident * bound option * tt_pattern option * tt_pattern
   | Tt_Eq of tt_pattern * tt_pattern
   | Tt_Refl of tt_pattern
   | Tt_Inhab
@@ -129,18 +129,18 @@ and shift_tt_pattern k lvl ((p',loc) as p) =
       let p = shift_tt_pattern k lvl p in
       Tt_As (p,k), loc
     | Tt_Bound m -> if m >= lvl then (Tt_Bound (m + k), loc) else p
-    | Tt_Lambda (x,copt,c) ->
+    | Tt_Lambda (x,bopt,copt,c) ->
       let copt = opt_map (shift_tt_pattern k lvl) copt
       and c = shift_tt_pattern k (lvl+1) c in
-      Tt_Lambda (x,copt,c), loc
+      Tt_Lambda (x,bopt,copt,c), loc
     | Tt_App (c1,c2) ->
       let c1 = shift_tt_pattern k lvl c1
       and c2 = shift_tt_pattern k lvl c2 in
       Tt_App (c1,c2), loc
-    | Tt_Prod (x,copt,c) ->
+    | Tt_Prod (x,bopt,copt,c) ->
       let copt = opt_map (shift_tt_pattern k lvl) copt
       and c = shift_tt_pattern k (lvl+1) c in
-      Tt_Prod (x,copt,c), loc
+      Tt_Prod (x,bopt,copt,c), loc
     | Tt_Eq (c1,c2) ->
       let c1 = shift_tt_pattern k lvl c1
       and c2 = shift_tt_pattern k lvl c2 in

--- a/src/syntax.ml
+++ b/src/syntax.ml
@@ -19,8 +19,8 @@ and tt_pattern' =
   | Tt_Refl of tt_pattern
   | Tt_Inhab
   | Tt_Bracket of tt_pattern
-  | Tt_Signature of (Name.ident * Name.ident option * tt_pattern) list
-  | Tt_Structure of (Name.ident * Name.ident option * tt_pattern) list
+  | Tt_Signature of (Name.ident * Name.ident * tt_pattern) list
+  | Tt_Structure of (Name.ident * Name.ident * tt_pattern) list
   | Tt_Projection of tt_pattern * Name.ident
 
 type pattern = pattern' * Location.t
@@ -108,7 +108,8 @@ let opt_map f = function
 
 let rec shift_pattern k lvl ((p', loc) as p) =
   match p' with
-    | Patt_Anonymous
+    | Patt_Anonymous ->
+      Patt_Anonymous, loc
     | Patt_Var m ->
       if m >= lvl then (Patt_Var (m + k), loc) else p
     | Patt_Jdg (p1,p2) ->

--- a/src/syntax.mli
+++ b/src/syntax.mli
@@ -19,8 +19,8 @@ and tt_pattern' =
   | Tt_Refl of tt_pattern
   | Tt_Inhab
   | Tt_Bracket of tt_pattern
-  | Tt_Signature of (Name.ident * Name.ident * tt_pattern) list
-  | Tt_Structure of (Name.ident * Name.ident * tt_pattern) list
+  | Tt_Signature of (Name.ident * Name.ident * bound option * tt_pattern) list
+  | Tt_Structure of (Name.ident * Name.ident * bound option * tt_pattern) list
   | Tt_Projection of tt_pattern * Name.ident
 
 type pattern = pattern' * Location.t

--- a/src/syntax.mli
+++ b/src/syntax.mli
@@ -25,6 +25,7 @@ and comp' =
   | Assume of (Name.ident * comp) * comp
   | Where of comp * expr * comp
   | Apply of expr * expr
+  | Match of expr * match_case list
   | Beta of (string list * comp) list * comp
   | Eta of (string list * comp) list * comp
   | Hint of (string list * comp) list * comp
@@ -51,6 +52,12 @@ and handler = {
   handler_ops: (string * (Name.ident * Name.ident * comp)) list;
   handler_finally : (Name.ident * comp) option;
 }
+
+and match_case = (Name.ident * comp option) list * match_pattern
+
+and match_pattern =
+  | MatchData of Name.ident * match_pattern list
+  | MatchJdg of comp * comp option
 
 (** Desugared toplevel commands *)
 type toplevel = toplevel' * Location.t

--- a/src/syntax.mli
+++ b/src/syntax.mli
@@ -53,11 +53,13 @@ and handler = {
   handler_finally : (Name.ident * comp) option;
 }
 
-and match_case = (Name.ident * comp option) list * match_pattern
+and match_case = (Name.ident * comp option) list * match_pattern * comp
 
-and match_pattern =
-  | MatchData of Name.ident * match_pattern list
-  | MatchJdg of comp * comp option
+and match_pattern = match_pattern' * Location.t
+and match_pattern' =
+  | MatchVar of bound
+  | MatchTag of Name.ident * match_pattern list
+  | MatchJdg of comp * comp
 
 (** Desugared toplevel commands *)
 type toplevel = toplevel' * Location.t

--- a/src/syntax.mli
+++ b/src/syntax.mli
@@ -10,6 +10,7 @@ and expr' =
   | Bound of bound
   | Function of Name.ident * comp
   | Handler of handler
+  | Tag of Name.ident * expr list
 
 (** Desugared types - indistinguishable from expressions *)
 and ty = expr

--- a/src/syntax.mli
+++ b/src/syntax.mli
@@ -8,10 +8,9 @@ type bound = int
 type tt_pattern = tt_pattern' * Location.t
 and tt_pattern' =
   | Tt_Anonymous
-  | Tt_Type
-  (** Pattern variables are a subset of the bound variables. *)
+  | Tt_Var of bound (* a pattern variable *)
   | Tt_Bound of bound
-  | Tt_Atom of Name.atom
+  | Tt_Type
   | Tt_Constant of Name.ident
   | Tt_Lambda of Name.ident * tt_pattern option * tt_pattern
   | Tt_App of tt_pattern * tt_pattern
@@ -28,6 +27,7 @@ type pattern = pattern' * Location.t
 and pattern' =
   | Patt_Anonymous
   | Patt_Var of bound
+  | Patt_Bound of bound
   | Patt_Jdg of tt_pattern * tt_pattern
   | Patt_Tag of Name.ident * pattern list
 

--- a/src/syntax.mli
+++ b/src/syntax.mli
@@ -20,8 +20,8 @@ and tt_pattern' =
   | Tt_Refl of tt_pattern
   | Tt_Inhab
   | Tt_Bracket of tt_pattern
-  | Tt_Signature of (Name.ident * Name.ident option * tt_pattern) list
-  | Tt_Structure of (Name.ident * Name.ident option * tt_pattern) list
+  | Tt_Signature of (Name.ident * Name.ident * tt_pattern) list
+  | Tt_Structure of (Name.ident * Name.ident * tt_pattern) list
   | Tt_Projection of tt_pattern * Name.ident
 
 type pattern = pattern' * Location.t

--- a/src/syntax.mli
+++ b/src/syntax.mli
@@ -8,7 +8,7 @@ type bound = int
 type tt_pattern = tt_pattern' * Location.t
 and tt_pattern' =
   | Tt_Anonymous
-  | Tt_Var of bound (* a pattern variable *)
+  | Tt_As of tt_pattern * bound
   | Tt_Bound of bound
   | Tt_Type
   | Tt_Constant of Name.ident
@@ -26,7 +26,7 @@ and tt_pattern' =
 type pattern = pattern' * Location.t
 and pattern' =
   | Patt_Anonymous
-  | Patt_Var of bound
+  | Patt_As of pattern * bound
   | Patt_Bound of bound
   | Patt_Jdg of tt_pattern * tt_pattern
   | Patt_Tag of Name.ident * pattern list

--- a/src/syntax.mli
+++ b/src/syntax.mli
@@ -53,7 +53,7 @@ and handler = {
   handler_finally : (Name.ident * comp) option;
 }
 
-and match_case = (Name.ident * comp option) list * match_pattern * comp
+and match_case = Name.ident list * match_pattern * comp
 
 and match_pattern = match_pattern' * Location.t
 and match_pattern' =

--- a/src/syntax.mli
+++ b/src/syntax.mli
@@ -3,6 +3,34 @@
 (** Bound variables - represented by de Bruijn indices *)
 type bound = int
 
+(** Patterns *)
+
+type tt_pattern = tt_pattern' * Location.t
+and tt_pattern' =
+  | Tt_Anonymous
+  | Tt_Type
+  (** Pattern variables are a subset of the bound variables. *)
+  | Tt_Bound of bound
+  | Tt_Atom of Name.atom
+  | Tt_Constant of Name.ident
+  | Tt_Lambda of Name.ident * tt_pattern option * tt_pattern
+  | Tt_App of tt_pattern * tt_pattern
+  | Tt_Prod of Name.ident * tt_pattern option * tt_pattern
+  | Tt_Eq of tt_pattern * tt_pattern
+  | Tt_Refl of tt_pattern
+  | Tt_Inhab
+  | Tt_Bracket of tt_pattern
+  | Tt_Signature of (Name.ident * Name.ident option * tt_pattern) list
+  | Tt_Structure of (Name.ident * Name.ident option * tt_pattern) list
+  | Tt_Projection of tt_pattern * Name.ident
+
+type pattern = pattern' * Location.t
+and pattern' =
+  | Patt_Anonymous
+  | Patt_Var of bound
+  | Patt_Jdg of tt_pattern * tt_pattern
+  | Patt_Tag of Name.ident * pattern list
+
 (** Desugared expressions *)
 type expr = expr' * Location.t
 and expr' =
@@ -53,13 +81,7 @@ and handler = {
   handler_finally : (Name.ident * comp) option;
 }
 
-and match_case = Name.ident list * match_pattern * comp
-
-and match_pattern = match_pattern' * Location.t
-and match_pattern' =
-  | MatchVar of bound
-  | MatchTag of Name.ident * match_pattern list
-  | MatchJdg of comp * comp
+and match_case = Name.ident list * pattern * comp
 
 (** Desugared toplevel commands *)
 type toplevel = toplevel' * Location.t

--- a/src/syntax.mli
+++ b/src/syntax.mli
@@ -12,9 +12,9 @@ and tt_pattern' =
   | Tt_Bound of bound
   | Tt_Type
   | Tt_Constant of Name.ident
-  | Tt_Lambda of Name.ident * tt_pattern option * tt_pattern
+  | Tt_Lambda of Name.ident * bound option * tt_pattern option * tt_pattern
   | Tt_App of tt_pattern * tt_pattern
-  | Tt_Prod of Name.ident * tt_pattern option * tt_pattern
+  | Tt_Prod of Name.ident * bound option * tt_pattern option * tt_pattern
   | Tt_Eq of tt_pattern * tt_pattern
   | Tt_Refl of tt_pattern
   | Tt_Inhab

--- a/tests/meta-match.m31
+++ b/tests/meta-match.m31
@@ -1,0 +1,32 @@
+
+Axiom A : Type.
+
+Axiom a : A.
+Axiom b : A.
+Axiom c : A.
+
+Check match a with
+  | |- b => 'b
+  | [] |- a => 'a
+  end.
+
+Check match λ [x : A] a with
+  | [x y z t x' y'] |- λ [x : y] z : Π [x' : y'] t => 'lambda x y z ('prod x' y' t)
+  end.
+
+Axiom list : Type.
+Axiom nil : list.
+Let cons := assume cons : A -> list -> list in cons. (* Matching constants of nonzero arity is broken. *)
+
+Check match 'foo (cons a (cons b (cons c nil))) 'bar with
+  | 'foo => 'no
+  | [x y z t x' y'] |- λ [x : y] z : Π [x' : y'] t => 'lambda x y z ('prod x' y' t)
+  | [x y] 'foo
+    (|- cons _ ((cons x _) as y))
+    'bar => 'pair x y
+  end.
+
+Check match {a : A, isconstr : forall [x : A] a == x} with
+  | |- { a as b : _, isconstr : forall [_] a == _} => 'bad
+  | |- { a : _, isconstr : forall [_] a == _} => 'ok
+  end.

--- a/tests/meta-match.m31.ref
+++ b/tests/meta-match.m31.ref
@@ -1,0 +1,19 @@
+A is assumed.
+a is assumed.
+b is assumed.
+c is assumed.
+'a
+'lambda (x₆ : A 
+         ⊢ x₆ : A) (⊢ A : Type) (x₆ : A 
+                                       ⊢ a : A)
+('prod (x'₅ : A 
+        ⊢ x'₅ : A) (⊢ A : Type) (x'₅ : A 
+                                       ⊢ A : Type))
+list is assumed.
+nil is assumed.
+cons is defined.
+'pair (cons₉ : A → list → list 
+       ⊢ b : A)
+(cons₉ : A → list → list 
+ ⊢ cons₉ b (cons₉ c nil) : list)
+'ok


### PR DESCRIPTION
This pull request introduces:
- a new variant of values, called tags, consisting of a quoted identifier (eg 'foo) applied to a list of arbitrary values. For instance:

        'closure_with_judgement (fun x -> x) Type

- a match statement

        match v with
          | [pattvars] pattern => comp
          ...
          end
where `pattvars` is a list of variables to be instantiated by values on a match.
The patterns are not linear. Terms are compared modulo alpha equality, and term judgements are compared through the terms only.
If the name of a binder is a pattern variable (eg `x` in `λ [x] foo`), that variable will be instantiated with the corresponding atom.
The value matching a sub-pattern can be used to instantiate a variable with the `as` keyword, eg

         | [x y] 'cons _ (('cons x _) as y)
will match list-like tag values with at least 2 elements, instantiating `x` with the second element and `y` with the tail.

See upcoming tests for examples.