### PR TITLE
Better applications

### DIFF
--- a/examples/auto.m31
+++ b/examples/auto.m31
@@ -70,6 +70,25 @@ Let auto := rec auto lst A ->
       end) 'none (find A lst)
   end.
 
+Axiom unit : Type.
+Axiom tt : unit.
+
+Let auto_handler := handler
+  | val x -> x
+  | #inhabit goal k ->
+    fun hints ->
+    match auto hints goal with
+      | [t] 'some t => k t
+      | 'none => k (#inhabit goal) hints
+    end
+  | #new_hint h k ->
+    match h with
+      | |- _ => fun hints ->
+        k tt ('cons h hints)
+    end
+  | finally f -> f 'nil
+  end.
+
 Axiom U : Type.
 Axiom V : Type.
 Axiom W : Type.
@@ -79,15 +98,11 @@ Check
   assume v : V in
   assume w : W in
   assume f : V -> W in
-  let lst := 'cons u ('cons v ('cons w ('cons f 'nil))) in
-  handle
-    #inhabit (prod U (prod V W))
-  with
-    | #inhabit goal k ->
-      match auto lst goal with
-        | [t] 'some t => k t
-        | 'none => k (#inhabit goal)
-      end
-  end.
+  with auto_handler handle
+    let _ := #new_hint f in
+    let _ := #new_hint w in
+    let _ := #new_hint v in
+    let _ := #new_hint u in
+    #inhabit (prod U (prod V W)).
 
 

--- a/examples/auto.m31
+++ b/examples/auto.m31
@@ -5,24 +5,6 @@ Axiom pair : Π [A B : Type] A -> (B -> (prod A B)).
 Axiom fst : Π [X Y : Type] prod X Y -> X.
 Axiom snd : Π [X Y : Type] prod X Y -> Y.
 
-(*
-to inhabit A, for each assumption of the form X -> Y -> A try to inhabit X and Y
-
-let rec inhabit ass A =
-  let rec inhab_apply a =
-    match a with
-      | a : X -> Y => let x := inhabit ass X in inhab_apply (a x)
-      | _ => a
-  in
-  fold (fun a found -> if found = 'none
-    then
-      match a with
-        | a : X -> [... A] =>
-          inhab_apply a
-        | _ => 'none
-    else found) ass 'none
-*)
-
 Let fold := rec fold f acc lst ->
   match lst with
     | 'nil => acc
@@ -88,24 +70,6 @@ Let auto := rec auto lst A ->
       end) 'none (find A lst)
   end.
 
-(*
-Let auto := rec auto lst ->
-  handler
-  | #inhabit goal k ->
-    match goal with
-    | [A B] ⊢ prod A B : Type =>
-      let a := (with (auto @ lst) handle #inhabit A) in
-      let b := (with (auto @ lst) handle #inhabit B) in
-      k @ (pair A B a b)
-    | [A] ⊢ A : Type =>
-      match ((find @ A) @ lst) with
-      | 'none => k @ (#inhabit goal)
-      | [f args rem] 'some f args rem => 
-      end
-    end
-  end.
-  *)
-
 Axiom U : Type.
 Axiom V : Type.
 Axiom W : Type.
@@ -125,8 +89,5 @@ Check
         | 'none => k (#inhabit goal)
       end
   end.
-
-
-
 
 

--- a/examples/lambda_afterhought.m31
+++ b/examples/lambda_afterhought.m31
@@ -9,5 +9,5 @@ Check
      let b := #fresh (B a) in
        λ [y : A] pair a b
    with
-     | #fresh t k -> λ [x : t] k @ x
+     | #fresh t k -> λ [x : t] k x
    end.

--- a/src/nucleus/eval.ml
+++ b/src/nucleus/eval.ml
@@ -243,7 +243,10 @@ and infer env (c',loc) =
         | Value.Closure f ->
           begin match cs with
             | [] -> Error.impossible ~loc "empty spine in Eval.infer"
-            | c::cs ->
+            | [c] ->
+              infer env c >>=
+              f
+            | c::(_::_ as cs) ->
               infer env c >>=
               f >>= fun v ->
               fold v cs

--- a/src/nucleus/eval.ml
+++ b/src/nucleus/eval.ml
@@ -142,11 +142,6 @@ and infer env (c',loc) =
      | _ -> Error.runtime ~loc "Only atoms can be substituted"
      end
 
-  | Syntax.Apply (e1, e2) ->
-     let v1 = Value.as_closure ~loc (expr env e1)
-     and v2 = expr env e2 in
-       v1 v2
-
   | Syntax.Match (e,cases) ->
     let v = expr env e in
     let rec fold = function
@@ -328,7 +323,6 @@ and check env ((c',loc) as c) (((ctx_check, t_check') as t_check) : Judgement.ty
   | Syntax.Return _
   | Syntax.With _
   | Syntax.Typeof _
-  | Syntax.Apply _
   | Syntax.Match _
   | Syntax.Constant _
   | Syntax.Prod _

--- a/src/nucleus/value.ml
+++ b/src/nucleus/value.ml
@@ -47,6 +47,14 @@ and print_value ?max_level xs v ppf =
   | Handler h -> print_handler xs h ppf
   | Tag (t, lst) -> print_tag ?max_level xs t lst ppf
 
+let print_value_key v ppf =
+  match v with
+    | Term _ -> Print.print ~at_level:0 ppf "<term>"
+    | Ty _ -> Print.print ~at_level:0 ppf "<type>"
+    | Closure _ -> Print.print ~at_level:0 ppf "<function>"
+    | Handler _ -> Print.print ~at_level:0 ppf "<handler>"
+    | Tag _ -> Print.print ~at_level:0 ppf "<tag>"
+
 let as_term ~loc = function
   | Term e -> e
   | Ty _ -> Error.runtime ~loc "expected a term but got a type"

--- a/src/nucleus/value.mli
+++ b/src/nucleus/value.mli
@@ -42,6 +42,8 @@ val bind: 'a result -> ('a -> 'b result)  -> 'b result
 (** Pretty-print a value. *)
 val print_value : ?max_level:int -> Name.ident list -> value -> Format.formatter -> unit
 
+val print_value_key : value -> Format.formatter -> unit
+
 (** Check that a result is a value and return it, or complain. *)
 val to_value : loc:Location.t -> 'a result -> 'a
 

--- a/src/parser/desugar.ml
+++ b/src/parser/desugar.ml
@@ -84,15 +84,6 @@ let rec comp constants bound ((c',loc) as c) =
        and c2 = Syntax.shift_comp (List.length w) 0 c2 in
        w, Syntax.Where (c1, e, c2)
 
-    | Input.Apply (e1, e2) ->
-       let w1, e1 = expr constants bound e1
-       and w2, e2 = expr constants bound e2 in
-       let k1 = List.length w1
-       and k2 = List.length w2 in
-       let e1 = Syntax.shift_expr k2 0 e1
-       and e2 = Syntax.shift_expr k1 k2 e2 in
-       w1 @ w2, Syntax.Apply (e1, e2)
-
     | Input.Match (e, cases) ->
        let w, e = expr constants bound e in
        let bound = List.fold_left (fun bound (x,_) -> add_bound x bound) bound w in
@@ -585,7 +576,7 @@ and expr constants bound ((e', loc) as e) =
   | (Input.Let _ | Input.Beta _ | Input.Eta _ | Input.Hint _ | Input.Inhabit _ |
      Input.Unhint _ | Input.Bracket _ | Input.Inhab | Input.Ascribe _ | Input.Lambda _ |
      Input.Spine _ | Input.Prod _ | Input.Eq _ | Input.Refl _ | Input.Operation _ |
-     Input.Whnf _ | Input.Apply _ | Input.Match _ | Input.Handle _ | Input.With _ |
+     Input.Whnf _ | Input.Match _ | Input.Handle _ | Input.With _ |
      Input.Typeof _ | Input.Assume _ | Input.Where _ | Input.Signature _ |
      Input.Structure _ | Input.Projection _) ->
     let x = Name.fresh_candy ()

--- a/src/parser/input.mli
+++ b/src/parser/input.mli
@@ -44,7 +44,6 @@ and term' =
   | Operation of string * expr
   | Handle of comp * handle_case list
   | With of expr * comp
-  | Apply of expr * expr
   | Tag of Name.ident * comp list
   | Match of comp * match_case list
   | Let of (Name.ident * comp) list * comp

--- a/src/parser/lexer.ml
+++ b/src/parser/lexer.ml
@@ -112,7 +112,6 @@ and token_aux ({ stream; pos_end; end_of_input; line_limit } as lexbuf) =
   | '_'                      -> f (); UNDERSCORE
   | "|-"                     -> f (); VDASH
   | '|'                      -> f (); BAR
-  | '@'                      -> f (); APPLY
   | '\'', name               -> f (); TAG (let s = lexeme lexbuf in String.sub s 1 (String.length s - 1))
   | "->" | 8594 | 10230      -> f (); ARROW
   | "=>" | 10233             -> f (); DARROW

--- a/src/parser/parser.mly
+++ b/src/parser/parser.mly
@@ -53,7 +53,7 @@
 %token TYPEOF
 
 (* Functions *)
-%token REC FUNCTION APPLY
+%token REC FUNCTION
 
 (* Axioms *)
 %token AXIOM REDUCE
@@ -165,7 +165,6 @@ plain_app_term:
   | e=simple_term es=nonempty_list(simple_term)     { match fst e with
                                                       | Tag (t, []) -> Tag (t, es)
                                                       | _ -> Spine (e, es) }
-  | e1=simple_term APPLY e2=app_term                { Apply (e1, e2) }
   | e1=simple_term p=PROJECTION                     { Projection(e1,Name.make p) }
   | WHNF t=simple_term                              { Whnf t }
   | TYPEOF t=simple_term                            { Typeof t }

--- a/src/syntax.ml
+++ b/src/syntax.ml
@@ -53,7 +53,6 @@ and comp' =
   | Let of (Name.ident * comp) list * comp
   | Assume of (Name.ident * comp) * comp
   | Where of comp * expr * comp
-  | Apply of expr * expr
   | Match of expr * match_case list
   | Beta of (string list * comp) list * comp
   | Eta of (string list * comp) list * comp
@@ -208,11 +207,6 @@ let rec shift_comp k lvl (c', loc) =
        and e = shift_expr k lvl e
        and c2 = shift_comp k lvl c2 in
        Where (c1, e, c2)
-
-    | Apply (e1, e2) ->
-       let e1 = shift_expr k lvl e1
-       and e2 = shift_expr k lvl e2 in
-       Apply (e1, e2)
 
     | Match (e, lst) ->
       let e = shift_expr k lvl e in

--- a/src/syntax.mli
+++ b/src/syntax.mli
@@ -53,7 +53,6 @@ and comp' =
   | Let of (Name.ident * comp) list * comp
   | Assume of (Name.ident * comp) * comp
   | Where of comp * expr * comp
-  | Apply of expr * expr
   | Match of expr * match_case list
   | Beta of (string list * comp) list * comp
   | Eta of (string list * comp) list * comp

--- a/tests/beta-arithmetic.m31.ref
+++ b/tests/beta-arithmetic.m31.ref
@@ -14,9 +14,7 @@ four is defined.
 five is defined.
 ten is defined.
 ⊢ refl (plus (S (S (S (S (S Z))))) (S (S (S (S Z)))))
-      : plus (S (S (S (S Z)))) (S (S (S (S (S Z)))))
-          ≡ plus (plus (S (S Z)) (S (S (S Z)))) (S (S (S (S Z))))
-⊢ refl (S (S (S Z)))
-      : S (S (S Z)) ≡ plus (S Z) (plus (S Z) (S Z))
-⊢ refl (S (S (S (S Z))))
-      : S (S (S (S Z))) ≡ times (S (S Z)) (S (S Z))
+  : plus (S (S (S (S Z)))) (S (S (S (S (S Z)))))
+      ≡ plus (plus (S (S Z)) (S (S (S Z)))) (S (S (S (S Z))))
+⊢ refl (S (S (S Z))) : S (S (S Z)) ≡ plus (S Z) (plus (S Z) (S Z))
+⊢ refl (S (S (S (S Z)))) : S (S (S (S Z))) ≡ times (S (S Z)) (S (S Z))

--- a/tests/beta-const.m31.ref
+++ b/tests/beta-const.m31.ref
@@ -2,5 +2,4 @@ A is assumed.
 B is assumed.
 a is assumed.
 eq_A_B is assumed.
-⊢ a
-      : B
+⊢ a : B

--- a/tests/beta-dependent.m31.ref
+++ b/tests/beta-dependent.m31.ref
@@ -6,5 +6,4 @@ f_beta is assumed.
 a is assumed.
 b is assumed.
 c is assumed.
-⊢ refl b
-      : b ≡ f a b c
+⊢ refl b : b ≡ f a b c

--- a/tests/beta-nat.m31.ref
+++ b/tests/beta-nat.m31.ref
@@ -4,11 +4,8 @@ S is assumed.
 plus is assumed.
 plus_Z is assumed.
 plus_S is assumed.
-⊢ Type
-      : Type
-⊢ refl (S (S Z))
-      : plus (S (S Z)) Z ≡ S (S Z)
-⊢ refl (S (S Z))
-      : plus (S Z) (S Z) ≡ S (S Z)
+⊢ Type : Type
+⊢ refl (S (S Z)) : plus (S (S Z)) Z ≡ S (S Z)
+⊢ refl (S (S Z)) : plus (S Z) (S Z) ≡ S (S Z)
 ⊢ λ [x : N] [y : N] refl (S (S (plus x y)))
-      : Π [x : N] [y : N] plus x (S (S y)) ≡ S (S (plus x y))
+  : Π [x : N] [y : N] plus x (S (S y)) ≡ S (S (plus x y))

--- a/tests/beta-pair.m31.ref
+++ b/tests/beta-pair.m31.ref
@@ -6,11 +6,7 @@ C is assumed.
 D is assumed.
 c is assumed.
 d is assumed.
-⊢ refl (fst C D (pair C D c d))
-      : c ≡ fst C D (pair C D c d)
-⊢ refl (fst D C (pair D C d c))
-      : d ≡ fst D C (pair D C d c)
-⊢ refl (fst C D (pair C D c d))
-      : c ≡ fst C D (pair C D c d)
-⊢ refl (fst C D (pair C D c d))
-      : c ≡ fst C D (pair C D c d)
+⊢ refl (fst C D (pair C D c d)) : c ≡ fst C D (pair C D c d)
+⊢ refl (fst D C (pair D C d c)) : d ≡ fst D C (pair D C d c)
+⊢ refl (fst C D (pair C D c d)) : c ≡ fst C D (pair C D c d)
+⊢ refl (fst C D (pair C D c d)) : c ≡ fst C D (pair C D c d)

--- a/tests/beta-primapp.m31.ref
+++ b/tests/beta-primapp.m31.ref
@@ -2,8 +2,7 @@ cow is assumed.
 horn is assumed.
 tail is assumed.
 tail_horn is assumed.
-⊢ refl horn
-      : horn ≡ tail horn
+⊢ refl horn : horn ≡ tail horn
 prod is assumed.
 pair is assumed.
 fst is assumed.
@@ -12,5 +11,4 @@ X is assumed.
 Y is assumed.
 a is assumed.
 f is assumed.
-⊢ λ [y : Y] refl (f a)
-      : Π [y : Y] f a ≡ fst X Y (pair X Y (f a) y)
+⊢ λ [y : Y] refl (f a) : Π [y : Y] f a ≡ fst X Y (pair X Y (f a) y)

--- a/tests/beta-sigma.m31.ref
+++ b/tests/beta-sigma.m31.ref
@@ -8,34 +8,32 @@ projT1 is assumed.
 projT2 is assumed.
 projT1_beta is assumed.
 ⊢ projT1_beta
-      : Π [A0 : Type] [B0 : A0 → Type] [a0 : A0] [b0 : B0 a0]
-          projT1 A0 B0 (existT A0 B0 a0 b0) ≡ a0
-⊢ refl a
-      : projT1 A B (existT A B a b) ≡ a
+  : Π [A0 : Type] [B0 : A0 → Type] [a0 : A0] [b0 : B0 a0]
+      projT1 A0 B0 (existT A0 B0 a0 b0) ≡ a0
+⊢ refl a : projT1 A B (existT A B a b) ≡ a
 projT2_beta is assumed.
-⊢ refl b
-      : projT2 A B (existT A B a b) ≡ b
+⊢ refl b : projT2 A B (existT A B a b) ≡ b
 sig_ind is assumed.
 sig_ind_beta is assumed.
 projT1' is defined.
 ⊢ λ [A0 : Type] [B0 : A0 → Type] [s : sigT A0 B0]
       sig_ind A0 B0 (λ [_ : sigT A0 B0] A0) (λ [x : A0] [y : B0 x] x) s
-      : Π [A0 : Type] [B0 : A0 → Type] sigT A0 B0 → A0
+  : Π [A0 : Type] [B0 : A0 → Type] sigT A0 B0 → A0
 ⊢ refl a
-      : a
-          ≡ sig_ind A B (λ [_ : sigT A B] A) (λ [x : A] [y : B x] x)
-                (existT A B a b)
+  : a
+      ≡ sig_ind A B (λ [_ : sigT A B] A) (λ [x : A] [y : B x] x)
+            (existT A B a b)
 ⊢ refl a
-      : projT1 A B (existT A B a b)
-          ≡ sig_ind A B (λ [_ : sigT A B] A) (λ [x : A] [y : B x] x)
-                (existT A B a b)
+  : projT1 A B (existT A B a b)
+      ≡ sig_ind A B (λ [_ : sigT A B] A) (λ [x : A] [y : B x] x)
+            (existT A B a b)
 projT2' is defined.
 ⊢ refl b
-      : projT2 A B (existT A B a b)
-          ≡ (λ [s : sigT A B]
-                 sig_ind A B
-                   (λ [s0 : sigT A B]
-                      B
-                        (sig_ind A B (λ [_ : sigT A B] A)
-                           (λ [x : A] [y : B x] x) s0))
-                   (λ [x : A] [y : B x] y) s) (existT A B a b)
+  : projT2 A B (existT A B a b)
+      ≡ (λ [s : sigT A B]
+             sig_ind A B
+               (λ [s0 : sigT A B]
+                  B
+                    (sig_ind A B (λ [_ : sigT A B] A)
+                       (λ [x : A] [y : B x] x) s0)) (λ [x : A] [y : B x] y)
+               s) (existT A B a b)

--- a/tests/beta-sum.m31.ref
+++ b/tests/beta-sum.m31.ref
@@ -3,6 +3,6 @@
 ⊢ λ [A : Type] [B : Type] [P : sum A B → Type]
       [l : Π [a : A] P (inl A B a)] [r : Π [b : B] P (inr A B b)] [
       b : B] refl (r b)
-      : Π [A : Type] [B : Type] [P : sum A B → Type]
-          [l : Π [a : A] P (inl A B a)] [r : Π [b : B] P (inr A B b)]
-          [b : B] r b ≡ sum_rect A B P l r (inr A B b)
+  : Π [A : Type] [B : Type] [P : sum A B → Type]
+      [l : Π [a : A] P (inl A B a)] [r : Π [b : B] P (inr A B b)] [
+      b : B] r b ≡ sum_rect A B P l r (inr A B b)

--- a/tests/check-lambda.m31.ref
+++ b/tests/check-lambda.m31.ref
@@ -4,11 +4,7 @@ C is assumed.
 f is assumed.
 g is assumed.
 a is assumed.
-⊢ λ [y : B a] g a y
-      : Π [y : B a] C a y
-⊢ λ [x : A] [y : B x] g x y
-      : Π [x : A] [y : B x] C x y
-⊢ λ [x : A] [y : B x] g x y
-      : Π [x : A] [y : B x] C x y
-⊢ λ [x : A] [y : B x] g x y
-      : Π [x : A] [y : B x] C x y
+⊢ λ [y : B a] g a y : Π [y : B a] C a y
+⊢ λ [x : A] [y : B x] g x y : Π [x : A] [y : B x] C x y
+⊢ λ [x : A] [y : B x] g x y : Π [x : A] [y : B x] C x y
+⊢ λ [x : A] [y : B x] g x y : Π [x : A] [y : B x] C x y

--- a/tests/church.m31.ref
+++ b/tests/church.m31.ref
@@ -1,49 +1,47 @@
 Nat is defined.
-⊢ Π [X : Type] (X → X) → X → X
-      : Type
+⊢ Π [X : Type] (X → X) → X → X : Type
 zero is defined.
 ⊢ λ [A : Type] [s : A → A] [z : A] z
-      : Π [X : Type] (X → X) → X → X
+  : Π [X : Type] (X → X) → X → X
 one is defined.
 ⊢ λ [A : Type] [s : A → A] [z : A] s z
-      : Π [X : Type] (X → X) → X → X
+  : Π [X : Type] (X → X) → X → X
 two is defined.
 ⊢ λ [A : Type] [s : A → A] [z : A] s (s z)
-      : Π [X : Type] (X → X) → X → X
+  : Π [X : Type] (X → X) → X → X
 three is defined.
 ⊢ λ [A : Type] [s : A → A] [z : A] s (s (s z))
-      : Π [X : Type] (X → X) → X → X
+  : Π [X : Type] (X → X) → X → X
 succ is defined.
 ⊢ λ [n : Π [X : Type] (X → X) → X → X] [B : Type] [s : B → B]
       [z : B] s (n B s z)
-      : (Π [X : Type] (X → X) → X → X) →
-          Π [X : Type] (X → X) → X → X
+  : (Π [X : Type] (X → X) → X → X) →
+      Π [X : Type] (X → X) → X → X
 succ' is defined.
 ⊢ λ [n : Π [X : Type] (X → X) → X → X] [A : Type] [s : A → A]
       [z : A] n A s (s z)
-      : (Π [X : Type] (X → X) → X → X) →
-          Π [X : Type] (X → X) → X → X
+  : (Π [X : Type] (X → X) → X → X) →
+      Π [X : Type] (X → X) → X → X
 add is defined.
 ⊢ λ [m : Π [X : Type] (X → X) → X → X]
       [n : Π [X : Type] (X → X) → X → X] [A : Type] [s : A → A]
       [z : A] m A s (n A s z)
-      : (Π [X : Type] (X → X) → X → X) →
-          (Π [X : Type] (X → X) → X → X) →
-            Π [X : Type] (X → X) → X → X
+  : (Π [X : Type] (X → X) → X → X) →
+      (Π [X : Type] (X → X) → X → X) →
+        Π [X : Type] (X → X) → X → X
 mult is defined.
 ⊢ λ [m : Π [X : Type] (X → X) → X → X]
       [n : Π [X : Type] (X → X) → X → X] [A : Type] [s : A → A]
       m A (n A s)
-      : (Π [X : Type] (X → X) → X → X) →
-          (Π [X : Type] (X → X) → X → X) →
-            Π [X : Type] (X → X) → X → X
+  : (Π [X : Type] (X → X) → X → X) →
+      (Π [X : Type] (X → X) → X → X) →
+        Π [X : Type] (X → X) → X → X
 N is assumed.
 Z is assumed.
 S is assumed.
 ⊢ refl (S ((λ [A : Type] [s : A → A] [z : A] s (s (s z))) N S Z))
-      : (λ [A : Type] [s : A → A] [z : A] s z) N S
-          ((λ [A : Type] [s : A → A] [z : A] s (s (s z))) N S Z)
-          ≡ ((λ [A : Type] [s : A → A] [z : A]
-                  (λ [A0 : Type] [s0 : A0 → A0] [z0 : A0] s0 z0) A s (s z))
-                 N ((λ [A : Type] [s : A → A] [z : A] s (s z)) N S)) 
-                Z
+  : (λ [A : Type] [s : A → A] [z : A] s z) N S
+      ((λ [A : Type] [s : A → A] [z : A] s (s (s z))) N S Z)
+      ≡ ((λ [A : Type] [s : A → A] [z : A]
+              (λ [A0 : Type] [s0 : A0 → A0] [z0 : A0] s0 z0) A s (s z)) N
+             ((λ [A : Type] [s : A → A] [z : A] s (s z)) N S)) Z

--- a/tests/compose.m31.ref
+++ b/tests/compose.m31.ref
@@ -1,11 +1,9 @@
 id is defined.
-⊢ λ [A : Type] [x : A] x
-      : Π [A : Type] A → A
+⊢ λ [A : Type] [x : A] x : Π [A : Type] A → A
 compose is defined.
 ⊢ λ [A : Type] [B : Type] [C : Type] [g : B → C] [f : A → B] [
       x : A] g (f x)
-      : Π [A : Type] [B : Type] [C : Type]
-          (B → C) → (A → B) → A → C
+  : Π [A : Type] [B : Type] [C : Type] (B → C) → (A → B) → A → C
 X is assumed.
 Y is assumed.
 Z is assumed.
@@ -14,7 +12,6 @@ x is assumed.
 f is assumed.
 g is assumed.
 h is assumed.
-⊢ refl (g (f x))
-      : g (f x) ≡ g (f x)
+⊢ refl (g (f x)) : g (f x) ≡ g (f x)
 ⊢ refl (h (g (f x)))
-      : h ((λ [x0 : X] g (f x0)) x) ≡ (λ [x0 : Y] h (g x0)) (f x)
+  : h ((λ [x0 : X] g (f x0)) x) ≡ (λ [x0 : Y] h (g x0)) (f x)

--- a/tests/context-subst.m31.ref
+++ b/tests/context-subst.m31.ref
@@ -4,14 +4,12 @@ P is defined.
 y is defined.
 x₄ : A 
 y₈ : (λ [z : A] A) x₄ 
-⊢ y₈
-      : A
+⊢ y₈ : A
 f is assumed.
 x₄ : A 
 P₆ : A → Type 
 y₈ : P₆ (f x₄) 
-⊢ y₈
-      : P₆ (f x₄)
+⊢ y₈ : P₆ (f x₄)
 a is assumed.
 b is assumed.
 ign is assumed.
@@ -20,5 +18,4 @@ igny is defined.
 P₆ : A → Type 
 y₈ : P₆ a 
 __eq₂₅ : P₆ b ≡ P₆ a 
-⊢ g (ign (P₆ a) y₈) (ign (P₆ b) y₈)
-      : A
+⊢ g (ign (P₆ a) y₈) (ign (P₆ b) y₈) : A

--- a/tests/equal_fun.m31.ref
+++ b/tests/equal_fun.m31.ref
@@ -3,5 +3,4 @@ B is assumed.
 f is assumed.
 foo is defined.
 ⊢ refl (λ [x : A] [y : B x] f x (f x y))
-      : (λ [x : A] [y : B x] f x (f x y))
-          ≡ (λ [x : A] [y : B x] f x (f x y))
+  : (λ [x : A] [y : B x] f x (f x y)) ≡ (λ [x : A] [y : B x] f x (f x y))

--- a/tests/error-beta-nat.m31.ref
+++ b/tests/error-beta-nat.m31.ref
@@ -4,7 +4,6 @@ S is assumed.
 plus is assumed.
 plus_Z is assumed.
 plus_S is assumed.
-⊢ Type
-      : Type
+⊢ Type : Type
 File "./error-beta-nat.m31", line 14, characters 4-19: Typing error
   failed to check that the term S (S Z) is equal to plus (S Z) (S (S Z))

--- a/tests/error-handle-change-type.m31.ref
+++ b/tests/error-handle-change-type.m31.ref
@@ -2,5 +2,4 @@ A is assumed.
 B is assumed.
 a is assumed.
 e₄ : B ≡ A 
-⊢ a
-      : B
+⊢ a : B

--- a/tests/error-inhabit-assume.m31.ref
+++ b/tests/error-inhabit-assume.m31.ref
@@ -2,5 +2,4 @@ A is assumed.
 B is assumed.
 a₆ : A 
 b₇ : A 
-⊢ B [] b₇
-      : Type
+⊢ B [] b₇ : Type

--- a/tests/eta-pair.m31.ref
+++ b/tests/eta-pair.m31.ref
@@ -9,8 +9,7 @@ C is assumed.
 D is assumed.
 p is assumed.
 ⊢ λ [c : C] [d : D] refl c
-      : Π [c : C] [d : D] fst C D (pair C D c d) ≡ c
+  : Π [c : C] [d : D] fst C D (pair C D c d) ≡ c
 ⊢ λ [c : C] [d : D] refl d
-      : Π [c : C] [d : D] snd C D (pair C D c d) ≡ d
-⊢ refl p
-      : p ≡ pair C D (fst C D p) (snd C D p)
+  : Π [c : C] [d : D] snd C D (pair C D c d) ≡ d
+⊢ refl p : p ≡ pair C D (fst C D p) (snd C D p)

--- a/tests/eta-unit.m31.ref
+++ b/tests/eta-unit.m31.ref
@@ -1,5 +1,4 @@
 unit is assumed.
 tt is assumed.
 unit_eta is assumed.
-⊢ λ [x : unit] refl tt
-      : Π [x : unit] x ≡ tt
+⊢ λ [x : unit] refl tt : Π [x : unit] x ≡ tt

--- a/tests/eta_commute.m31.ref
+++ b/tests/eta_commute.m31.ref
@@ -5,5 +5,4 @@ List is assumed.
 m is assumed.
 n is assumed.
 lst is assumed.
-⊢ lst
-      : List (plus n m)
+⊢ lst : List (plus n m)

--- a/tests/handle-conjure.m31
+++ b/tests/handle-conjure.m31
@@ -18,5 +18,5 @@ Check
   handle
     λ [a : A] Q A B a (#implicit (B a))
   with
-  | #implicit T k -> k @ (conjure @ T)
+  | #implicit T k -> k (conjure T)
   end.

--- a/tests/handle-counter.m31
+++ b/tests/handle-counter.m31
@@ -12,6 +12,6 @@ Check
     f (#get tt) (#get tt) (#get tt)
   with
   | val v -> (fun _ -> v)
-  | #get _ k -> (fun i -> (k @ i) @ (s i))
-  | finally f -> f @ z
+  | #get _ k -> (fun i -> (k i) (s i))
+  | finally f -> f z
   end.

--- a/tests/handle-counter.m31.ref
+++ b/tests/handle-counter.m31.ref
@@ -4,5 +4,4 @@ s is assumed.
 unit is assumed.
 tt is assumed.
 f is assumed.
-⊢ f z (s z) (s (s z))
-      : N
+⊢ f z (s z) (s (s z)) : N

--- a/tests/handle-op-under-lambda.m31
+++ b/tests/handle-op-under-lambda.m31
@@ -11,5 +11,5 @@ Check
   handle
     λ [b : B] f (#gimme tt)
   with
-  | #gimme _ k -> k @ a
+  | #gimme _ k -> k a
   end.

--- a/tests/handle-op-under-lambda.m31.ref
+++ b/tests/handle-op-under-lambda.m31.ref
@@ -5,5 +5,4 @@ a is assumed.
 f is assumed.
 unit is assumed.
 tt is assumed.
-⊢ λ [b : B] f a
-      : B → C
+⊢ λ [b : B] f a : B → C

--- a/tests/handler_state.m31
+++ b/tests/handler_state.m31
@@ -5,9 +5,9 @@ Let state :=
   fun s0 ->
     handler
     | val x -> (fun _ -> x)
-    | #lookup _ k -> (fun s -> (k @ s) @ s)
-    | #update s k -> (fun _ -> (k @ tt) @ s)
-    | finally f -> f @ s0
+    | #lookup _ k -> (fun s -> k s s)
+    | #update s k -> (fun _ -> k tt s)
+    | finally f -> f s0
     end.
 
 Parameter N : Type.
@@ -16,7 +16,7 @@ Parameter s : N -> N.
 Parameter f : N -> N -> N -> N.
 
 Check
-  with state @ z handle
+  with state z handle
     let a := #lookup tt in
     let _ := #update (s a) in
     let b := #lookup tt in

--- a/tests/handler_state.m31.ref
+++ b/tests/handler_state.m31.ref
@@ -5,5 +5,4 @@ N is assumed.
 z is assumed.
 s is assumed.
 f is assumed.
-⊢ f z (s z) (s (s z))
-      : N
+⊢ f z (s z) (s (s z)) : N

--- a/tests/hint_long_spine.m31.ref
+++ b/tests/hint_long_spine.m31.ref
@@ -4,5 +4,4 @@ a is assumed.
 b is assumed.
 f is assumed.
 f_def is assumed.
-⊢ refl b
-      : f a ≡ b
+⊢ refl b : f a ≡ b

--- a/tests/inhabit-type.m31.ref
+++ b/tests/inhabit-type.m31.ref
@@ -1,10 +1,7 @@
 A is assumed.
 a is assumed.
-⊢ []
-      : [[A]]
+⊢ [] : [[A]]
 B is assumed.
 f is assumed.
-⊢ []
-      : [[B a]]
-⊢ λ [x : A] []
-      : Π [x : A] [[B x]]
+⊢ [] : [[B a]]
+⊢ λ [x : A] [] : Π [x : A] [[B x]]

--- a/tests/lambda-nesting.m31.ref
+++ b/tests/lambda-nesting.m31.ref
@@ -1,5 +1,5 @@
 f is defined.
 g is defined.
 ⊢ refl (λ [T : Type] [U : Type] [x : T] [y : U] x)
-      : (λ [T : Type] [U : Type] [x : T] [y : U] x)
-          ≡ (λ [T : Type] [U : Type] λ [x : T] [y : U] x)
+  : (λ [T : Type] [U : Type] [x : T] [y : U] x)
+      ≡ (λ [T : Type] [U : Type] λ [x : T] [y : U] x)

--- a/tests/match_spine_trailing-flat_e-spine.m31.ref
+++ b/tests/match_spine_trailing-flat_e-spine.m31.ref
@@ -4,22 +4,16 @@ unit_rect is assumed.
 unit_iota_tt is assumed.
 it is defined.
 ⊢ refl tt
-      : tt
-          ≡ (unit_rect (λ [_ : unit] unit → unit)) (λ [x : unit] x) tt
-                tt
+  : tt ≡ (unit_rect (λ [_ : unit] unit → unit)) (λ [x : unit] x) tt tt
 ⊢ refl tt
-      : tt
-          ≡ (unit_rect (λ [_ : unit] unit → unit) (λ [x : unit] x)) tt
-                tt
+  : tt ≡ (unit_rect (λ [_ : unit] unit → unit) (λ [x : unit] x)) tt tt
 ⊢ refl tt
-      : tt
-          ≡ ((unit_rect (λ [_ : unit] unit → unit) (λ [x : unit] x)) tt)
-                tt
+  : tt
+      ≡ ((unit_rect (λ [_ : unit] unit → unit) (λ [x : unit] x)) tt) tt
 ⊢ refl tt
-      : tt
-          ≡ (((unit_rect (λ [_ : unit] unit → unit)) (λ [x : unit] x))
-                 tt) tt
+  : tt
+      ≡ (((unit_rect (λ [_ : unit] unit → unit)) (λ [x : unit] x)) tt)
+            tt
 ⊢ refl tt
-      : tt
-          ≡ ((unit_rect (λ [_ : unit] unit → unit)) (λ [x : unit] x))
-                tt tt
+  : tt
+      ≡ ((unit_rect (λ [_ : unit] unit → unit)) (λ [x : unit] x)) tt tt

--- a/tests/match_spine_trailing-nested_e-spine.m31.ref
+++ b/tests/match_spine_trailing-nested_e-spine.m31.ref
@@ -4,18 +4,12 @@ unit_rect is assumed.
 unit_iota_tt is assumed.
 it is defined.
 ⊢ refl tt
-      : tt
-          ≡ (unit_rect (λ [m : unit] unit → unit) (λ [x : unit] x)) tt
-                tt
+  : tt ≡ (unit_rect (λ [m : unit] unit → unit) (λ [x : unit] x)) tt tt
 ⊢ refl tt
-      : tt
-          ≡ (unit_rect (λ [m : unit] unit → unit) (λ [x : unit] x)) tt
-                tt
+  : tt ≡ (unit_rect (λ [m : unit] unit → unit) (λ [x : unit] x)) tt tt
 ⊢ refl tt
-      : tt
-          ≡ ((unit_rect (λ [m : unit] unit → unit) (λ [x : unit] x)) tt)
-                tt
+  : tt
+      ≡ ((unit_rect (λ [m : unit] unit → unit) (λ [x : unit] x)) tt) tt
 ⊢ refl tt
-      : tt
-          ≡ ((unit_rect (λ [m : unit] unit → unit) (λ [x : unit] x)) tt)
-                tt
+  : tt
+      ≡ ((unit_rect (λ [m : unit] unit → unit) (λ [x : unit] x)) tt) tt

--- a/tests/parallel_let.m31.ref
+++ b/tests/parallel_let.m31.ref
@@ -1,3 +1,2 @@
 cow is defined.
-⊢ Type → Type → Type
-      : Type
+⊢ Type → Type → Type : Type

--- a/tests/rec-list-length.m31
+++ b/tests/rec-list-length.m31
@@ -1,9 +1,9 @@
 Let length := rec length lst ->
   match lst with
   | 'nil => 'z
-  | [lst] 'cons _ lst => 's (length @ lst)
+  | [lst] 'cons _ lst => 's (length lst)
   end.
 
 Let mylist := 'cons 'a ('cons Type ('cons 'nil 'nil)).
 
-Check length @ mylist.
+Check length mylist.

--- a/tests/sequential_let.m31.ref
+++ b/tests/sequential_let.m31.ref
@@ -1,3 +1,2 @@
 cow is defined.
-⊢ Type → Type
-      : Type
+⊢ Type → Type : Type

--- a/tests/structure-check.m31.ref
+++ b/tests/structure-check.m31.ref
@@ -1,4 +1,3 @@
 A is assumed.
 a is assumed.
-⊢ {x as x := a, y as y := (refl a)}
-      : {x as x : A, y as y : (x ≡ a)}
+⊢ {x := a, y := refl a} : {x : A, y : x ≡ a}

--- a/tests/test-check-lambda.m31.ref
+++ b/tests/test-check-lambda.m31.ref
@@ -4,5 +4,4 @@ C is assumed.
 f is assumed.
 g is assumed.
 a is assumed.
-⊢ λ [y : B a] g a y
-      : Π [y : B a] C a y
+⊢ λ [y : B a] g a y : Π [y : B a] C a y

--- a/tests/typeof.m31.ref
+++ b/tests/typeof.m31.ref
@@ -2,15 +2,9 @@ A is assumed.
 P is assumed.
 a is assumed.
 b is assumed.
-⊢ A
-      : Type
-⊢ Type
-      : Type
-⊢ Type
-      : Type
-⊢ P a
-      : Type
-⊢ b
-      : P a
-⊢ Type
-      : Type
+⊢ A : Type
+⊢ Type : Type
+⊢ Type : Type
+⊢ P a : Type
+⊢ b : P a
+⊢ Type : Type

--- a/tests/untagged_functional_arg.m31.ref
+++ b/tests/untagged_functional_arg.m31.ref
@@ -1,5 +1,5 @@
 G is defined.
 G' is defined.
 ⊢ refl (λ [T : Type] [g : T → T] [x : T] g x)
-      : (λ [T : Type] [g : T → T] [x : T] g x)
-          ≡ (λ [T' : Type] [g : T' → T'] [x : T'] g x)
+  : (λ [T : Type] [g : T → T] [x : T] g x)
+      ≡ (λ [T' : Type] [g : T' → T'] [x : T'] g x)


### PR DESCRIPTION
Instead of having to write `(f @ x) @ y` to apply meta level functions we now write `f x y` (`(f x) y` works too).