### PR TITLE
Implement top-level handlers, close #86

### DIFF
--- a/src/andromeda.ml
+++ b/src/andromeda.ml
@@ -128,6 +128,9 @@ let rec exec_cmd base_dir interactive env c =
      if interactive then Format.printf "%t is assumed.@." (Name.print_ident x) ;
      env
 
+  | Syntax.TopHandle lst ->
+     List.fold_left (fun env (op, xc) -> Environment.add_handle op xc env) env lst
+
   | Syntax.TopLet (x, c) ->
      let v = Eval.comp_value env c in
      let env = Environment.add_bound x v env in

--- a/src/nucleus/environment.ml
+++ b/src/nucleus/environment.ml
@@ -16,6 +16,7 @@ type t = {
   eta : (string list list * Pattern.eta_hint list) HintMap.t;
   general : (string list list * Pattern.general_hint list) GeneralMap.t;
   inhabit : (string list list * Pattern.inhabit_hint list) HintMap.t;
+  handle : (string * (Name.ident * Syntax.comp)) list;
   files : string list;
 }
 
@@ -27,6 +28,7 @@ let empty = {
   eta = HintMap.empty ;
   general = GeneralMap.empty ;
   inhabit = HintMap.empty ;
+  handle = [] ;
   files = [] ;
 }
 
@@ -167,6 +169,14 @@ let add_fresh ~loc env x (ctx, t) =
   let yt = Value.Term (ctx, Tt.mk_atom ~loc y, t) in
   let env = add_bound x yt env in
   y, env
+
+let add_handle op xc env =
+  { env with handle = (op, xc) :: env.handle }
+
+let lookup_handle op {handle=lst} =
+  try
+    Some (List.assoc op lst)
+  with Not_found -> None
 
 let add_file f env =
   { env with files = (Filename.basename f) :: env.files }

--- a/src/nucleus/environment.mli
+++ b/src/nucleus/environment.mli
@@ -64,6 +64,12 @@ val unhint : string list -> t -> t
 (** Add a bound variable with given name to the environment. *)
 val add_bound : Name.ident -> Value.value -> t -> t
 
+(** Add a top-level handler case to the environment. *)
+val add_handle : string -> (Name.ident * Syntax.comp) -> t -> t
+
+(** Lookup the top-level handler for the given operation, if any. *)
+val lookup_handle : string -> t -> (Name.ident * Syntax.comp) option
+
 (** Add a file to the list of files included. *)
 val add_file : string -> t -> t
 

--- a/src/nucleus/eval.mli
+++ b/src/nucleus/eval.mli
@@ -16,16 +16,9 @@ val hint_bind : Environment.t -> (string list * Syntax.comp) list -> Environment
     the environment [env] extended with the hints. *)
 val inhabit_bind : Environment.t -> (string list * Syntax.comp) list -> Environment.t Value.result
 
-(** [comp env c] evaluates computation [c] in environment [env]. *)
-val comp : Environment.t -> Syntax.comp -> Value.value Value.result
-
 (** [comp_value env] evaluates computation [c] in environment [env] and returns
     its value, or triggers a runtime error if the result is an operation. *)
 val comp_value : Environment.t -> Syntax.comp -> Value.value
-
-(** [comp_term env c] evaluates computation [c] in environment [env],
-    checks that the result is a term and returns it. *)
-val comp_term : Environment.t -> Syntax.comp -> Judgement.term
 
 (** [comp_ty env c] evaluates computation [c] in environment [env],
     checks that the result is a type and returns it. *)

--- a/src/parser/desugar.ml
+++ b/src/parser/desugar.ml
@@ -557,6 +557,10 @@ let toplevel constants bound (d', loc) =
       let ryts, u = fold bound [] ryts in
       Syntax.Axiom (x, ryts, u)
 
+    | Input.TopHandle lst ->
+       let lst = List.map (fun (op, x, c) -> op, (x, comp constants (add_bound x bound) c)) lst in
+       Syntax.TopHandle lst
+
     | Input.TopLet (x, yts, u, ((_, loc) as c)) ->
       let c = match u with
         | None -> c

--- a/src/parser/input.mli
+++ b/src/parser/input.mli
@@ -89,7 +89,9 @@ and match_case = Name.ident list * pattern * comp
 (** Sugared toplevel commands *)
 type toplevel = toplevel' * Location.t
 and toplevel' =
-  | Axiom of Name.ident * (bool * (Name.ident * ty)) list * ty (** introduce a primitive constant, the boolean is [true] if the argument is eagerly reducing *)
+  | Axiom of Name.ident * (bool * (Name.ident * ty)) list * ty
+    (** introduce a primitive constant, the boolean is [true] if the argument is eagerly reducing *)
+  | TopHandle of (string * Name.ident * comp) list 
   | TopLet of Name.ident * (Name.ident * ty) list * ty option * comp (** global let binding *)
   | TopCheck of comp (** infer the type of a computation *)
   | TopBeta of (string list * comp) list (** global beta hint *)

--- a/src/parser/lexer.ml
+++ b/src/parser/lexer.ml
@@ -22,6 +22,7 @@ let reserved = [
   ("Hint", TOPHINT) ;
   ("unhint", UNHINT) ;
   ("Unhint", TOPUNHINT) ;
+  ("Handle", TOPHANDLE) ;
   ("Hypothesis", AXIOM) ;
   ("inhabit", INHABIT) ;
   ("Inhabit", TOPINHABIT) ;

--- a/src/parser/parser.mly
+++ b/src/parser/parser.mly
@@ -30,14 +30,15 @@
 
 (* Toplevel computations *)
 %token TOPCHECK
+%token TOPHANDLE
+%token TOPLET
+%token TOPBETA TOPETA TOPHINT TOPINHABIT
+%token TOPUNHINT
 
 (* Let binding *)
-%token TOPLET
 %token LET COLONEQ AND IN
 
 (* Hints *)
-%token TOPBETA TOPETA TOPHINT TOPINHABIT
-%token TOPUNHINT
 %token BETA ETA HINT INHABIT
 %token UNHINT
 
@@ -100,8 +101,11 @@ commandline:
 (* Things that can be defined on toplevel. *)
 topcomp: mark_location(plain_topcomp) { $1 }
 plain_topcomp:
-  | TOPLET x=name yts=typed_binder* u=return_type? COLONEQ c=term    { TopLet (x, List.concat yts, u, c) }
-  | TOPLET REC x=name a=function_abstraction COLONEQ e=term          { TopLet (x, [], None, (Rec (x, a, e),snd e)) }
+  | TOPLET x=name yts=typed_binder* u=return_type? COLONEQ c=term 
+       { TopLet (x, List.concat yts, u, c) }
+  | TOPLET REC x=name a=function_abstraction COLONEQ e=term
+       { TopLet (x, [], None, (Rec (x, a, e),snd e)) }
+  | TOPHANDLE lst=list(top_handler_case) END         { TopHandle lst }
   | TOPCHECK c=term                                  { TopCheck c }
   | TOPBETA ths=tags_hints                           { TopBeta ths }
   | TOPETA ths=tags_hints                            { TopEta ths }
@@ -274,6 +278,9 @@ handler_case:
   | BAR VAL x=name DARROW t=term                 { CaseVal (x, t) }
   | BAR op=OPERATION x=name k=name DARROW t=term { CaseOp (op, x, k, t) }
   | BAR FINALLY x=name DARROW t=term             { CaseFinally (x, t) }
+
+top_handler_case:
+  | BAR op=OPERATION x=name DARROW t=term        { (op, x, t) }
 
 match_case:
   | BAR a=untyped_binder p=pattern DARROW c=term  { (a, p, c) }

--- a/src/syntax.ml
+++ b/src/syntax.ml
@@ -79,6 +79,7 @@ and match_case = Name.ident list * pattern * comp
 type toplevel = toplevel' * Location.t
 and toplevel' =
   | Axiom of Name.ident * (bool * (Name.ident * comp)) list * comp
+  | TopHandle of (string * (Name.ident * comp)) list
   | TopLet of Name.ident * comp (** global let binding *)
   | TopCheck of comp (** infer the type of a computation *)
   | TopBeta of (string list * comp) list

--- a/src/syntax.mli
+++ b/src/syntax.mli
@@ -79,6 +79,7 @@ and match_case = Name.ident list * pattern * comp
 type toplevel = toplevel' * Location.t
 and toplevel' =
   | Axiom of Name.ident * (bool * (Name.ident * comp)) list * comp (** introduce a constant *)
+  | TopHandle of (string * (Name.ident * comp)) list
   | TopLet of Name.ident * comp (** global let binding *)
   | TopCheck of comp (** infer the type of a computation *)
   | TopBeta of (string list * comp) list


### PR DESCRIPTION
The top-level handlers are recursive and do not have access to the continuation.