### PR TITLE
Convert terms from pairs to records.

### DIFF
--- a/src/nucleus/eval.ml
+++ b/src/nucleus/eval.ml
@@ -374,7 +374,7 @@ and require_equal ~loc env ((lctx,lte,lty) as ljdg) ((rctx,rte,rty) as rjdg)
             let ctx = Context.join ctxeq (Context.join lctx rctx) in (* user may have done something surprising somehow *)
             f ctx
           else
-            Error.typing ~loc:(snd eq) "this expression should have type@ %t@ but has type@ %t"
+            Error.typing ~loc:(eq.Tt.loc) "this expression should have type@ %t@ but has type@ %t"
                          (print_ty env tgoal) (print_ty env teq)
         | Value.Tag (t, []) when (Name.eq_ident t tnone) ->
           error ()
@@ -384,8 +384,8 @@ and require_equal ~loc env ((lctx,lte,lty) as ljdg) ((rctx,rte,rty) as rjdg)
 
 and require_equal_ty ~loc env (lctx,Tt.Ty lte) (rctx,Tt.Ty rte)
                      (f : Context.t -> 'a Value.result) error : 'a Value.result =
-  require_equal ~loc env (lctx,lte,Tt.mk_type_ty ~loc:(snd lte))
-                         (rctx,rte,Tt.mk_type_ty ~loc:(snd rte))
+  require_equal ~loc env (lctx,lte,Tt.mk_type_ty ~loc:(lte.Tt.loc))
+                         (rctx,rte,Tt.mk_type_ty ~loc:(rte.Tt.loc))
                          f error
 
 and check env ((c',loc) as c) (((ctx_check, t_check') as t_check) : Judgement.ty) : (Context.t * Tt.term) Value.result =
@@ -416,7 +416,7 @@ and check env ((c',loc) as c) (((ctx_check, t_check') as t_check) : Judgement.ty
     infer env c >>= as_term ~loc >>= fun (ctxe, e, t') ->
     let k ctx = Value.return (ctx, e) in
     require_equal_ty ~loc env t_check (ctxe,t') k
-      (fun () -> Error.typing ~loc:(snd e)
+      (fun () -> Error.typing ~loc:(e.Tt.loc)
                               "this expression should have type@ %t@ but has type@ %t"
                               (print_ty env t_check') (print_ty env t'))
 
@@ -426,7 +426,7 @@ and check env ((c',loc) as c) (((ctx_check, t_check') as t_check) : Judgement.ty
        let (ctxe, e', t') = Value.as_term ~loc v in
        let k ctx = Value.return (ctx, e') in
        require_equal_ty ~loc env t_check (ctxe,t') k
-         (fun () -> Error.typing ~loc:(snd e')
+         (fun () -> Error.typing ~loc:(e'.Tt.loc)
                                  "this expression should have type@ %t@ but has type@ %t"
                                  (print_ty env t_check') (print_ty env t'))
      in

--- a/src/nucleus/hint.ml
+++ b/src/nucleus/hint.ml
@@ -30,7 +30,7 @@ let has_head_name = function
     given bound variables [pvars]. That is, the bound variables from [pvars]
     are treated as pattern variables. Return the list of those [pvars] that
     were not encoutered, and the pattern generated. *)
-let rec of_term env pvars ((e',loc) as e) t =
+let rec of_term env pvars ({Tt.term=e';loc;} as e) t =
   let original = pvars, Pattern.Term (e,t) in
   match e' with
 

--- a/src/nucleus/pattern.ml
+++ b/src/nucleus/pattern.ml
@@ -52,7 +52,7 @@ type hint_key =
 
 type general_key = hint_key option * hint_key option * hint_key option
 
-let rec term_key_opt (e',loc) =
+let rec term_key_opt {Tt.term=e';loc} =
   match e' with
   | Tt.Type -> Some Key_Type
   | Tt.Atom x -> Some (Key_Atom x)
@@ -72,7 +72,7 @@ let rec term_key_opt (e',loc) =
 let term_key e =
   match term_key_opt e with
   | Some k -> k
-  | None -> Error.impossible ~loc:(snd e) "De Bruijn index encountered in term_key"
+  | None -> Error.impossible ~loc:(e.Tt.loc) "De Bruijn index encountered in term_key"
 
 let ty_key (Tt.Ty t) = term_key t
 let ty_key_opt (Tt.Ty t) = term_key_opt t

--- a/src/nucleus/simplify.ml
+++ b/src/nucleus/simplify.ml
@@ -1,13 +1,13 @@
 (** Simplification of expressions and types. *)
 
-let is_small (e',_) =
+let is_small {Tt.term=e'} =
 match e' with
   | Tt.Constant (_, es) -> es = []
   | Tt.Type | Tt.Inhab _ | Tt.Bound _ | Tt.Atom _ -> true
   | Tt.Lambda _ | Tt.Spine _ | Tt.Prod _ | Tt.Refl _ | Tt.Eq _
   | Tt.Bracket _ | Tt.Signature _ | Tt.Structure _ | Tt.Projection _ -> false
 
-let rec term ((e',loc) as e) =
+let rec term ({Tt.term=e';loc} as e) =
     match e' with
 
     | Tt.Type -> e
@@ -143,7 +143,7 @@ and spine ~loc h xts t es =
   in
 
   (* First we simplify the head and the arguments. *)
-  let (h', _) as h = term h
+  let {Tt.term=h'} as h = term h
   and xts, t = simplify_xts [] [] xts
   and es = List.map term es in
 
@@ -192,30 +192,30 @@ and spine ~loc h xts t es =
     Error.impossible ~loc "de Bruijn encountered in Simplify.spine"
 
 and project ~loc te xts p =
-  let te',_ = te in match te' with
-    | Tt.Structure xtes ->
-      let sig1 = Tt.mk_signature ~loc (List.map (fun (x,y,t,_) -> x,y,t) xtes) in
-      let sig2 = Tt.mk_signature ~loc xts in
-      if Tt.alpha_equal sig1 sig2
-      then
-        let te = Tt.field_value ~loc xtes p in
-        term te
-      else Tt.mk_projection ~loc te xts p
-    | Tt.Constant _
-    | Tt.Lambda _
-    | Tt.Spine _
-    | Tt.Atom _
-    | Tt.Type
-    | Tt.Inhab _
-    | Tt.Bracket _
-    | Tt.Prod _
-    | Tt.Eq _
-    | Tt.Refl _
-    | Tt.Signature _
-    | Tt.Projection _ -> Tt.mk_projection ~loc te xts p
-    
-    | Tt.Bound _ ->
-      Error.impossible ~loc "de Bruijn encountered in Simplify.project"
+  match te.Tt.term with
+  | Tt.Structure xtes ->
+     let sig1 = Tt.mk_signature ~loc (List.map (fun (x,y,t,_) -> x,y,t) xtes) in
+     let sig2 = Tt.mk_signature ~loc xts in
+     if Tt.alpha_equal sig1 sig2
+     then
+       let te = Tt.field_value ~loc xtes p in
+       term te
+     else Tt.mk_projection ~loc te xts p
+  | Tt.Constant _
+  | Tt.Lambda _
+  | Tt.Spine _
+  | Tt.Atom _
+  | Tt.Type
+  | Tt.Inhab _
+  | Tt.Bracket _
+  | Tt.Prod _
+  | Tt.Eq _
+  | Tt.Refl _
+  | Tt.Signature _
+  | Tt.Projection _ -> Tt.mk_projection ~loc te xts p
+                                        
+  | Tt.Bound _ ->
+     Error.impossible ~loc "de Bruijn encountered in Simplify.project"
 
 let context ctx = ctx
 

--- a/src/nucleus/tt.mli
+++ b/src/nucleus/tt.mli
@@ -3,7 +3,7 @@
 (** An [('a, 'b) abstraction] is a ['b] bound by [(x1, 'a1), ..., (xn, 'an)]. *)
 type ('a, 'b) abstraction = (Name.ident * 'a) list * 'b
 
-type term = term' * Location.t
+type term = { term : term' ; loc : Location.t}
 and term' = private
 (** The type of TT terms.
     (For details on the mutual definition with [term'], see module Location.)


### PR DESCRIPTION
We anticipate that terms will become more complex, for instance
they will contain local assumptions. It makes sense to convert
them to records for future extensibility.