### PR TITLE
Add assumption printers and fix empty spine bug

### DIFF
--- a/src/nucleus/assumption.ml
+++ b/src/nucleus/assumption.ml
@@ -10,6 +10,24 @@ type t = { free : AtomSet.t; bound : BoundSet.t }
 
 let empty = {free = AtomSet.empty; bound = BoundSet.empty; }
 
+let is_empty {free;bound} =
+  AtomSet.is_empty free && BoundSet.is_empty bound
+
+let print_db xs k ppf =
+  try
+    if !Config.debruijn
+    then
+      Print.print ppf "%t[%d]" (Name.print_ident (List.nth xs k)) k
+    else
+      Print.print ppf "%t" (Name.print_ident (List.nth xs k))
+  with
+    | Not_found | Failure "nth" -> Print.print ppf "DEBRUIJN[%d]" k
+
+let print xs {free;bound} ppf =
+  Print.print ppf "%t ; %t"
+              (Print.sequence Name.print_atom ", " (AtomSet.elements free))
+              (Print.sequence (print_db xs) ", " (BoundSet.elements bound))
+
 let singleton x =
   let free = AtomSet.add x AtomSet.empty in
   {free;bound=BoundSet.empty;}

--- a/src/nucleus/assumption.mli
+++ b/src/nucleus/assumption.mli
@@ -4,6 +4,10 @@ type t
 
 val empty : t
 
+val is_empty : t -> bool
+
+val print : Name.ident list -> t -> Format.formatter -> unit
+
 val singleton : Name.atom -> t
 
 val add_atoms : Name.AtomSet.t -> t -> t

--- a/src/nucleus/tt.ml
+++ b/src/nucleus/tt.ml
@@ -52,7 +52,7 @@ let mk_prod ~loc xts ((Ty e) as t) =
 
 let mk_spine ~loc e xts t es =
   match xts with
-    | [] -> {term = e.term; assumptions=Assumption.empty; loc}
+    | [] -> {e with loc}
     | _::_ -> {term = Spine (e, (xts, t), es); assumptions=Assumption.empty; loc}
 
 let mk_type ~loc = {term = Type; assumptions=Assumption.empty; loc}
@@ -614,7 +614,16 @@ let print_annot ?(prefix="") k ppf =
 
 *)
 
-let rec print_term ?max_level xs {term=e;_} ppf =
+let rec print_term ?max_level xs {term=e;assumptions;_} ppf =
+  if !Config.print_dependencies && not (Assumption.is_empty assumptions)
+  then
+    Print.print ppf ?max_level ~at_level:3 "(%t)^{{%t}}"
+                (print_term' ~max_level:3 xs e)
+                (Assumption.print xs assumptions)
+  else
+    print_term' ?max_level xs e ppf
+
+and print_term' ?max_level xs e ppf =
   let print ?at_level = Print.print ?max_level ?at_level ppf in
     match e with
       | Type ->


### PR DESCRIPTION
`mk_spine  e [] t []` used to discard the assumptions of `e`.