### PR TITLE
User mode equality

### DIFF
--- a/prelude.m31
+++ b/prelude.m31
@@ -5,6 +5,9 @@ let print = external "print"
 handle
   | equal _ _ => None
   | abstract _ _ => None
+  | as_prod _ => None
+  | as_eq _ => None
+  | as_signature _ => None
   end
 
 let symmetry = λ (A : Type, x y : A, h : x ≡ y), handle refl x : y ≡ x with

--- a/prelude.m31
+++ b/prelude.m31
@@ -1,16 +1,9 @@
-(* The prelude is empty for now. *)
 
-let print = external "print"
+#include_once "std/base.m31"
+#include_once "std/equal.m31"
 
-handle
-  | equal _ _ => None
-  | abstract _ _ => None
-  | as_prod _ => None
-  | as_eq _ => None
-  | as_signature _ => None
-  end
+let betas = nil
+let hints = nil
+let action = reset
 
-let symmetry = λ (A : Type, x y : A, h : x ≡ y), handle refl x : y ≡ x with
-  | equal _ _ =>
-    yield (Some h)
-  end
+#include "std/equal_handle.m31"

--- a/src/parser/desugar.ml
+++ b/src/parser/desugar.ml
@@ -629,7 +629,7 @@ let toplevel (env : Value.Env.t) bound (d', loc) =
 
     | Input.Verbosity n -> Syntax.Verbosity n
 
-    | Input.Include fs -> Syntax.Include fs
+    | Input.Include (fs, b) -> Syntax.Include (fs, b)
 
     | Input.Environment -> Syntax.Environment
 

--- a/src/parser/input.mli
+++ b/src/parser/input.mli
@@ -95,7 +95,7 @@ and toplevel' =
   | TopLet of Name.ident * (Name.ident * ty) list * ty option * comp (** global let binding *)
   | TopCheck of comp (** infer the type of a computation *)
   | Verbosity of int
-  | Include of string list
+  | Include of string list * bool (** the boolean is [true] if the files should be included only once *)
   | Quit (** quit the toplevel *)
   | Help (** print help *)
   | Environment (** print the current environment *)

--- a/src/parser/lexer.ml
+++ b/src/parser/lexer.ml
@@ -92,6 +92,7 @@ and token_aux ({ stream;_ } as lexbuf) =
   | "#quit"                  -> f (); g (); QUIT
   | "#verbosity", Plus hspace -> g (); verbosity lexbuf
   | "#include"               -> f (); INCLUDE
+  | "#include_once"          -> f (); INCLUDEONCE
   | quoted_string            -> f (); let s = lexeme lexbuf in QUOTED_STRING (String.sub s 1 (String.length s - 2))
   | '('                      -> f (); LPAREN
   | ')'                      -> f (); RPAREN

--- a/src/parser/parser.mly
+++ b/src/parser/parser.mly
@@ -70,7 +70,7 @@
 %token ENVIRONMENT HELP QUIT
 %token <int> VERBOSITY
 %token <string> QUOTED_STRING
-%token INCLUDE
+%token INCLUDE INCLUDEONCE
 
 %token EOF
 
@@ -123,7 +123,8 @@ plain_topdirective:
   | HELP                                             { Help }
   | QUIT                                             { Quit }
   | VERBOSITY                                        { Verbosity $1 }
-  | INCLUDE fs=QUOTED_STRING+                        { Include fs }
+  | INCLUDE fs=QUOTED_STRING+                        { Include (fs, false) }
+  | INCLUDEONCE fs=QUOTED_STRING+                    { Include (fs, true) }
 
 (* Main syntax tree *)
 

--- a/src/syntax.ml
+++ b/src/syntax.ml
@@ -82,7 +82,7 @@ and toplevel' =
   | TopLet of Name.ident * comp (** global let binding *)
   | TopCheck of comp (** infer the type of a computation *)
   | Verbosity of int
-  | Include of string list
+  | Include of string list * bool (** the boolean is [true] if the files should be included only once *)
   | Quit (** quit the toplevel *)
   | Help (** print help *)
   | Environment (** print the current environment *)

--- a/src/syntax.mli
+++ b/src/syntax.mli
@@ -82,7 +82,7 @@ and toplevel' =
   | TopLet of Name.ident * comp (** global let binding *)
   | TopCheck of comp (** infer the type of a computation *)
   | Verbosity of int
-  | Include of string list
+  | Include of string list * bool (** the boolean is [true] if the files should be included only once *)
   | Quit (** quit the toplevel *)
   | Help (** print help *)
   | Environment (** print the current environment *)

--- a/std/base.m31
+++ b/std/base.m31
@@ -1,0 +1,11 @@
+
+let print = external "print"
+
+handle
+  | equal _ _ => None
+  | abstract _ _ => None
+  | as_prod _ => None
+  | as_eq _ => None
+  | as_signature _ => None
+  end
+

--- a/std/equal.m31
+++ b/std/equal.m31
@@ -1,0 +1,235 @@
+
+#include "utils.m31"
+
+operation fail 0
+operation beta 1
+operation hint 1
+operation whnf 1
+
+(*
+Matching works the following way:
+we have a list (|- xs : As) of typed atoms, such that each may appear in the following ones
+we have a typed term (|- target : t) in which any of the atoms may appear
+we have some value f
+we have a typed term (|- e : te) which is being matched
+
+we must find an instantiation of the xs such that t == te and target == e
+such an instantiation is a list of vs
+if we find it we return (Some (f vs))
+otherwise we return None
+
+Usually f is a term of type (forall xs : As, foo), but there's no reason it couldn't be a function or even something weird.
+
+For instance a beta hint b : forall y : B, e1 ==[T] e2 gives us
+- xs : As = [y : B]
+- target : t = e1 : T
+- f = b
+matching with e : T gives us a witness of e == e2[??/y]
+*)
+let generic_matcher = fun pat e =>
+  match pat with
+    | pair ?f (pair ?quants ?lhs) => fail
+  end
+
+
+let process_beta =
+  let rec deep quants e b = match b with
+    | |- forall (?x : _), ?b =>
+      deep (cons x quants) e b
+    | |- ?lhs == _ => pair e (pair quants lhs)
+    end
+  in
+  fun b => match b with
+    | |- ?e : ?b => deep nil e b
+    end
+
+let process_hint =
+  let rec deep quants e h = match h with
+    | |- forall (?x : _), ?h =>
+      deep (cons x quants) e h
+    | |- _ == _ => pair e (pair quants h)
+    end
+  in
+  fun h => match h with
+    | |- ?e : ?h => deep nil e h
+    end
+
+let transitivity = lambda (t : Type) (a b c : t) (eq1 : a == b) (eq2 : b == c),
+  handle eq2 : a == c with
+    | equal ((|- a == c : _) as ?x) ((|- b == c : _) as ?y) => handle yield (congruence x y) with
+      | equal a b => yield (Some eq1)
+    end
+  end
+
+(* pick the rhs because it's more reduced in practice *)
+let hide_witness = fun eq => match eq with
+  |- _ : ?a == ?b => match a with |- _ : ?t =>
+    handle refl b : a == b with equal b a => yield (Some (symmetry t a b eq)) end
+  end end
+
+(* implicit arguments and hide witness *)
+let symmetry = fun eq =>
+  match eq with
+    |- _ : ?a == ?b =>
+      match a with |- _ : ?t =>
+        hide_witness (symmetry t a b eq)
+      end
+  end
+
+let transitivity = fun eq1 eq2 =>
+  match pair eq1 eq2 with
+    | pair (|- _ : ?a == ?b) (|- _ : _ == ?c) =>
+      match a with |- _ : ?t =>
+        hide_witness (transitivity t a b c eq1 eq2)
+      end
+  end
+
+let unopt = fun v => match v with
+  | Some ?v => v
+  end
+
+(* attempt to apply one of betas to e (not to a subterm of e) *)
+let rec step_at betas e =
+  match betas with
+    | nil => None
+    | cons ?b ?rem =>
+      match generic_matcher b e with
+        | (Some _) as ?m => m
+        | None => step_at rem e
+      end
+  end
+
+
+let rec do_whnf betas e =
+  match e with
+    | |- ?e1 ?e2 : ?t =>
+      match do_whnf betas e1 with
+        | Some (|- ?eq : _ == ?e1') =>
+          (*
+            At this point, [e2] has type [a] for some [a], and both [e1] and [e1'] have the same type [forall x : a, foo] such that [foo[e2/x] == t].
+            However if that equality is difficult to derive the following ascription may do something undesired or fail.
+            Therefore in the future it may be better to explicitly do
+            match equal foo[e2/x] t with
+              | Some ?eqt => use eqt in (e1' e2) : t
+              | None => fail
+            end
+            
+            The other option would be to have unicity of typing primitives which,
+            given a judgement (ctx |- e : t) derives a type t' from the annotations of e and from ctx such that (ctx |- e : t'),
+            and then return ctx |- refl t : t == t' and ctx |- e : t'
+            
+            then t' would be foo[e2/x] for both (e1 e2) and (e1' e2), problem solved (because e1, e1' : forall x : A, foo)
+          *)
+          let e' = (e1' e2) : t in
+          let eq = (handle unopt (congruence e e') with equal e1 e1' => yield (Some eq) end) : e == e' in
+          match do_whnf betas e' with
+            | Some (|- ?eq' : _ == ?e'') =>
+              Some (transitivity eq eq')
+            | None => Some eq
+          end
+        | None =>
+          match reduce e with
+            | Some (|- ?eq : _ == ?e') =>
+              match do_whnf betas e' with
+                | Some (|- ?eq' : _ == ?e'') =>
+                  Some (transitivity eq eq')
+                | None => Some eq
+              end
+            | None =>
+              (* e1 is in whnf and e is not a beta redex, so we only need to see if a beta hint applies to e *)
+              match step_at betas e with
+                | Some (|- ?eq : _ == ?e') =>
+                  match do_whnf betas e' with
+                    | Some (|- ?eq' : _ == ?e'') =>
+                      Some (transitivity eq eq')
+                    | None => Some eq
+                  end
+                | None => None
+              end
+          end
+      end
+    | |- _ : ?t =>
+      match step_at betas e with
+        | Some (|- ?eq : _ == ?e') =>
+          match do_whnf betas e' with
+            | Some (|- ?eq' : _ == ?e'') =>
+              Some (transitivity eq eq')
+            | None => Some eq
+          end
+        | None => None
+          (* TODO are there any non application cases where we need to reduce a subterm? *)
+      end
+  end
+
+let whnf_eq = fun betas e => match do_whnf betas e with
+  | Some ?eq => eq
+  | None => refl e
+  end
+
+(* we return the betas and hints so that we may reuse them. eg
+let comp1 = with equality betas hints handle (foo ... add_beta b ... baz)
+let v = match comp1 with pair ?v _ => v end
+let betas = match comp1 with pair _ (pair ?betas _) => betas
+let hints = ...
+
+let comp2 = with equality betas hints handle ...
+...
+
+then in comp2 the hint b is available
+*)
+let rec equality betas hints = handler
+  | equal (|- ?a : ?t) ?b (* : ?t *) => fun betas hints =>
+    match (with equality betas hints handle congruence a b) with
+      | pair (Some ?eq) (pair ?betas ?hints) => yield (Some eq) betas hints
+      | pair None _ => (* loops *)
+        match (with equality betas hints handle pair (whnf_eq betas a) (whnf_eq betas b)) with
+          | pair (pair (|- ?eqa : _ == ?a') (|- ?eqb : _ == ?b')) (pair ?betas ?hints) =>
+            match (with equality betas hints handle equal a' b') with
+              | pair (Some ?eq) (pair ?betas ?hints) =>
+                let eq = transitivity eqa eq in
+                let eq = transitivity eq (symmetry eqb) in
+                yield (Some eq) betas hints
+              | pair None _ => yield None betas hints
+            end
+        end
+    end
+
+  | whnf ?e => fun betas hints =>
+    match (with equality betas hints handle whnf_eq betas e) with
+      | pair ?eq (pair ?betas ?hints) =>
+        yield eq betas hints
+    end
+
+  | beta ?b => fun betas hints =>
+    let b = process_beta b in
+    yield () (cons b betas) hints
+
+  | hint ?h => fun betas hints =>
+    let h = process_hint h in
+    yield () betas (cons h hints)
+
+  | val ?v => fun betas hints => pair v (pair betas hints)
+
+  | finally ?f => f betas hints
+  end
+
+
+constant A : Type
+constant a : A
+constant b : A
+constant f : A -> A -> A
+
+
+let test = with equality nil nil handle whnf ((lambda x y : A, f y x) a b)
+let _ = print (fst test)
+
+constant eq : forall x : A, f a x == b
+
+let cmp = with equality nil nil handle
+    let _ = beta eq in
+    ()
+    
+let betas = fst (snd cmp)
+
+check fst (with equality betas nil handle whnf (f a a))
+

--- a/std/equal.m31
+++ b/std/equal.m31
@@ -1,4 +1,5 @@
 
+#include_once "base.m31"
 #include "utils.m31"
 
 (* debug message *)
@@ -8,6 +9,11 @@ operation fail 0
 operation beta 1
 operation hint 1
 operation whnf 1
+
+(* actions tell equal_handle what to do *)
+data top_beta 1
+data top_hint 1
+data reset 0
 
 (*
 Matching works the following way:
@@ -100,6 +106,11 @@ let process_hint =
   fun h => match h with
     | |- ?e : ?h => deep nil e h
     end
+
+let symmetry = λ (A : Type, x y : A, h : x ≡ y), handle refl x : y ≡ x with
+  | equal _ _ =>
+    yield (Some h)
+  end
 
 let transitivity = lambda (t : Type) (a b c : t) (eq1 : a == b) (eq2 : b == c),
   handle eq2 : a == c with
@@ -260,23 +271,40 @@ let rec equality betas hints = handler
   | finally ?f => f betas hints
   end
 
+(* doesn't return the state *)
+let equality_in = fun betas hints => handler
+  | equal (|- ?a : ?t) ?b (* : ?t *) => fun betas hints =>
+    match (with equality betas hints handle congruence a b) with
+      | pair (Some ?eq) (pair ?betas ?hints) => yield (Some eq) betas hints
+      | pair None _ => (* loops *)
+        match (with equality betas hints handle pair (whnf_eq betas a) (whnf_eq betas b)) with
+          | pair (pair (|- ?eqa : _ == ?a') (|- ?eqb : _ == ?b')) (pair ?betas ?hints) =>
+            match (with equality betas hints handle equal a' b') with
+              | pair (Some ?eq) (pair ?betas ?hints) =>
+                let eq = transitivity eqa eq in
+                let eq = transitivity eq (symmetry eqb) in
+                yield (Some eq) betas hints
+              | pair None _ => yield None betas hints
+            end
+        end
+    end
 
-constant A : Type
-constant a : A
-constant b : A
-constant f : A -> A -> A
+  | whnf ?e => fun betas hints =>
+    match (with equality betas hints handle whnf_eq betas e) with
+      | pair ?eq (pair ?betas ?hints) =>
+        yield eq betas hints
+    end
 
+  | beta ?b => fun betas hints =>
+    let b = process_beta b in
+    yield () (cons b betas) hints
 
-let test = with equality nil nil handle whnf ((lambda x y : A, f y x) a b)
-let _ = print (fst test)
+  | hint ?h => fun betas hints =>
+    let h = process_hint h in
+    yield () betas (cons h hints)
 
-constant eq : forall x : A, f a x == b
+  | val ?v => fun betas hints => v
 
-let cmp = with equality nil nil handle
-    let _ = beta eq in
-    ()
-    
-let betas = fst (snd cmp)
-
-check fst (with equality betas nil handle whnf (f a a))
+  | finally ?f => f betas hints
+  end
 

--- a/std/equal.m31
+++ b/std/equal.m31
@@ -1,6 +1,9 @@
 
 #include "utils.m31"
 
+(* debug message *)
+data (!) 1 let (!) = fun x => print ! x
+
 operation fail 0
 operation beta 1
 operation hint 1
@@ -8,7 +11,7 @@ operation whnf 1
 
 (*
 Matching works the following way:
-we have a list (|- xs : As) of typed atoms, such that each may appear in the following ones
+we have a list (|- xs : As = maybe vs) of typed atoms with potential values, such that each atom may appear in the following types
 we have a typed term (|- target : t) in which any of the atoms may appear
 we have some value f
 we have a typed term (|- e : te) which is being matched
@@ -26,16 +29,60 @@ For instance a beta hint b : forall y : B, e1 ==[T] e2 gives us
 - f = b
 matching with e : T gives us a witness of e == e2[??/y]
 *)
+
+(* assoc_update which fails to match if the value to update isn't already present *)
+let assoc_update = fun x v lst =>
+  let rec aux acc lst = match lst with
+    | cons (pair x _) ?lst => rev_append acc (cons (pair x v) lst)
+    | cons ?y ?lst => aux (cons y acc) lst
+    end
+  in aux nil lst
+
+(* updates quants with values such that lhs matches rhs *)
+let rec collector quants lhs rhs =
+  (* is lhs an atom?
+     NB it would be nice to have a matching primitive to know if some term is an atom. *)
+  match assoc_find lhs quants with
+    | Some None => (* not yet set atom *)
+      Some (assoc_update lhs (Some rhs) quants)
+    | Some (Some ?lhs) => (* already set atom *)
+      collector quants lhs rhs
+    | None => (* not an atom *)
+      match pair lhs rhs with
+        | pair ?a ?a => (* alpha equal *)
+          Some quants
+        | pair (|- ?l1 ?l2) (|- ?r1 ?r2) =>
+          match collector quants l1 r1 with
+            (* there could be something smarter to do in either failure case *)
+            | Some ?quants => collector quants l2 r2
+            | None => None
+          end
+        | _ => None
+      end
+  end
+
+let rec apply_quants f quants = match quants with
+  | nil => Some f
+  | cons (pair _ None) _ => None
+  | cons (pair _ (Some ?v)) ?quants =>
+    apply_quants (f v) quants
+  end
+
 let generic_matcher = fun pat e =>
   match pat with
-    | pair ?f (pair ?quants ?lhs) => fail
+    | pair ?f (pair ?quants ?lhs) =>
+      match collector quants lhs e with
+        | Some ?quants =>
+          apply_quants f quants
+        | None => None
+      end
   end
 
 
 let process_beta =
   let rec deep quants e b = match b with
     | |- forall (?x : _), ?b =>
-      deep (cons x quants) e b
+      deep (cons (pair x None) quants) e b
     | |- ?lhs == _ => pair e (pair quants lhs)
     end
   in
@@ -46,7 +93,7 @@ let process_beta =
 let process_hint =
   let rec deep quants e h = match h with
     | |- forall (?x : _), ?h =>
-      deep (cons x quants) e h
+      deep (cons (pair x None) quants) e h
     | |- _ == _ => pair e (pair quants h)
     end
   in

--- a/std/equal_handle.m31
+++ b/std/equal_handle.m31
@@ -1,0 +1,47 @@
+(* equal.m31 should already be included, since we need to set [action] *)
+
+let betas = match action with
+  | reset => betas
+  | top_beta ?b =>
+    match (with equality betas hints handle beta b) with
+      pair _ (pair ?betas _) => betas
+    end
+  | top_hint _ => betas
+end
+
+let hints = match action with
+  | reset => hints
+  | top_beta _ => hints
+  | top_hint ?h =>
+    match (with equality betas hints handle hint h) with
+      pair _ (pair _ ?hints) => hints
+    end
+end
+
+handle
+  | equal a b =>
+    with equality_in betas hints handle equal a b
+
+  | whnf e =>
+    with equality_in betas hints handle whnf e
+
+  | as_prod e =>
+    match (with equality_in betas hints handle whnf e) with
+      | |- ?eq : _ == (forall (_ : _), _) => Some eq
+      | _ => None
+    end
+
+  | as_eq e =>
+    match (with equality_in betas hints handle whnf e) with
+      | |- ?eq : _ == (_ == _) => Some eq
+      | _ => None
+    end
+
+  | as_signature e => (* TODO no good way to match generic signature *)
+    with equality_in betas hints handle whnf e
+
+  (* top level handler has no state. If you want to have local hints do [fst (with equality betas hints handle ...)] *)
+  | beta b => let _ = ! b in fail
+  | hint h => let _ = ! h in fail
+end
+

--- a/std/utils.m31
+++ b/std/utils.m31
@@ -12,6 +12,13 @@ let rec fold f acc lst = match lst with
   | cons ?x ?tl => fold (f acc x) tl
   end
 
+let rec assoc_find x lst = match lst with
+  | nil => None
+  | cons (pair x ?v) _ => Some v
+  | cons _ ?lst => assoc_find x lst
+  end
+
+let rev_append = fun l1 l2 => fold (fun acc x => cons x acc) l2 l1
 
 (** pair stuff *)
 let fst = fun v => match v with

--- a/std/utils.m31
+++ b/std/utils.m31
@@ -1,0 +1,25 @@
+
+(** list stuff *)
+let rev =
+  let rec rev acc = fun lst => match lst with
+    | nil => acc
+    | cons ?x ?tl => rev (cons x acc) tl
+    end
+  in rev nil
+
+let rec fold f acc lst = match lst with
+  | nil => acc
+  | cons ?x ?tl => fold (f acc x) tl
+  end
+
+
+(** pair stuff *)
+let fst = fun v => match v with
+  | pair ?v _ => v
+  end
+
+let snd = fun v => match v with
+  | pair _ ?v => v
+  end
+
+

--- a/tests/user-equal.m31
+++ b/tests/user-equal.m31
@@ -1,14 +1,19 @@
-Axiom A : Type.
-Axiom B : Type.
 
-Check handle (assume a : A in a) :: B with
-  | #equal ('pair (|- B : Type) (|- A : Type)) =>
-    let eq := assume eq : B == A in eq in
-    yield ('some eq)
-  end.
 
-Check handle (assume a : A in a) :: B with
-  | #equal ?v =>
-    yield 'none
-  end.
+constant A : Type
+constant a : A
+constant b : A
+constant f : A -> A -> A
+
+
+let test = with equality_in nil nil handle whnf ((lambda x y : A, f y x) a b)
+let _ = print test
+
+constant eq : forall x : A, f a x == b
+
+let action = top_beta eq
+
+#include "../std/equal_handle.m31"
+
+check whnf (f a a)
 

--- a/tests/user-equal.m31.ref
+++ b/tests/user-equal.m31.ref
@@ -1,7 +1,12 @@
-A is assumed.
-B is assumed.
-a₄ : A 
-eq₅ : B ≡ A 
-⊢ a₄ : B
-File "./user-equal.m31", line 10, characters 14-32: Typing error
-  this expression should have type B but has type A
+Constant A is declared.
+Constant a is declared.
+Constant b is declared.
+Constant f is declared.
+test is defined.
+⊢ refl (f b a) : (λ (x : A) (y : A), f y x) a b ≡ f b a
+_ is defined.
+Constant eq is declared.
+action is defined.
+#including ../std/equal_handle.m31
+#processed ../std/equal_handle.m31
+⊢ eq a : f a a ≡ b


### PR DESCRIPTION
Still incomplete, but basic use is now possible as seen in `tests/user-equal.m31`.

std/base.m31 contains a binding of external print, and a trivial top level handler to get better errors when there is no complex one.

std/utils.m31 contains some trivial list and pair operations

std/equal.m31 contains the equality and hint handler. It uses a high level matcher (as opposed to the primitive low level one) to instantiate hints. Currently that matcher isn't very intelligent, but I expect that will change at some point.

std/equal_handle.m31 is a hack to have a top level handler with top level hints. It can't do dynamic hints though.
In order for it to work I added a way to include a file multiple times. We now have `#include` and `#include_once` with the later having the semantics of the old `#include`. Files on the command line can be included multiple times, eg if we do `andromeda file.m31 file.m31`, which is an arbitrary choice.

tests/user-equal.m31 has become an example of use of this equality checking system.

Missing:
-use general hints
-high level matching anything other than a match variable to something and an application to an application

I plan to update tests and fix the previous as they come up.

The following need kernel support:
-low level matching of arbitrary signatures (and structures) to ensure that we return something sane in as_signature
-top level state to avoid having to use the include hack like we currently do, and to allow dynamic hints with the top level handler
