### PR TITLE
Operations know if they were emitted in checking mode

### DIFF
--- a/src/nucleus/eval.ml
+++ b/src/nucleus/eval.ml
@@ -101,9 +101,9 @@ let rec infer (c',loc) =
             Some f
           end
         and handler_ops = Name.IdentMap.mapi (fun op cases ->
-            let f (vs,cont) =
+            let f {Value.args=vs;checking;cont} =
               Value.set_continuation cont
-              (multimatch_cases ~loc op cases vs)
+              (match_op_cases ~loc op cases vs checking)
             in
             f)
           handler_ops
@@ -386,7 +386,7 @@ and check ((c',loc) as c) (Jdg.Ty (ctx_check, t_check') as t_check) : (Context.t
   | Syntax.Operation (op, cs) ->
      let rec fold vs = function
        | [] ->
-          Value.perform op vs >>= as_term ~loc >>= fun (Jdg.Term (ctxe, e', t')) ->
+          Value.perform_at op vs t_check >>= as_term ~loc >>= fun (Jdg.Term (ctxe, e', t')) ->
           require_equal_ty ~loc t_check (Jdg.mk_ty ctxe t') >>=
             begin function
               | Some (ctx, hyps) -> Value.return (ctx, Tt.mention_atoms hyps e')
@@ -561,7 +561,7 @@ and match_cases ~loc cases v =
             | [], [] -> infer c
             | x::xs, v::vs ->
               Value.add_bound x v (fold2 xs vs)
-            | _::_, [] | [], _::_ -> Error.impossible ~loc "bad multimatch case"
+            | _::_, [] | [], _::_ -> Error.impossible ~loc "bad match case"
           in
           fold2 (List.rev xs) vs
         | None -> fold cases
@@ -569,12 +569,12 @@ and match_cases ~loc cases v =
   in
   fold cases
 
-and multimatch_cases ~loc op cases vs =
+and match_op_cases ~loc op cases vs checking =
   let rec fold = function
     | [] ->
       Value.perform op vs
-    | (xs, ps, c) :: cases ->
-      Matching.multimatch_pattern ps vs >>= begin function
+    | (xs, ps, pt, c) :: cases ->
+      Matching.match_op_pattern ps pt vs checking >>= begin function
         | Some vs ->
           let rec fold2 xs vs = match xs, vs with
             | [], [] -> infer c
@@ -598,10 +598,20 @@ let comp_value ((_, loc) as c) =
   let r = infer c in
   Value.top_handle ~loc r
 
-let comp_handle (xs,c) =
-  Value.mk_closure' (fun vs ->
+let comp_handle (xs,y,c) =
+  Value.mk_closure' (fun (vs,checking) ->
       let rec fold2 xs vs = match xs,vs with
-        | [], [] -> infer c
+        | [], [] ->
+          begin match y with
+            | Some y ->
+              let checking = match checking with
+                | Some jt -> Some (Value.mk_term (Jdg.term_of_ty jt))
+                | None -> None
+              in
+              let vy = Value.from_option checking in
+              Value.add_bound y vy (infer c)
+            | None -> infer c
+          end
         | x::xs, v::vs -> Value.add_bound x v (fold2 xs vs)
         | [],_::_ | _::_,[] -> Error.impossible ~loc:(snd c) "bad top handler case"
       in

--- a/src/nucleus/matching.ml
+++ b/src/nucleus/matching.ml
@@ -217,10 +217,16 @@ let match_pattern p v =
   end in
   return r
 
-let multimatch_pattern ps vs =
+let match_op_pattern ps pt vs checking =
   Value.get_env >>= fun env ->
   let r = begin try
     let xvs = multicollect_pattern env [] ps vs in
+    let xvs = match pt, checking with
+      | None, (None | Some _) -> xvs
+      | Some p, Some (Jdg.Ty (ctx,Tt.Ty t)) ->
+        collect_tt_pattern env xvs p ctx t Tt.typ
+      | Some _, None -> raise Match_fail
+    in
     (* return in decreasing de bruijn order: ready to fold with add_bound *)
     let xvs = List.sort (fun (k,_) (k',_) -> compare k k') xvs in
     let xvs = List.rev_map snd xvs in

--- a/src/nucleus/matching.mli
+++ b/src/nucleus/matching.mli
@@ -2,5 +2,7 @@
 (** Match a value against a pattern. Matches are returned in order of decreasing de bruijn index. *)
 val match_pattern : Syntax.pattern -> Value.value -> Value.value list option Value.result
 
-val multimatch_pattern : Syntax.pattern list -> Value.value list -> Value.value list option Value.result
+val match_op_pattern : Syntax.pattern list -> Syntax.tt_pattern option ->
+                       Value.value list ->    Jdg.ty option ->
+                       Value.value list option Value.result
 

--- a/src/nucleus/value.ml
+++ b/src/nucleus/value.ml
@@ -22,7 +22,7 @@ type dynamic = {
 type lexical = {
   bound : (Name.ident * value) list;
   continuation : (value,value) closure option;
-  handle : (Name.ident * (value list,value) closure) list;
+  handle : (Name.ident * (value list * Jdg.ty option,value) closure) list;
   files : string list;
 }
 
@@ -43,13 +43,15 @@ and ('a,'b) closure = Clos of ('a -> 'b result)
 
 and 'a performance =
   | Return of 'a
-  | Perform of Name.ident * value list * dynamic * (value,'a) closure
+  | Perform of Name.ident * value list * Jdg.ty option * dynamic * (value,'a) closure
 
 and 'a result = env -> 'a performance * state
 
+and operation_args = { args : value list; checking : Jdg.ty option; cont : (value,value) closure }
+
 and handler = {
   handler_val: (value,value) closure option;
-  handler_ops: (value list * (value,value) closure, value) closure Name.IdentMap.t;
+  handler_ops: (operation_args, value) closure Name.IdentMap.t;
   handler_finally: (value,value) closure option;
 }
 
@@ -118,10 +120,10 @@ let update_ref x v env =
 let rec bind (r:'a result) (f:'a -> 'b result) : 'b result = fun env ->
   match r env with
   | Return v, state -> f v {env with state}
-  | Perform (op, vs, d, k), state -> 
+  | Perform (op, vs, jt, d, k), state -> 
      let env = {env with state} in
      let k = mk_closure0 (fun x -> bind (apply_closure k x) f) env in
-     Perform (op, vs, d, k), env.state
+     Perform (op, vs, jt, d, k), env.state
 
 let (>>=) = bind
 
@@ -223,7 +225,10 @@ let return_unit = return (Tag (name_unit, []))
 
 (** Operations *)
 let perform op vs env =
-  Perform (op, vs, env.dynamic, mk_closure0 return env), env.state
+  Perform (op, vs, None, env.dynamic, mk_closure0 return env), env.state
+
+let perform_at op vs jt env =
+  Perform (op, vs, Some jt, env.dynamic, mk_closure0 return env), env.state
 
 let perform_equal v1 v2 =
   perform name_equal [v1;v2]
@@ -526,17 +531,17 @@ let rec handle_result {handler_val; handler_ops; handler_finally} (r : value res
      | Some f -> apply_closure f v env
      | None -> Return v, env.state
      end
-  | Perform (op, vs, dynamic, cont), state ->
+  | Perform (op, vs, jt, dynamic, cont), state ->
      let env = {env with dynamic; state} in
      let h = {handler_val; handler_ops; handler_finally=None} in
      let cont = mk_closure0 (fun v env -> handle_result h (apply_closure cont v) env) env in
      begin
        try
          let f = Name.IdentMap.find op handler_ops in
-         apply_closure f (vs, cont) env
+         apply_closure f {args=vs;checking=jt; cont} env
        with
          Not_found ->
-           Perform (op, vs, dynamic, cont), env.state
+           Perform (op, vs, jt, dynamic, cont), env.state
      end
   end >>= fun v ->
   match handler_finally with
@@ -546,12 +551,12 @@ let rec handle_result {handler_val; handler_ops; handler_finally} (r : value res
 let rec top_handle ~loc r env =
   match r env with
     | Return v, state -> v,{env with state}
-    | Perform (op, vs, dynamic, k), state ->
+    | Perform (op, vs, checking, dynamic, k), state ->
        let env = {env with dynamic;state} in
        begin match lookup_handle op env with
         | None -> Error.runtime ~loc "unhandled operation %t" (Name.print_op op)
         | Some f ->
-          let r = apply_closure f vs >>=
+          let r = apply_closure f (vs,checking) >>=
             apply_closure k
           in
           top_handle ~loc r env

--- a/src/nucleus/value.mli
+++ b/src/nucleus/value.mli
@@ -24,9 +24,11 @@ type value = private
   | Ref of Store.key
   | String of string (** NB: strings are opaque to the user, ie not lists *)
 
+and operation_args = { args : value list; checking : Jdg.ty option; cont : (value,value) closure }
+
 and handler = {
   handler_val: (value,value) closure option;
-  handler_ops: (value list * (value,value) closure, value) closure Name.IdentMap.t;
+  handler_ops: (operation_args, value) closure Name.IdentMap.t;
   handler_finally: (value,value) closure option;
 }
 
@@ -74,7 +76,7 @@ val return_unit : value result
 
 val return_handler :
    (value -> value result) option ->
-   (value list * (value,value) closure -> value result) Name.IdentMap.t ->
+   (operation_args -> value result) Name.IdentMap.t ->
    (value -> value result) option ->
    value result
 
@@ -106,6 +108,8 @@ val list_cons : value -> value list -> value
 
 (** Operations *)
 val perform : Name.ident -> value list -> value result
+
+val perform_at : Name.ident -> value list -> Jdg.ty -> value result
 
 val perform_equal : value -> value -> value result
 
@@ -194,7 +198,7 @@ val add_signature : loc:Location.t -> Name.signature -> Tt.signature -> unit top
 val add_topbound : loc:Location.t -> Name.ident -> value -> unit toplevel
 
 (** Add a top-level handler case to the environment. *)
-val add_handle : Name.ident -> (value list,value) closure -> unit toplevel
+val add_handle : Name.ident -> (value list * Jdg.ty option,value) closure -> unit toplevel
 
 (** Set the continuation for a handler computation. *)
 val set_continuation : (value,value) closure -> 'a result -> 'a result

--- a/src/parser/input.mli
+++ b/src/parser/input.mli
@@ -86,12 +86,14 @@ and expr = term
 (** Handle cases *)
 and handle_case =
   | CaseVal of match_case (* val p -> c *)
-  | CaseOp of Name.ident * multimatch_case (* op p1 ... pn -> c *)
+  | CaseOp of Name.ident * match_op_case (* op p1 ... pn -> c *)
   | CaseFinally of match_case (* finally p -> c *)
 
 and match_case = pattern * comp
 
-and multimatch_case = pattern list * comp
+and match_op_case = pattern list * tt_pattern option * comp
+
+type top_op_case = Name.ident list * Name.ident option * comp
 
 (** Sugared toplevel commands *)
 type toplevel = toplevel' * Location.t
@@ -100,7 +102,7 @@ and toplevel' =
   | DeclData of Name.ident * int
   | DeclConstant of Name.ident * ty
   | DeclSignature of Name.signature * (Name.label * Name.ident option * ty) list
-  | TopHandle of (Name.ident * Name.ident list * comp) list
+  | TopHandle of (Name.ident * top_op_case) list
   | TopLet of Name.ident * (Name.ident * ty) list * ty option * comp (** global let binding *)
   | TopDo of comp (** evaluate a computation at top level *)
   | TopFail of comp
@@ -110,3 +112,4 @@ and toplevel' =
   | Quit (** quit the toplevel *)
   | Help (** print help *)
   | Environment (** print the current environment *)
+

--- a/src/parser/parser.mly
+++ b/src/parser/parser.mly
@@ -271,20 +271,24 @@ handler_cases:
 
 handler_case:
   | VAL p=pattern DARROW t=term                                 { CaseVal (p, t) }
-  | op=var_name ps=prefix_pattern* DARROW t=term                { CaseOp (op, (ps, t)) }
-  | op=PREFIXOP p=prefix_pattern DARROW t=term
-    { let op = Name.make ~fixity:Name.Prefix (fst op) in CaseOp (op, ([p], t)) }
-  | p1=binop_pattern op=INFIXOP0 p2=binop_pattern DARROW t=term
-    { let op = Name.make ~fixity:Name.Infix0 (fst op) in CaseOp (op, ([p1; p2], t)) }
-  | p1=binop_pattern op=INFIXOP1 p2=binop_pattern DARROW t=term
-    { let op = Name.make ~fixity:Name.Infix1 (fst op) in CaseOp (op, ([p1; p2], t)) }
-  | p1=binop_pattern op=INFIXOP2 p2=binop_pattern DARROW t=term
-    { let op = Name.make ~fixity:Name.Infix2 (fst op) in CaseOp (op, ([p1; p2], t)) }
-  | p1=binop_pattern op=INFIXOP3 p2=binop_pattern DARROW t=term
-    { let op = Name.make ~fixity:Name.Infix3 (fst op) in CaseOp (op, ([p1; p2], t)) }
-  | p1=binop_pattern op=INFIXOP4 p2=binop_pattern DARROW t=term
-    { let op = Name.make ~fixity:Name.Infix4 (fst op) in CaseOp (op, ([p1; p2], t)) }
+  | op=var_name ps=prefix_pattern* pt=handler_checking DARROW t=term                { CaseOp (op, (ps, pt, t)) }
+  | op=PREFIXOP p=prefix_pattern pt=handler_checking DARROW t=term
+    { let op = Name.make ~fixity:Name.Prefix (fst op) in CaseOp (op, ([p], pt, t)) }
+  | p1=binop_pattern op=INFIXOP0 p2=binop_pattern pt=handler_checking DARROW t=term
+    { let op = Name.make ~fixity:Name.Infix0 (fst op) in CaseOp (op, ([p1; p2], pt, t)) }
+  | p1=binop_pattern op=INFIXOP1 p2=binop_pattern pt=handler_checking DARROW t=term
+    { let op = Name.make ~fixity:Name.Infix1 (fst op) in CaseOp (op, ([p1; p2], pt, t)) }
+  | p1=binop_pattern op=INFIXOP2 p2=binop_pattern pt=handler_checking DARROW t=term
+    { let op = Name.make ~fixity:Name.Infix2 (fst op) in CaseOp (op, ([p1; p2], pt, t)) }
+  | p1=binop_pattern op=INFIXOP3 p2=binop_pattern pt=handler_checking DARROW t=term
+    { let op = Name.make ~fixity:Name.Infix3 (fst op) in CaseOp (op, ([p1; p2], pt, t)) }
+  | p1=binop_pattern op=INFIXOP4 p2=binop_pattern pt=handler_checking DARROW t=term
+    { let op = Name.make ~fixity:Name.Infix4 (fst op) in CaseOp (op, ([p1; p2], pt, t)) }
   | FINALLY p=pattern DARROW t=term                             { CaseFinally (p, t) }
+
+handler_checking:
+  |                    { None }
+  | COLON pt=tt_pattern { Some pt }
 
 top_handler_cases:
   | BAR lst=separated_nonempty_list(BAR, top_handler_case)  { lst }
@@ -292,19 +296,23 @@ top_handler_cases:
 
 (* XXX allow patterns here *)
 top_handler_case:
-  | op=var_name xs=name* DARROW t=term                    { (op, xs, t) }
-  | op=PREFIXOP x=name DARROW t=term
-    { let op = Name.make ~fixity:Name.Prefix (fst op) in (op, [x], t) }
-  | x1=name op=INFIXOP0 x2=name DARROW t=term
-    { let op = Name.make ~fixity:Name.Infix0 (fst op) in (op, [x1;x2], t) }
-  | x1=name op=INFIXOP1 x2=name DARROW t=term
-    { let op = Name.make ~fixity:Name.Infix1 (fst op) in (op, [x1;x2], t) }
-  | x1=name op=INFIXOP2 x2=name DARROW t=term
-    { let op = Name.make ~fixity:Name.Infix2 (fst op) in (op, [x1;x2], t) }
-  | x1=name op=INFIXOP3 x2=name DARROW t=term
-    { let op = Name.make ~fixity:Name.Infix3 (fst op) in (op, [x1;x2], t) }
-  | x1=name op=INFIXOP4 x2=name DARROW t=term
-    { let op = Name.make ~fixity:Name.Infix4 (fst op) in (op, [x1;x2], t) }
+  | op=var_name xs=name* y=top_handler_checking DARROW t=term           { (op, (xs, y, t)) }
+  | op=PREFIXOP x=name y=top_handler_checking DARROW t=term
+    { let op = Name.make ~fixity:Name.Prefix (fst op) in (op, ([x], y, t)) }
+  | x1=name op=INFIXOP0 x2=name y=top_handler_checking DARROW t=term
+    { let op = Name.make ~fixity:Name.Infix0 (fst op) in (op, ([x1;x2], y, t)) }
+  | x1=name op=INFIXOP1 x2=name y=top_handler_checking DARROW t=term
+    { let op = Name.make ~fixity:Name.Infix1 (fst op) in (op, ([x1;x2], y, t)) }
+  | x1=name op=INFIXOP2 x2=name y=top_handler_checking DARROW t=term
+    { let op = Name.make ~fixity:Name.Infix2 (fst op) in (op, ([x1;x2], y, t)) }
+  | x1=name op=INFIXOP3 x2=name y=top_handler_checking DARROW t=term
+    { let op = Name.make ~fixity:Name.Infix3 (fst op) in (op, ([x1;x2], y, t)) }
+  | x1=name op=INFIXOP4 x2=name y=top_handler_checking DARROW t=term
+    { let op = Name.make ~fixity:Name.Infix4 (fst op) in (op, ([x1;x2], y, t)) }
+
+top_handler_checking:
+  |              { None }
+  | COLON x=name { Some x }
 
 match_cases:
   | BAR lst=separated_nonempty_list(BAR, match_case)  { lst }

--- a/src/syntax.mli
+++ b/src/syntax.mli
@@ -74,14 +74,16 @@ and comp' =
 
 and handler = {
   handler_val: match_case list;
-  handler_ops: multimatch_case list Name.IdentMap.t;
+  handler_ops: match_op_case list Name.IdentMap.t;
   handler_finally : match_case list;
 }
 
 and match_case = Name.ident list * pattern * comp
 
 (** Match multiple patterns at once, with shared pattern variables *)
-and multimatch_case = Name.ident list * pattern list * comp
+and match_op_case = Name.ident list * pattern list * tt_pattern option * comp
+
+type top_op_case = Name.ident list * Name.ident option * comp
 
 (** Desugared toplevel commands *)
 type toplevel = toplevel' * Location.t
@@ -90,7 +92,7 @@ and toplevel' =
   | DeclData of Name.ident * int
   | DeclConstant of Name.ident * comp (** introduce a constant *)
   | DeclSignature of Name.signature * (Name.label * Name.ident * comp) list
-  | TopHandle of (Name.ident * (Name.ident list * comp)) list
+  | TopHandle of (Name.ident * top_op_case) list
   | TopLet of Name.ident * comp (** global let binding *)
   | TopDo of comp (** evaluate a computation *)
   | TopFail of comp
@@ -99,3 +101,4 @@ and toplevel' =
   | Quit (** quit the toplevel *)
   | Help (** print help *)
   | Environment (** print the current environment *)
+


### PR DESCRIPTION
Note that since top handlers can only have one case per operation, we assign the option to the type:

`handle op x : t => c end`
will have `t := Some v` if `op` was emitted in checking mode for `t`, otherwise `None`