### PR TITLE
Rame spines to applications

### DIFF
--- a/src/nucleus/matching.ml
+++ b/src/nucleus/matching.ml
@@ -129,7 +129,7 @@ let rec collect_tt_pattern env xvs (p',_) ctx ({Tt.term=e';loc;_} as e) t =
      in
      collect_tt_pattern env xvs p ctx te out
 
-  | Syntax.Tt_App (p1,p2), Tt.Spine (e1,((x,a),b),e2) ->
+  | Syntax.Tt_Apply (p1,p2), Tt.Apply (e1,((x,a),b),e2) ->
     let prod = Tt.mk_prod_ty ~loc x a b in
     let xvs = collect_tt_pattern env xvs p1 ctx e1 prod in
     let xvs = collect_tt_pattern env xvs p2 ctx e2 a in
@@ -246,7 +246,7 @@ let rec collect_tt_pattern env xvs (p',_) ctx ({Tt.term=e';loc;_} as e) t =
        xvs
      else raise Match_fail
 
-  | (Syntax.Tt_Type | Syntax.Tt_Constant _ | Syntax.Tt_App _
+  | (Syntax.Tt_Type | Syntax.Tt_Constant _ | Syntax.Tt_Apply _
      | Syntax.Tt_Lambda _ | Syntax.Tt_Prod _
      | Syntax.Tt_Eq _ | Syntax.Tt_Refl _
      | Syntax.Tt_Signature _ | Syntax.Tt_Structure _

--- a/src/nucleus/tt.mli
+++ b/src/nucleus/tt.mli
@@ -46,7 +46,7 @@ and term' = private
       [e] is applied to [e1, ..., en], and that the type of [e] is
       [forall (x1 : t1) ... (xn : tn), t]. Here [tk] depends on
       [x1, ..., x{k-1}] and [t] depends on [x1, ..., xn]. *)
-  | Spine of term * ty ty_abstraction * term
+  | Apply of term * ty ty_abstraction * term
 
   (** a dependent product [forall (x1 : t1) ... (xn : tn), t], where [tk]
       depends on [x1, ..., x{k-1}] and [t] depends on [x1, ..., xn]. *)
@@ -89,7 +89,7 @@ type constsig = (Name.ident * ty) list * ty
 val mk_atom: loc:Location.t -> Name.atom -> term
 val mk_constant: loc:Location.t -> Name.ident -> term list -> term
 val mk_lambda: loc:Location.t -> Name.ident -> ty -> term -> ty -> term
-val mk_spine: loc:Location.t -> term -> Name.ident -> ty -> ty -> term -> term
+val mk_apply: loc:Location.t -> term -> Name.ident -> ty -> ty -> term -> term
 val mk_type: loc:Location.t -> term
 val mk_type_ty: loc:Location.t -> ty
 val mk_prod: loc:Location.t -> Name.ident -> ty -> ty -> term

--- a/src/nucleus/tt.mli
+++ b/src/nucleus/tt.mli
@@ -3,28 +3,15 @@
 (** An [('a, 'b) abstraction] is a ['b] bound by (x, 'a) *)
 type ('a, 'b) abstraction = (Name.ident * 'a) * 'b
 
-type term = { term : term' ; assumptions : Assumption.t; loc : Location.t}
-and term' = private
 (** The type of TT terms.
     (For details on the mutual definition with [term'], see module Location.)
 
     We use locally nameless syntax: names for free variables and deBruijn
     indices for bound variables. In terms of type [term], bound variables are
     not allowed to appear "bare", i.e., without an associated binder.
-
-    Instead of nesting binary applications [((e1 e2) ... en)], we use
-    spines [e1 [e2; ...; en]]. The reason for this is one of efficiency:
-    because we need to tag every application with the argument and result type,
-    nested applications use quadratic space (in the number of the applications)
-    whereas spines use linear space. Consequently, lambda abstractions and
-    products also accept lists of arguments.
-
-    To represent nested bindings, we use an auxiliary type
-    [(A, B) abstraction], which consists of a list [(x1 : a1), ..., (xn : an)],
-    where each [ak] has type [A] and can depend on variables [x1, ..., x{k-1}],
-    and of a single [b] of type [B] that can depend on all [x1, ..., xn]. *)
-
-
+*)
+type term = { term : term' ; assumptions : Assumption.t; loc : Location.t}
+and term' = private
   (** term denoting the type of types *)
   | Type
 
@@ -37,19 +24,13 @@ and term' = private
   (** a constant applied to arguments *)
   | Constant of Name.ident * term list
 
-  (** a lambda abstraction [fun (x1 : t1) ... (xn : tn) -> e : t] where
-      [tk] depends on [x1, ..., x{k-1}], while [e] and [t] depend on
-      [x1, ..., xn] *)
+  (** a lambda abstraction [fun (x1 : t1) -> e : t] *)
   | Lambda of (term * ty) ty_abstraction
 
-  (** a spine [e ((x1 : t1) ..., (xn : tn) : t) e1 ... en] means that
-      [e] is applied to [e1, ..., en], and that the type of [e] is
-      [forall (x1 : t1) ... (xn : tn), t]. Here [tk] depends on
-      [x1, ..., x{k-1}] and [t] depends on [x1, ..., xn]. *)
+  (** an application tagged with the type at wich it happens *)
   | Apply of term * ty ty_abstraction * term
 
-  (** a dependent product [forall (x1 : t1) ... (xn : tn), t], where [tk]
-      depends on [x1, ..., x{k-1}] and [t] depends on [x1, ..., xn]. *)
+  (** a dependent product [forall (x1 : t1), t] *)
   | Prod of ty ty_abstraction
 
   (** strict equality type [e1 == e2] where [e1] and [e2] have type [t]. *)

--- a/src/parser/desugar.ml
+++ b/src/parser/desugar.ml
@@ -80,10 +80,10 @@ let rec tt_pattern (env : Value.env) bound vars n (p,loc) =
       let p, vars, n = tt_pattern env (add_bound x bound) vars n p in
       (Syntax.Tt_Lambda (x,bopt,popt,p), loc), vars, n
 
-    | Input.Tt_App (p1,p2) ->
+    | Input.Tt_Apply (p1,p2) ->
       let p1, vars, n = tt_pattern env bound vars n p1 in
       let p2, vars, n = tt_pattern env bound vars n p2 in
-      (Syntax.Tt_App (p1,p2), loc), vars, n
+      (Syntax.Tt_Apply (p1,p2), loc), vars, n
 
     | Input.Tt_Prod (b,x,popt,p) ->
       let popt, vars, n = match popt with
@@ -531,7 +531,7 @@ and spine ~yield env bound ((c',loc) as c) cs =
 
   List.fold_left (fun h c ->
     let c = comp ~yield env bound c in
-    Syntax.App (h,c), loc) c cs
+    Syntax.Apply (h,c), loc) c cs
 
 (* Desugar handler cases. *)
 and handler ~loc env bound hcs =

--- a/src/parser/input.mli
+++ b/src/parser/input.mli
@@ -15,7 +15,7 @@ and tt_pattern' =
   | Tt_Name of Name.ident
   (** For each binder the boolean indicates whether the bound variable should be a pattern variable *)
   | Tt_Lambda of bool * Name.ident * tt_pattern option * tt_pattern
-  | Tt_App of tt_pattern * tt_pattern
+  | Tt_Apply of tt_pattern * tt_pattern
   | Tt_Prod of bool * Name.ident * tt_pattern option * tt_pattern
   | Tt_Eq of tt_pattern * tt_pattern
   | Tt_Refl of tt_pattern

--- a/src/parser/parser.mly
+++ b/src/parser/parser.mly
@@ -3,7 +3,7 @@
 
   let tt_spine h lst =
     let loc = snd h in
-    List.fold_left (fun h e -> Tt_App (h, e), loc) h lst
+    List.fold_left (fun h e -> Tt_Apply (h, e), loc) h lst
 
 %}
 
@@ -398,14 +398,14 @@ app_tt_pattern: mark_location(plain_app_tt_pattern) { $1 }
 plain_app_tt_pattern:
   | p=plain_prefix_tt_pattern                 { p }
   | p=app_tt_pattern AS x=patt_var            { Tt_As (p,x) }
-  | p1=app_tt_pattern p2=prefix_tt_pattern    { Tt_App (p1, p2) }
+  | p1=app_tt_pattern p2=prefix_tt_pattern    { Tt_Apply (p1, p2) }
 
 prefix_tt_pattern: mark_location(plain_prefix_tt_pattern) { $1 }
 plain_prefix_tt_pattern:
   | p=plain_simple_tt_pattern                 { p }
   | REFL p=prefix_tt_pattern                  { Tt_Refl p }
   | op=PREFIXOP e=prefix_tt_pattern
-    { let op = Tt_Name (Name.make ~fixity:Name.Infix4 (fst op)), snd op in Tt_App (op, e) }
+    { let op = Tt_Name (Name.make ~fixity:Name.Infix4 (fst op)), snd op in Tt_Apply (op, e) }
 
 simple_tt_pattern: mark_location(plain_simple_tt_pattern) { $1 }
 plain_simple_tt_pattern:

--- a/src/syntax.mli
+++ b/src/syntax.mli
@@ -13,7 +13,7 @@ and tt_pattern' =
   | Tt_Type
   | Tt_Constant of Name.ident
   | Tt_Lambda of Name.ident * bound option * tt_pattern option * tt_pattern
-  | Tt_App of tt_pattern * tt_pattern
+  | Tt_Apply of tt_pattern * tt_pattern
   | Tt_Prod of Name.ident * bound option * tt_pattern option * tt_pattern
   | Tt_Eq of tt_pattern * tt_pattern
   | Tt_Refl of tt_pattern
@@ -58,7 +58,7 @@ and comp' =
   | Typeof of comp
   | Constant of Name.ident * comp list
   | Lambda of Name.ident * comp option * comp
-  | App of comp * comp
+  | Apply of comp * comp
   | Prod of Name.ident * comp * comp
   | Eq of comp * comp
   | Refl of comp


### PR DESCRIPTION
Consistently call applications `Apply` everywhere, except in
`Input` because it still parses whole spines.