### PR TITLE
Syntax cleanup

### DIFF
--- a/examples/auto.m31
+++ b/examples/auto.m31
@@ -5,7 +5,7 @@ Axiom pair : Π [A B : Type] A -> (B -> (prod A B)).
 Axiom fst : Π [X Y : Type] prod X Y -> X.
 Axiom snd : Π [X Y : Type] prod X Y -> Y.
 
-Let fold := rec fold f acc lst ->
+Let fold := rec fold f acc lst =>
   match lst with
     | 'nil => acc
     | [x lst] 'cons x lst =>
@@ -14,7 +14,7 @@ Let fold := rec fold f acc lst ->
     end.
 
 (* [applicable A T] = Some n with n>=0 if T is of the form Π [x1 ... xn] A *)
-Let applicable := fun A -> rec applicable T ->
+Let applicable := fun A => rec applicable T =>
   match T with
     | |- A => 'some 'z
     | [B] |- Π [x : _] B =>
@@ -25,8 +25,8 @@ Let applicable := fun A -> rec applicable T ->
     | _ => 'none
   end.
 
-Let find := fun A lst ->
-  fold (fun acc v ->
+Let find := fun A lst =>
+  fold (fun acc v =>
     match v with
       | [T] |- _ : T =>
         match applicable A T with
@@ -35,8 +35,8 @@ Let find := fun A lst ->
         end
     end) 'nil lst.
 
-Let auto := rec auto lst A ->
-  let auto_apply := rec auto_apply argn a ->
+Let auto := rec auto lst A =>
+  let auto_apply := rec auto_apply argn a =>
     match argn with
       | 'z => 'some a
       | [argn] 's argn =>
@@ -60,7 +60,7 @@ Let auto := rec auto lst A ->
       end
 
     | |- _ : Type =>
-      fold (fun found v ->
+      fold (fun found v =>
       match found with
         | 'some _ => found
         | 'none =>
@@ -74,19 +74,19 @@ Axiom unit : Type.
 Axiom tt : unit.
 
 Let auto_handler := handler
-  | val x -> x
-  | #inhabit goal k ->
-    fun hints ->
+  | val x => x
+  | #inhabit goal k =>
+    fun hints =>
     match auto hints goal with
       | [t] 'some t => k t
       | 'none => k (#inhabit goal) hints
     end
-  | #new_hint h k ->
+  | #new_hint h k =>
     match h with
-      | |- _ => fun hints ->
+      | |- _ => fun hints =>
         k tt ('cons h hints)
     end
-  | finally f -> f 'nil
+  | finally f => f 'nil
   end.
 
 Axiom U : Type.

--- a/examples/auto.m31
+++ b/examples/auto.m31
@@ -5,7 +5,7 @@ Axiom pair : Π [A B : Type] A -> (B -> (prod A B)).
 Axiom fst : Π [X Y : Type] prod X Y -> X.
 Axiom snd : Π [X Y : Type] prod X Y -> Y.
 
-Let fold := rec fold f acc lst =>
+Let rec fold f acc lst :=
   match lst with
     | 'nil => acc
     | [x lst] 'cons x lst =>
@@ -14,11 +14,11 @@ Let fold := rec fold f acc lst =>
     end.
 
 (* [applicable A T] = Some n with n>=0 if T is of the form Π [x1 ... xn] A *)
-Let applicable := fun A => rec applicable T =>
+Let rec applicable A T :=
   match T with
     | |- A => 'some 'z
     | [B] |- Π [x : _] B =>
-      match applicable B with
+      match applicable A B with
         | 'none => 'none
         | [n] 'some n => 'some ('s n)
       end
@@ -35,8 +35,8 @@ Let find := fun A lst =>
         end
     end) 'nil lst.
 
-Let auto := rec auto lst A =>
-  let auto_apply := rec auto_apply argn a =>
+Let rec auto lst A :=
+  let rec auto_apply argn a :=
     match argn with
       | 'z => 'some a
       | [argn] 's argn =>

--- a/examples/lambda_afterhought.m31
+++ b/examples/lambda_afterhought.m31
@@ -9,5 +9,5 @@ Check
      let b := #fresh (B a) in
        λ [y : A] pair a b
    with
-     | #fresh t k -> λ [x : t] k x
+     | #fresh t k => λ [x : t] k x
    end.

--- a/src/parser/parser.mly
+++ b/src/parser/parser.mly
@@ -150,8 +150,8 @@ plain_ty_term:
   | e=plain_equal_term                              { e }
   | PROD a=typed_binder+ e=term                     { Prod (List.concat a, e) }
   | LAMBDA a=binder+ e=term                         { Lambda (List.concat a, e) }
-  | FUNCTION a=function_abstraction ARROW e=term    { Function (a, e) }
-  | REC x=name a=function_abstraction ARROW e=term  { Rec (x, a, e) }
+  | FUNCTION a=function_abstraction DARROW e=term    { Function (a, e) }
+  | REC x=name a=function_abstraction DARROW e=term  { Rec (x, a, e) }
   | t1=equal_term ARROW t2=ty_term                  { Prod ([(Name.anonymous, t1)], t2) }
 
 equal_term: mark_location(plain_equal_term) { $1 }
@@ -269,9 +269,9 @@ tags_unhint:
   | ts=tag_var { ts }
 
 handler_case:
-  | BAR VAL x=name ARROW t=term                 { CaseVal (x, t) }
-  | BAR op=OPERATION x=name k=name ARROW t=term { CaseOp (op, x, k, t) }
-  | BAR FINALLY x=name ARROW t=term             { CaseFinally (x, t) }
+  | BAR VAL x=name DARROW t=term                 { CaseVal (x, t) }
+  | BAR op=OPERATION x=name k=name DARROW t=term { CaseOp (op, x, k, t) }
+  | BAR FINALLY x=name DARROW t=term             { CaseFinally (x, t) }
 
 match_case:
   | BAR a=untyped_binder p=pattern DARROW c=term  { (a, p, c) }

--- a/src/parser/parser.mly
+++ b/src/parser/parser.mly
@@ -100,7 +100,8 @@ commandline:
 (* Things that can be defined on toplevel. *)
 topcomp: mark_location(plain_topcomp) { $1 }
 plain_topcomp:
-  | TOPLET x=name yts=typed_binder* u=return_type? COLONEQ c=term { TopLet (x, List.concat yts, u, c) }
+  | TOPLET x=name yts=typed_binder* u=return_type? COLONEQ c=term    { TopLet (x, List.concat yts, u, c) }
+  | TOPLET REC x=name a=function_abstraction COLONEQ e=term          { TopLet (x, [], None, (Rec (x, a, e),snd e)) }
   | TOPCHECK c=term                                  { TopCheck c }
   | TOPBETA ths=tags_hints                           { TopBeta ths }
   | TOPETA ths=tags_hints                            { TopEta ths }
@@ -130,29 +131,30 @@ quoted_string:
 
 term: mark_location(plain_term) { $1 }
 plain_term:
-  | e=plain_ty_term                                   { e }
-  | LET a=let_clauses IN c=term                       { Let (a, c) }
-  | ASSUME x=var_name COLON t=ty_term IN c=term       { Assume ((x, t), c) }
-  | c1=equal_term WHERE e=simple_term COLONEQ c2=term { Where (c1, e, c2) }
-  | BETA tshs=tags_opt_hints IN c=term                { Beta (tshs, c) }
-  | ETA tshs=tags_opt_hints IN c=term                 { Eta (tshs, c) }
-  | HINT tshs=tags_opt_hints IN c=term                { Hint (tshs, c) }
-  | INHABIT tshs=tags_opt_hints IN c=term             { Inhabit (tshs, c) }
-  | UNHINT ts=tags_unhints IN c=term                  { Unhint (ts, c) }
-  | MATCH e=term WITH lst=match_case* END             { Match (e, lst) }
-  | HANDLE c=term WITH hcs=handler_case* END          { Handle (c, hcs) }
-  | WITH h=term HANDLE c=term                         { With (h, c) }
-  | HANDLER hcs=handler_case* END                     { Handler (hcs) }
-  | e=app_term DCOLON t=ty_term                       { Ascribe (e, t) }
+  | e=plain_ty_term                                                 { e }
+  | LET a=let_clauses IN c=term                                     { Let (a, c) }
+  | LET REC x=name a=function_abstraction COLONEQ e=term IN c=term  { Let ([x,(Rec (x, a, e),snd e)], c) }
+  | ASSUME x=var_name COLON t=ty_term IN c=term                     { Assume ((x, t), c) }
+  | c1=equal_term WHERE e=simple_term COLONEQ c2=term               { Where (c1, e, c2) }
+  | BETA tshs=tags_opt_hints IN c=term                              { Beta (tshs, c) }
+  | ETA tshs=tags_opt_hints IN c=term                               { Eta (tshs, c) }
+  | HINT tshs=tags_opt_hints IN c=term                              { Hint (tshs, c) }
+  | INHABIT tshs=tags_opt_hints IN c=term                           { Inhabit (tshs, c) }
+  | UNHINT ts=tags_unhints IN c=term                                { Unhint (ts, c) }
+  | MATCH e=term WITH lst=match_case* END                           { Match (e, lst) }
+  | HANDLE c=term WITH hcs=handler_case* END                        { Handle (c, hcs) }
+  | WITH h=term HANDLE c=term                                       { With (h, c) }
+  | HANDLER hcs=handler_case* END                                   { Handler (hcs) }
+  | e=app_term DCOLON t=ty_term                                     { Ascribe (e, t) }
 
 ty_term: mark_location(plain_ty_term) { $1 }
 plain_ty_term:
-  | e=plain_equal_term                              { e }
-  | PROD a=typed_binder+ e=term                     { Prod (List.concat a, e) }
-  | LAMBDA a=binder+ e=term                         { Lambda (List.concat a, e) }
+  | e=plain_equal_term                               { e }
+  | PROD a=typed_binder+ e=term                      { Prod (List.concat a, e) }
+  | LAMBDA a=binder+ e=term                          { Lambda (List.concat a, e) }
   | FUNCTION a=function_abstraction DARROW e=term    { Function (a, e) }
   | REC x=name a=function_abstraction DARROW e=term  { Rec (x, a, e) }
-  | t1=equal_term ARROW t2=ty_term                  { Prod ([(Name.anonymous, t1)], t2) }
+  | t1=equal_term ARROW t2=ty_term                   { Prod ([(Name.anonymous, t1)], t2) }
 
 equal_term: mark_location(plain_equal_term) { $1 }
 plain_equal_term:

--- a/tests/error-handle-change-type.m31
+++ b/tests/error-handle-change-type.m31
@@ -8,6 +8,6 @@ Check
   (handle
      (λ [e : B == A] let crime := (hint e in (a :: B)) in #mafia crime)
    with
-   | #mafia x k -> x
+   | #mafia x k => x
    end
   ).

--- a/tests/handle-conjure.m31
+++ b/tests/handle-conjure.m31
@@ -1,10 +1,10 @@
 (* Create a variable of type A out of thin air. *)
 Let conjure :=
-  (fun U ->
+  (fun U =>
      handle
        λ [magic : U] #conjure magic
      with
-     | #conjure x _ -> x
+     | #conjure x _ => x
      end
   ).
 
@@ -18,5 +18,5 @@ Check
   handle
     λ [a : A] Q A B a (#implicit (B a))
   with
-  | #implicit T k -> k (conjure T)
+  | #implicit T k => k (conjure T)
   end.

--- a/tests/handle-counter.m31
+++ b/tests/handle-counter.m31
@@ -11,7 +11,7 @@ Check
   handle
     f (#get tt) (#get tt) (#get tt)
   with
-  | val v -> (fun _ -> v)
-  | #get _ k -> (fun i -> (k i) (s i))
-  | finally f -> f z
+  | val v => (fun _ => v)
+  | #get _ k => (fun i => (k i) (s i))
+  | finally f => f z
   end.

--- a/tests/handle-op-under-lambda.m31
+++ b/tests/handle-op-under-lambda.m31
@@ -11,5 +11,5 @@ Check
   handle
     λ [b : B] f (#gimme tt)
   with
-  | #gimme _ k -> k a
+  | #gimme _ k => k a
   end.

--- a/tests/handler_state.m31
+++ b/tests/handler_state.m31
@@ -2,12 +2,12 @@ Parameter unit : Type.
 Parameter tt : unit.
 
 Let state :=
-  fun s0 ->
+  fun s0 =>
     handler
-    | val x -> (fun _ -> x)
-    | #lookup _ k -> (fun s -> k s s)
-    | #update s k -> (fun _ -> k tt s)
-    | finally f -> f s0
+    | val x => (fun _ => x)
+    | #lookup _ k => (fun s => k s s)
+    | #update s k => (fun _ => k tt s)
+    | finally f => f s0
     end.
 
 Parameter N : Type.

--- a/tests/rec-list-length.m31
+++ b/tests/rec-list-length.m31
@@ -1,4 +1,4 @@
-Let length := rec length lst ->
+Let length := rec length lst =>
   match lst with
   | 'nil => 'z
   | [lst] 'cons _ lst => 's (length lst)


### PR DESCRIPTION
We need to use the double arrow when matching, otherwise we have

    match v with
      | |- A -> B -> C -> D
which is quite ambiguous. Then for consistency other meta-level arrows should be `=>`, especially for the handler statements.

Also add `let rec f x y := foo in bar` and `Let rec f x y := foo.`