### PR TITLE
Make [external "..."] a term in its own right

### DIFF
--- a/examples/implicit.m31
+++ b/examples/implicit.m31
@@ -90,10 +90,10 @@ Let rec solve_eq s A B :=
     end
   in
   match s with | 'pair ?insts ?vars =>
-    let _ := (external "print") ('input A B insts) in
+    let _ := external "print" ('input A B insts) in
     let A := apply_insts A insts in
     let B := apply_insts B insts in
-    let _ := (external "print") ('output A B) in
+    let _ := external "print" ('output A B) in
     match 'pair A B with
       | 'pair A A => 'some s (* trivial case *)
       | 'pair (|- ?A1 ?A2) (|- ?B1 ?B2) =>
@@ -130,7 +130,7 @@ Let h := handler
   | #equal eq k =>
     fun s =>
     match eq with
-      | 'pair ?A ?B => let _ := (external "print") ('equal eq s) in
+      | 'pair ?A ?B => let _ := external "print" ('equal eq s) in
         match solve_eq s A B with
           | 'some ('pair ?insts ?vars) =>
             assume eq : A == B in

--- a/src/parser/parser.mly
+++ b/src/parser/parser.mly
@@ -170,7 +170,6 @@ plain_app_term:
                                                       | Tag (t, []) -> Tag (t, es)
                                                       | _ -> Spine (e, es) }
   | e1=simple_term p=PROJECTION                     { Projection(e1,Name.make p) }
-  | EXTERNAL s=QUOTED_STRING                        { External s }
   | WHNF t=simple_term                              { Whnf t }
   | SNF t=simple_term                               { Snf t }
   | TYPEOF t=simple_term                            { Typeof t }
@@ -179,6 +178,7 @@ plain_app_term:
 
 simple_term: mark_location(plain_simple_term) { $1 }
 plain_simple_term:
+  | EXTERNAL s=QUOTED_STRING                        { External s }
   | TYPE                                            { Type }
   | LRBRACK                                         { Inhab }
   | x=var_name                                      { Var x }


### PR DESCRIPTION
This avoids having to parenthesize like [(external "...") x y]