### PR TITLE
Use question marks for pattern variables

### DIFF
--- a/examples/auto.m31
+++ b/examples/auto.m31
@@ -8,7 +8,7 @@ Let snd := assume snd : Π [X Y : Type] prod X Y -> Y in snd.
 Let rec fold f acc lst :=
   match lst with
     | 'nil => acc
-    | [x lst] 'cons x lst =>
+    | 'cons ?x ?lst =>
       let acc := f acc x in
       fold f acc lst
     end.
@@ -20,7 +20,7 @@ Let rec is_x xs t :=
   match xs with
     | 'cons ('pair t _) _ =>
       'true
-    | [xs] 'cons _ xs =>
+    | 'cons _ ?xs =>
       is_x xs t
     | 'nil => 'false
   end.
@@ -28,12 +28,12 @@ Let rec is_x xs t :=
 Let rec set_x x v xs :=
   match xs with
     | 'cons ('pair x ('some v)) _ => 'some xs
-    | [tail] 'cons ('pair x 'none) tail =>
+    | 'cons ('pair x 'none) ?tail =>
       'some ('cons ('pair x ('some v)) tail)
     | 'cons ('pair x _) _ => 'none (* x already set to something other than v *)
-    | [y tail] 'cons y tail =>
+    | 'cons ?y ?tail =>
       match set_x x v tail with
-        | [tail] 'some tail => 'some ('cons y tail)
+        | 'some ?tail => 'some ('cons y tail)
         | 'none => 'none
       end
   end.
@@ -45,9 +45,9 @@ Let rec apply_match xs target t :=
     | 'false =>
       match 'pair target t with
         | 'pair t t => 'some xs (* they were actually equal *)
-        | [a b c d] 'pair (|- a b) (|- c d) =>
+        | 'pair (|- ?a ?b) (|- ?c ?d) =>
           match apply_match xs a c with
-            | [xs] 'some xs =>
+            | 'some ?xs =>
               apply_match xs b d
             | 'none => 'none
           end
@@ -59,10 +59,10 @@ Let rec apply_match xs target t :=
    such that we autofill if the term option is None and use the term otherwise. *)
 Let rec applicable A xs T :=
   match apply_match xs A T with
-    | [xs] 'some xs => 'some xs
+    | 'some ?xs => 'some xs
     | 'none =>
       match T with
-        | [x B] |- Π [x : _] B =>
+        | |- Π [?x : _] ?B =>
           applicable A ('cons ('pair x 'none) xs) B
         | _ => 'none
       end
@@ -71,10 +71,10 @@ Let rec applicable A xs T :=
 Let find := fun A lst =>
   fold (fun acc v =>
     match v with
-      | [T] |- _ : T =>
+      | |- _ : ?T =>
         match applicable A 'nil T with
           | 'none => acc
-          | [n] 'some n => 'cons ('pair (rev n) v) acc
+          | 'some ?n => 'cons ('pair (rev n) v) acc
         end
     end) 'nil lst.
 
@@ -82,15 +82,15 @@ Let rec auto lst A :=
   let rec auto_apply args a :=
     match args with
       | 'nil => 'some a
-      | [args] 'cons ('pair _ 'none) args =>
+      | 'cons ('pair _ 'none) ?args =>
         match a with
-          | [T] |- _ : Π [x : T] _ =>
+          | |- _ : Π [x : ?T] _ =>
             match auto lst T with
-              | [t] 'some t => auto_apply args (a t)
+              | 'some ?t => auto_apply args (a t)
               | 'none => 'none
             end
         end
-      | [v args] 'cons ('pair _ ('some v)) args =>
+      | 'cons ('pair _ ('some ?v)) ?args =>
         auto_apply args (a v)
     end
   in
@@ -110,7 +110,7 @@ Let rec auto lst A :=
         | 'some _ => found
         | 'none =>
           match v with
-            | [n v] 'pair n v => auto_apply n v
+            | 'pair ?n ?v => auto_apply n v
           end
       end) 'none (find A lst)
   end.
@@ -123,7 +123,7 @@ Let auto_handler := handler
   | #inhabit goal k =>
     fun hints =>
     match auto hints goal with
-      | [t] 'some t => k (t :: goal) hints
+      | 'some ?t => k (t :: goal) hints
       | 'none => k (#inhabit goal) hints
     end
   | #new_hint h k =>

--- a/examples/implicit.m31
+++ b/examples/implicit.m31
@@ -2,7 +2,7 @@
 Let rec fold f acc lst :=
   match lst with
     | 'nil => acc
-    | [x lst] 'cons x lst =>
+    | 'cons ?x ?lst =>
       let acc := f acc x in
       fold f acc lst
     end.
@@ -14,7 +14,7 @@ Let rec append l1 l2 :=
   match l1 with
     | 'nil =>
       l2
-    | [x tl] 'cons x tl =>
+    | 'cons ?x ?tl =>
       let lapp := append tl l2 in
       'cons x lapp
   end.
@@ -55,7 +55,7 @@ Let rec append l1 l2 :=
 *)
 
 Let add_fresh := fun s => match s with
-  | [inst vars] 'pair inst vars =>
+  | 'pair ?inst ?vars =>
     assume T_ : Type in
     assume x_ : T_ in
     'pair x_ ('pair inst ('cons x_ ('cons T_ vars)))
@@ -65,14 +65,14 @@ Let add_fresh := fun s => match s with
    IMPORTANT: insts must be in order of application *)
 Let apply_insts := fun v insts =>
   fold (fun v inst => match inst with
-    | [x vx] 'pair x vx =>
+    | 'pair ?x ?vx =>
       v where x := vx
     end) v (rev insts).
 
 Let rec mem x l :=
   match l with
-    | [y] 'cons (x as y) _ => 'some y
-    | [l] 'cons _ l => mem x l
+    | 'cons (x as ?y) _ => 'some y
+    | 'cons _ ?l => mem x l
     | 'nil => 'none
   end.
 
@@ -80,33 +80,33 @@ Let rec mem x l :=
 Let rec solve_eq s A B :=
   let instantiate := fun s x v =>
     match 'pair x v with
-      | [tx tv] 'pair (|- _ : tx) (|- _ : tv) =>
+      | 'pair (|- _ : ?tx) (|- _ : ?tv) =>
         match solve_eq s tx tv with
-          | [insts vars] 'some ('pair insts vars) =>
+          | 'some ('pair ?insts ?vars) =>
             let insts := 'cons ('pair (apply_insts x insts) (apply_insts v insts)) insts in
             'some ('pair insts vars)
           | 'none => 'none
         end
     end
   in
-  match s with | [insts vars] 'pair insts vars =>
+  match s with | 'pair ?insts ?vars =>
     let _ := (external "print") ('input A B insts) in
     let A := apply_insts A insts in
     let B := apply_insts B insts in
     let _ := (external "print") ('output A B) in
     match 'pair A B with
       | 'pair A A => 'some s (* trivial case *)
-      | [A1 A2 B1 B2] 'pair (|- A1 A2) (|- B1 B2) =>
+      | 'pair (|- ?A1 ?A2) (|- ?B1 ?B2) =>
         match solve_eq s A1 B1 with
-          | [s] 'some s =>
+          | 'some ?s =>
             solve_eq s A2 B2
           | 'none => 'none
         end
       | _ => match mem A vars with
-        | [A] 'some A =>
+        | 'some ?A =>
           instantiate s A B
         | 'none => match mem B vars with
-          | [B] 'some B =>
+          | 'some ?B =>
             instantiate s B A
           | 'none => 'none
           end
@@ -116,7 +116,7 @@ Let rec solve_eq s A B :=
 
 Let finalize := fun s =>
   match s with
-    | [insts v] 'pair ('pair insts _) v =>
+    | 'pair ('pair ?insts _) ?v =>
       apply_insts v insts
   end.
 
@@ -125,14 +125,14 @@ Let h := handler
   | val x => fun s => 'pair s x
   | #implicit _ k =>
     fun s => match add_fresh s with
-      | [x s] 'pair x s => k x s
+      | 'pair ?x ?s => k x s
       end
   | #equal eq k =>
     fun s =>
     match eq with
-      | [A B] 'pair A B => let _ := (external "print") ('equal eq s) in
+      | 'pair ?A ?B => let _ := (external "print") ('equal eq s) in
         match solve_eq s A B with
-          | [insts vars] 'some ('pair insts vars) =>
+          | 'some ('pair ?insts ?vars) =>
             assume eq : A == B in
             let eqinst := 'pair (apply_insts eq insts) (refl (apply_insts A insts)) in
             let vars := 'cons eq vars in

--- a/src/parser/input.mli
+++ b/src/parser/input.mli
@@ -10,6 +10,7 @@ type tt_pattern = tt_pattern' * Location.t
 and tt_pattern' =
   | Tt_Anonymous
   | Tt_As of tt_pattern * Name.ident
+  | Tt_Var of Name.ident
   | Tt_Type
   | Tt_Name of Name.ident
   | Tt_Lambda of Name.ident * tt_pattern option * tt_pattern
@@ -27,6 +28,7 @@ type pattern = pattern' * Location.t
 and pattern' =
   | Patt_Anonymous
   | Patt_As of pattern * Name.ident
+  | Patt_Var of Name.ident
   | Patt_Name of Name.ident
   | Patt_Jdg of tt_pattern * tt_pattern
   | Patt_Tag of Name.ident * pattern list
@@ -85,7 +87,7 @@ and handle_case =
   | CaseOp of string * Name.ident * Name.ident * comp (* #op x k -> c *)
   | CaseFinally of Name.ident * comp (* finally x -> c *)
                                   
-and match_case = Name.ident list * pattern * comp
+and match_case = pattern * comp
 
 (** Sugared toplevel commands *)
 type toplevel = toplevel' * Location.t

--- a/src/parser/input.mli
+++ b/src/parser/input.mli
@@ -13,15 +13,16 @@ and tt_pattern' =
   | Tt_Var of Name.ident
   | Tt_Type
   | Tt_Name of Name.ident
-  | Tt_Lambda of Name.ident * tt_pattern option * tt_pattern
+  (** For each binder the boolean indicates whether the bound variable should be a pattern variable *)
+  | Tt_Lambda of bool * Name.ident * tt_pattern option * tt_pattern
   | Tt_App of tt_pattern * tt_pattern
-  | Tt_Prod of Name.ident * tt_pattern option * tt_pattern
+  | Tt_Prod of bool * Name.ident * tt_pattern option * tt_pattern
   | Tt_Eq of tt_pattern * tt_pattern
   | Tt_Refl of tt_pattern
   | Tt_Inhab
   | Tt_Bracket of tt_pattern
-  | Tt_Signature of (Name.ident * Name.ident option * tt_pattern) list
-  | Tt_Structure of (Name.ident * Name.ident option * tt_pattern) list
+  | Tt_Signature of (Name.ident * bool * Name.ident option * tt_pattern) list
+  | Tt_Structure of (Name.ident * bool * Name.ident option * tt_pattern) list
   | Tt_Projection of tt_pattern * Name.ident
 
 type pattern = pattern' * Location.t

--- a/src/parser/lexer.ml
+++ b/src/parser/lexer.ml
@@ -110,6 +110,7 @@ and token_aux ({ stream; pos_end; end_of_input; line_limit } as lexbuf) =
   | ':'                      -> f (); COLON
   | ','                      -> f (); COMMA
   | ';'                      -> f (); SEMICOLON
+  | '?', name                -> f (); PATTVAR (let s = lexeme lexbuf in String.sub s 1 (String.length s - 1))
   | '.', name                -> f (); PROJECTION (let s = lexeme lexbuf in String.sub s 1 (String.length s - 1))
   | '.'                      -> f (); g (); DOT
   | '_'                      -> f (); UNDERSCORE

--- a/tests/list-append.m31
+++ b/tests/list-append.m31
@@ -3,7 +3,7 @@ Let rec append l1 l2 :=
   match l1 with
     | 'nil =>
       l2
-    | [x tl] 'cons x tl =>
+    | 'cons ?x ?tl =>
       'cons x (append tl l2)
   end.
 
@@ -11,7 +11,7 @@ Let rec append' l1 l2 :=
   match l1 with
     | 'nil =>
       l2
-    | [x tl] 'cons x tl =>
+    | 'cons ?x ?tl =>
       let lapp := append' tl l2 in
       'cons x lapp
   end.

--- a/tests/meta-match.m31
+++ b/tests/meta-match.m31
@@ -7,11 +7,11 @@ Axiom c : A.
 
 Check match a with
   | |- b => 'b
-  | [] |- a => 'a
+  | |- a => 'a
   end.
 
 Check match λ [x : A] a with
-  | [x y z t x' y'] |- λ [x : y] z : Π [x' : y'] t => 'lambda x y z ('prod x' y' t)
+  | |- λ [?x : ?y] ?z : Π [?x' : ?y'] ?t => 'lambda x y z ('prod x' y' t)
   end.
 
 Axiom list : Type.
@@ -20,9 +20,9 @@ Let cons := assume cons : A -> list -> list in cons. (* Matching constants of no
 
 Check match 'foo (cons a (cons b (cons c nil))) 'bar with
   | 'foo => 'no
-  | [x y z t x' y'] |- λ [x : y] z : Π [x' : y'] t => 'lambda x y z ('prod x' y' t)
-  | [x y] 'foo
-    (|- cons _ ((cons x _) as y))
+  | |- λ [?x : ?y] ?z : Π [?x' : ?y'] ?t => 'lambda x y z ('prod x' y' t)
+  | 'foo
+    (|- cons _ ((cons ?x _) as ?y))
     'bar => 'pair x y
   end.
 

--- a/tests/rec-list-length.m31
+++ b/tests/rec-list-length.m31
@@ -1,7 +1,7 @@
 Let length := rec length lst =>
   match lst with
   | 'nil => 'z
-  | [lst] 'cons _ lst => 's (length lst)
+  | 'cons _ ?lst => 's (length lst)
   end.
 
 Let mylist := 'cons 'a ('cons Type ('cons 'nil 'nil)).


### PR DESCRIPTION
Closes #97.

Binders in patterns have the special syntax

         λ [?x : tt_pattern] tt_pattern
 to replace the previous

         | [x] ... λ [x : tt_pattern] tt_pattern