### PR TITLE
Clean up printing

### DIFF
--- a/src/nucleus/assumption.ml
+++ b/src/nucleus/assumption.ml
@@ -16,16 +16,16 @@ let print_db xs k ppf =
   try
     if !Config.debruijn
     then
-      Print.print ppf "%t[%d]" (Name.print_ident (List.nth xs k)) k
+      Format.fprintf ppf "%t[%d]" (Name.print_ident (List.nth xs k)) k
     else
-      Print.print ppf "%t" (Name.print_ident (List.nth xs k))
+      Name.print_ident (List.nth xs k) ppf
   with
-    | Not_found | Failure "nth" -> Print.print ppf "DEBRUIJN[%d]" k
+    | Not_found | Failure "nth" -> Format.fprintf ppf "DEBRUIJN[%d]" k
 
 let print xs {free;bound} ppf =
-  Print.print ppf "%t ; %t"
-              (Print.sequence Name.print_atom ", " (AtomSet.elements free))
-              (Print.sequence (print_db xs) ", " (BoundSet.elements bound))
+  Format.fprintf ppf "%t@ ;@ %t"
+              (Print.sequence Name.print_atom "," (AtomSet.elements free))
+              (Print.sequence (print_db xs) "," (BoundSet.elements bound))
 
 let singleton x =
   let free = AtomSet.add x AtomSet.empty in

--- a/src/nucleus/jdg.ml
+++ b/src/nucleus/jdg.ml
@@ -18,16 +18,9 @@ let strengthen (Term (ctx,e,t)) =
   Term (ctx,e,t)
 
 let print_term ~penv ?max_level (Term (ctx, e,t)) ppf =
-  Print.print ?max_level ~at_level:100 ppf
-              "%t@[<hov 2>%s %t@ : %t@]"
+  Print.print ?max_level ~at_level:4 ppf
+              "%t%s @[<hv>@[<hov>%t@]@;<1 -2>: @[<hov>%t@]@]"
               (Context.print ~penv ctx)
               (Print.char_vdash ())
               (Tt.print_term ~penv ~max_level:999 e)
-              (Tt.print_ty ~penv ~max_level:999 t)
-
-let print_ty ~penv ?max_level (Ty (ctx, t)) ppf =
-  Print.print ?max_level ~at_level:0 ppf
-              "%t@[<hov 2>%s %t@ type@]"
-              (Context.print ~penv ctx)
-              (Print.char_vdash ())
               (Tt.print_ty ~penv ~max_level:999 t)

--- a/src/nucleus/jdg.mli
+++ b/src/nucleus/jdg.mli
@@ -24,6 +24,3 @@ val strengthen : term -> term
 
 (** Print the judgement that something is a term. *)
 val print_term : penv:Tt.print_env -> ?max_level:int -> term -> Format.formatter -> unit
-
-(** Print the judgement that something is a type. *)
-val print_ty : penv:Tt.print_env -> ?max_level:int -> ty -> Format.formatter -> unit

--- a/src/nucleus/tt.ml
+++ b/src/nucleus/tt.ml
@@ -370,6 +370,46 @@ and alpha_equal_term_ty (e, t) (e', t') = alpha_equal e e' && alpha_equal_ty t t
 
 (****** Printing routines *****)
 
+module Lvl =
+struct
+  (* Parentheses levels (low level means "less likely to need
+      parentheses around itself") *)
+
+  (* Highest level possible for a term *)
+  let highest = 1000
+
+  (* Under no circumstances will this be parenthesized *)
+  let no_parens = 0
+
+  let proj = no_parens (* a projection is never parenthesized *)
+  let proj_left = no_parens
+
+  (* Things that look like an application *)
+  let app = 100
+  let app_left = 100
+  let app_right = app - 1
+
+  (* Equality type *)
+  let eq = 200
+  let eq_left = eq - 1
+  let eq_right = eq - 1
+
+  (* Lambdas, products and arrows *)
+  let binder = 300
+  let in_binder = binder
+  let arr = binder
+  let arr_left = arr - 1
+  let arr_right = arr
+
+  (* A structure or a signature clause *)
+  let struct_clause = 400
+  let sig_clause = 400
+
+  (* Type ascription in a binding *)
+  let ascription = highest
+end
+
+
 type print_env =
   { forbidden : Name.ident list ;
     sigs : Name.signature -> Name.label list }
@@ -382,17 +422,6 @@ let print_annot ?(prefix="") k ppf =
     Format.fprintf ppf "%s[@[%t@]]" prefix k
   else
     Format.fprintf ppf ""
-
-(*
-
-  Level 0: Type, name, bound
-  Level 1: apply (0,0), refl (0)
-  Level 2: eq (1,1)
-  Level 3: lambda, prod, arrow
-
-  let, ascribe
-
-*)
 
 let print_binders ~penv print_u print_v xus ppf =
   Format.pp_open_hovbox ppf 2 ;
@@ -409,11 +438,11 @@ let print_binders ~penv print_u print_v xus ppf =
   Print.print ppf ",@ %t" (print_v ~penv) ;
   Format.pp_close_box ppf ()
 
-let rec print_term ~penv ?max_level {term=e;assumptions;_} ppf =
+let rec print_term ?max_level ~penv {term=e;assumptions;_} ppf =
   if !Config.print_dependencies && not (Assumption.is_empty assumptions)
   then
-    Print.print ppf ?max_level ~at_level:3 "(%t)^{{%t}}"
-                (print_term' ~penv ~max_level:3 e)
+    Format.fprintf ppf "(%t)^{{%t}}"
+                (print_term' ~penv ~max_level:Lvl.highest e)
                 (Assumption.print penv.forbidden assumptions)
   else
     print_term' ~penv ?max_level e ppf
@@ -422,7 +451,7 @@ and print_term' ~penv ?max_level e ppf =
   let print ?at_level = Print.print ?max_level ?at_level ppf in
     match e with
       | Type ->
-        print ~at_level:0 "Type"
+        Format.fprintf ppf "Type"
 
       | Atom x ->
         Name.print_atom x ppf
@@ -435,48 +464,51 @@ and print_term' ~penv ?max_level e ppf =
           try
             let x = List.nth penv.forbidden k in
             if !Config.debruijn
-            then print ~at_level:0 "%t[%d]" (Name.print_ident x) k
+            then Format.fprintf ppf "%t[%d]" (Name.print_ident x) k
             else Name.print_ident x ppf
           with
           | Not_found | Failure "nth" ->
               (** XXX this should never get printed *)
-              print ~at_level:0 "DEBRUIJN[%d]" k
+              Format.fprintf ppf "DEBRUIJN[%d]" k
         end
 
-      | Lambda a -> print_lambda ?max_level penv a ppf
+      | Lambda a -> print_lambda ?max_level ~penv a ppf
 
-      | Apply (e, xtst, es) -> print_apply ?max_level penv e xtst es ppf
+      | Apply (e1, _, e2) ->
+         print ~at_level:Lvl.app "%t@ %t"
+               (print_term ~max_level:Lvl.app_left ~penv e1)
+               (print_term ~max_level:Lvl.app_right ~penv e2)
 
-      | Prod xts -> print_prod ?max_level penv xts ppf
+      | Prod xts -> print_prod ?max_level ~penv xts ppf
 
       | Eq (t, e1, e2) ->
-        print ~at_level:2 "%t@ %s%t@ %t"
-          (print_term ~penv ~max_level:1 e1)
+        print ~at_level:Lvl.eq "%t@ %s%t@ %t"
+          (print_term ~max_level:Lvl.eq_left ~penv e1)
           (Print.char_equal ())
           (print_annot (print_ty ~penv t))
-          (print_term ~penv ~max_level:1 e2)
+          (print_term ~max_level:Lvl.eq_right ~penv e2)
 
       | Refl (t, e) ->
-        print ~at_level:1 "refl%t@ %t"
+        print ~at_level:Lvl.app "refl%t@ %t"
           (print_annot (print_ty ~penv t))
-          (print_term ~penv ~max_level:0 e)
+          (print_term ~max_level:Lvl.app_right ~penv  e)
 
       | Signature s ->
-        print ~at_level:0 "%t" (Name.print_ident s)
+        Name.print_ident s ppf
 
       | Structure (s, es) ->
          print_structure ?max_level ~penv s es ppf
 
       | Projection (e, s, l) ->
-         print ~at_level:0 "%t%t.%t"
-               (print_term ~penv ~max_level:0 e)
+         print ~at_level:Lvl.proj "%t%t.%t"
+               (print_term ~max_level:Lvl.proj_left ~penv e)
                (print_annot (Name.print_ident s))
                (Name.print_ident l)
 
-and print_ty ~penv ?max_level (Ty t) ppf = print_term ~penv ?max_level t ppf
+and print_ty ?max_level ~penv (Ty t) ppf = print_term ?max_level ~penv t ppf
 
 (** [print_lambda a e t ppf] prints a lambda abstraction using formatter [ppf]. *)
-and print_lambda ?max_level penv ((x, u), (e, _)) ppf =
+and print_lambda ?max_level ~penv ((x, u), (e, _)) ppf =
   let x = (if occurs 0 e = 0 then Name.anonymous else x) in
   let rec collect xus e =
     match e.term with
@@ -487,20 +519,20 @@ and print_lambda ?max_level penv ((x, u), (e, _)) ppf =
        (List.rev xus, e)
   in
   let xus, e = collect [(x,u)] e in
-  Print.print ?max_level ~at_level:3 ppf "%s%t"
+  Print.print ?max_level ~at_level:Lvl.binder ppf "%s%t"
     (Print.char_lambda ())
     (print_binders ~penv
-                   (print_ty ~max_level:999)
-                   (fun ~penv -> print_term ~penv e)
+                   (print_ty ~max_level:Lvl.ascription)
+                   (fun ~penv -> print_term ~max_level:Lvl.in_binder ~penv e)
                    xus)
 
 (** [print_prod a e t ppf] prints a lambda abstraction using formatter [ppf]. *)
-and print_prod ?max_level penv ((x, u), t) ppf =
+and print_prod ?max_level ~penv ((x, u), t) ppf =
   if occurs_ty 0 t = 0 then
-    Print.print ?max_level ~at_level:3 ppf "%t@ %s@ %t"
-          (print_ty ~penv ~max_level:2 u)
+    Print.print ?max_level ~at_level:Lvl.arr ppf "%t@ %s@ %t"
+          (print_ty ~max_level:Lvl.arr_left ~penv u)
           (Print.char_arrow ())
-          (print_ty ~penv:(add_forbidden Name.anonymous penv) t)
+          (print_ty ~max_level:Lvl.arr_right ~penv:(add_forbidden Name.anonymous penv) t)
   else
     let rec collect xus ((Ty t) as t_ty) =
       match t.term with
@@ -510,56 +542,45 @@ and print_prod ?max_level penv ((x, u), t) ppf =
          (List.rev xus, t_ty)
     in
     let xus, t = collect [(x,u)] t in
-    Print.print ?max_level ~at_level:3 ppf "%s%t"
+    Print.print ?max_level ~at_level:Lvl.binder ppf "%s%t"
                 (Print.char_prod ())
                 (print_binders ~penv
-                               (print_ty ~max_level:999)
-                               (fun ~penv -> print_ty ~penv t)
+                               (print_ty ~max_level:Lvl.ascription)
+                               (fun ~penv -> print_ty ~max_level:Lvl.in_binder ~penv t)
                                xus)
 
-and print_apply ?max_level penv e1 (yts, u) e2 ppf =
-  let rec collect_args es e =
-    match e.term with
-    | Apply (e, _, e') -> collect_args (e' :: es) e
-    | _ -> e, es
-  in
-  let e, es = collect_args [e2] e1 in
-  Print.print ?max_level ~at_level:1 ppf "%t@ %t"
-              (print_term ~penv ~max_level:0 e)
-              (Print.sequence (print_term ~penv ~max_level:0) "" es)
-
-and print_signature_clause penv x y t ppf =
+and print_signature_clause ~penv x y t ppf =
   if Name.eq_ident x y then
-    Print.print ppf "@[<hov>%t :@ %t@]"
+    Format.fprintf ppf "@[<hov>%t :@ %t@]"
       (Name.print_ident x)
-      (print_ty ~penv t)
+      (print_ty ~max_level:Lvl.sig_clause ~penv t)
   else
-    Print.print ppf "@[<hov>%t as %t :@ %t@]"
+    Format.fprintf ppf "@[<hov>%t as %t :@ %t@]"
       (Name.print_ident x)
       (Name.print_ident y)
-      (print_ty ~penv t)
+      (print_ty ~max_level:Lvl.sig_clause ~penv t)
 
 and print_signature ~penv xts ppf =
   match xts with
   | [] -> ()
   | [x,y,t] ->
      let y = Name.refresh penv.forbidden y in
-     print_signature_clause penv x y t ppf
+     print_signature_clause ~penv x y t ppf
   | (x,y,t) :: lst ->
      let y = Name.refresh penv.forbidden y in
      Print.print ppf "%t,@ %t"
-        (print_signature_clause penv x y t)
+        (print_signature_clause ~penv x y t)
         (print_signature ~penv:(add_forbidden y penv) lst)
 
 and print_structure_clause ~penv (l,e) ppf =
-  Print.print ppf "@[<hov>%t@ =@ %t@]"
-              (Name.print_ident l)
-              (print_term ~penv e)
+  Format.fprintf ppf "@[<hov>%t@ =@ %t@]"
+                 (Name.print_ident l)
+                 (print_term ~max_level:Lvl.struct_clause ~penv e)
 
 and print_structure ?max_level ~penv s es ppf =
   let les = List.combine (penv.sigs s) es in
-  Print.print ?max_level ~at_level:0 ppf "{@[<hv>%t@]}"
-       (Print.sequence (print_structure_clause ~penv) "," les)
+  Format.fprintf ppf "{@[<hv>%t@]}"
+                 (Print.sequence (print_structure_clause ~penv) "," les)
 
 (****** Structure stuff ********)
 

--- a/src/nucleus/tt.mli
+++ b/src/nucleus/tt.mli
@@ -153,6 +153,7 @@ type print_env =
   { forbidden : Name.ident list ;
     sigs : Name.signature -> Name.label list }
 
-val print_ty : penv:print_env -> ?max_level:int -> ty -> Format.formatter -> unit
-val print_term : penv:print_env -> ?max_level:int -> term -> Format.formatter -> unit
+val print_ty : ?max_level:int -> penv:print_env -> ty -> Format.formatter -> unit
+val print_term : ?max_level:int -> penv:print_env -> term -> Format.formatter -> unit
 val print_signature : penv:print_env -> signature -> Format.formatter -> unit
+

--- a/src/utils/location.ml
+++ b/src/utils/location.ml
@@ -14,13 +14,16 @@ and known = {
 
 let print loc ppf =
   match loc with
-  | Unknown -> Print.print ppf "?:?"
+
+  | Unknown -> Format.fprintf ppf "?:?"
+
   | Known {filename; start_line; start_col; end_line; end_col} ->
-    if start_line = end_line then
-      Print.print ppf "File \"%s\", line %d, characters %d-%d"
+    if start_line = end_line
+    then
+      Format.fprintf ppf "File \"%s\", line %d, characters %d-%d"
         filename start_line (1+ start_col) end_col
     else
-      Print.print ppf "File \"%s\", lines %d-%d, characters %d-%d"
+      Format.fprintf ppf "File \"%s\", lines %d-%d, characters %d-%d"
         filename start_line end_line (1+ start_col) end_col
 
 let unknown = Unknown

--- a/src/utils/name.ml
+++ b/src/utils/name.ml
@@ -20,9 +20,9 @@ type signature = ident
 
 let print_ident x ppf =
   match x with
-  | Ident (s, Word) -> Print.print ppf "%s" s
-  | Ident (_, Anonymous) -> Print.print ppf "_"
-  | Ident (s, (Prefix|Infix0|Infix1|Infix2|Infix3|Infix4)) -> Print.print ppf "( %s )" s
+  | Ident (s, Word) -> Format.fprintf ppf "%s" s
+  | Ident (_, Anonymous) -> Format.fprintf ppf "_"
+  | Ident (s, (Prefix|Infix0|Infix1|Infix2|Infix3|Infix4)) -> Format.fprintf ppf "( %s )" s
 
 let print_label = print_ident
 
@@ -44,9 +44,14 @@ let subscript k =
 
 let print_atom x ppf =
   match x with
-  | Atom (s, Word, k) -> Print.print ppf "%s%s" s (subscript k)
-  | Atom (_, Anonymous, k) -> Print.print ppf "_%s" (subscript k)
-  | Atom (s, (Prefix|Infix0|Infix1|Infix2|Infix3|Infix4), k) -> Print.print ppf "( %s%s )" s (subscript k)
+  | Atom (s, Word, k) ->
+     Format.fprintf ppf "%s%s" s (subscript k)
+
+  | Atom (_, Anonymous, k) ->
+     Format.fprintf ppf "_%s" (subscript k)
+
+  | Atom (s, (Prefix|Infix0|Infix1|Infix2|Infix3|Infix4), k) ->
+     Format.fprintf ppf "( %s%s )" s (subscript k)
 
 let print_op = print_ident
 

--- a/src/utils/print.ml
+++ b/src/utils/print.ml
@@ -16,18 +16,15 @@ let print ?(at_level=min_int) ?(max_level=max_int) ppf =
   if at_level <= max_level then
     Format.fprintf ppf
   else
-    fun fmt -> Format.fprintf ppf ("(@[" ^^ fmt ^^ "@])")
+    fun fmt -> Format.fprintf ppf ("(" ^^ fmt ^^ ")")
 
 let sequence print_u separator us ppf =
-  Format.fprintf ppf "@[<hov>" ;
-  begin match us with
+  match us with
     | [] -> ()
     | [u] -> print_u u ppf
     | u :: ((_ :: _) as us) ->
       print_u u ppf ;
       List.iter (fun u -> print ppf "%s@ " separator ; print_u u ppf) us
-  end ;
-  Format.fprintf ppf "@]"
 
 (** Unicode and ascii version of symbols *)
 

--- a/tests/beta-arithmetic.m31.ref
+++ b/tests/beta-arithmetic.m31.ref
@@ -14,13 +14,13 @@ four is defined.
 five is defined.
 ten is defined.
 ⊢ refl (plus (S (S (S (S (S Z))))) (S (S (S (S Z)))))
-  : plus (S (S (S (S Z)))) (S (S (S (S (S Z)))))
-      ≡ plus (plus (S (S Z)) (S (S (S Z)))) (S (S (S (S Z))))
+  : plus (S (S (S (S Z)))) (S (S (S (S (S Z))))) ≡ plus (plus (S (S Z)) (S
+    (S (S Z)))) (S (S (S (S Z))))
 The command failed with error:
 File "./beta-arithmetic.m31", line 29, characters 5-14: Typing error
-  failed to check that the term S (S (S Z)) is equal to
-  plus (S Z) (plus (S Z) (S Z))
+  failed to check that the term S (S (S Z)) is equal to plus (S Z) (plus (S
+  Z) (S Z))
 The command failed with error:
 File "./beta-arithmetic.m31", line 36, characters 5-13: Typing error
-  failed to check that the term S (S (S (S Z))) is equal to
-  times (S (S Z)) (S (S Z))
+  failed to check that the term S (S (S (S Z))) is equal to times (S (S Z))
+  (S (S Z))

--- a/tests/beta-nat.m31.ref
+++ b/tests/beta-nat.m31.ref
@@ -7,5 +7,5 @@ Constant plus_S is declared.
 ⊢ Type : Type
 ⊢ refl (S (S Z)) : plus (S (S Z)) Z ≡ S (S Z)
 ⊢ refl (S (S Z)) : plus (S Z) (S Z) ≡ S (S Z)
-⊢ λ (x : N), λ (y : N), refl (S (S (plus x y)))
-  : Π (x : N), Π (y : N), plus x (S (S y)) ≡ S (S (plus x y))
+⊢ λ (x : N) (y : N), refl (S (S (plus x y)))
+  : Π (x : N) (y : N), plus x (S (S y)) ≡ S (S (plus x y))

--- a/tests/beta-pair.m31.ref
+++ b/tests/beta-pair.m31.ref
@@ -8,7 +8,7 @@ Constant c is declared.
 Constant d is declared.
 ⊢ refl (Fst C D (Pair C D c d)) : c ≡ Fst C D (Pair C D c d)
 ⊢ refl (Fst D C (Pair D C d c)) : d ≡ Fst D C (Pair D C d c)
-⊢ refl (Fst C D (Pair C D ((λ (t : Type), λ (x : t), x) C c) d))
+⊢ refl (Fst C D (Pair C D ((λ (t : Type) (x : t), x) C c) d))
   : c ≡ Fst C D (Pair C D c d)
 ⊢ refl (Fst C D (Pair C D c d))
-  : c ≡ Fst C D (Pair C D ((λ (t : Type), λ (x : t), x) C c) d)
+  : c ≡ Fst C D (Pair C D ((λ (t : Type) (x : t), x) C c) d)

--- a/tests/beta-primapp.m31.ref
+++ b/tests/beta-primapp.m31.ref
@@ -11,4 +11,4 @@ Constant X is declared.
 Constant Y is declared.
 Constant a is declared.
 Constant f is declared.
-⊢ λ (y : Y), refl (f a) : Π (y : Y), f a ≡ Fst X Y (Pair X Y (f a) y)
+⊢ λ (_ : Y), refl (f a) : Π (y : Y), f a ≡ Fst X Y (Pair X Y (f a) y)

--- a/tests/beta-sigma.m31.ref
+++ b/tests/beta-sigma.m31.ref
@@ -8,62 +8,38 @@ Constant projT1 is declared.
 Constant projT2 is declared.
 Constant projT1_beta is declared.
 ⊢ projT1_beta
-  : Π (A0 : Type),
-      Π (B0 : A0 → Type),
-        Π (a0 : A0),
-          Π (b0 : B0 a0), projT1 A0 B0 (existT A0 B0 a0 b0) ≡ a0
+  : Π (A0 : Type) (B0 : A0 → Type) (a0 : A0) (b0 : B0 a0), projT1 A0 B0
+        (existT A0 B0 a0 b0) ≡ a0
 ⊢ refl a : projT1 A B (existT A B a b) ≡ a
 Constant projT2_beta is declared.
 ⊢ refl b : projT2 A B (existT A B a b) ≡ b
 Constant sig_ind is declared.
 Constant sig_ind_beta is declared.
 projT1' is defined.
-⊢ λ (A0 : Type),
-      λ (B0 : A0 → Type),
-        λ (s : sigT A0 B0),
-          sig_ind
-            A0 B0 (λ (_ : sigT A0 B0), A0)
-            ((λ (X : Type), λ (Y : X → Type), λ (x : X), λ (y : Y x), x)
-               A0 B0) s
-  : Π (A0 : Type),
-      Π (B0 : A0 → Type), Π (s : sigT A0 B0), (λ (_ : sigT A0 B0), A0) s
+⊢ λ (A0 : Type) (B0 : A0 → Type) (s : sigT A0 B0), sig_ind A0 B0
+        (λ (_ : sigT A0 B0), A0)
+        ((λ (X : Type) (Y : X → Type) (x : X) (_ : Y x), x) A0 B0) s
+  : Π (A0 : Type) (B0 : A0 → Type) (s : sigT A0 B0),
+        (λ (_ : sigT A0 B0), A0) s
 ⊢ refl a
-  : a
-      ≡ (λ (A0 : Type),
-             λ (B0 : A0 → Type),
-               λ (s : sigT A0 B0),
-                 sig_ind
-                   A0 B0 (λ (_ : sigT A0 B0), A0)
-                   ((λ (X : Type),
-                       λ (Y : X → Type), λ (x : X), λ (y : Y x), x)
-                      A0 B0) s) A B (existT A B a b)
+  : a ≡
+    (λ (A0 : Type) (B0 : A0 → Type) (s : sigT A0 B0), sig_ind A0 B0
+         (λ (_ : sigT A0 B0), A0)
+         ((λ (X : Type) (Y : X → Type) (x : X) (_ : Y x), x) A0 B0) s) A B
+    (existT A B a b)
 ⊢ refl a
-  : projT1 A B (existT A B a b)
-      ≡ (λ (A0 : Type),
-             λ (B0 : A0 → Type),
-               λ (s : sigT A0 B0),
-                 sig_ind
-                   A0 B0 (λ (_ : sigT A0 B0), A0)
-                   ((λ (X : Type),
-                       λ (Y : X → Type), λ (x : X), λ (y : Y x), x)
-                      A0 B0) s) A B (existT A B a b)
+  : projT1 A B (existT A B a b) ≡
+    (λ (A0 : Type) (B0 : A0 → Type) (s : sigT A0 B0), sig_ind A0 B0
+         (λ (_ : sigT A0 B0), A0)
+         ((λ (X : Type) (Y : X → Type) (x : X) (_ : Y x), x) A0 B0) s) A B
+    (existT A B a b)
 projT2' is defined.
 ⊢ refl b
-  : projT2 A B (existT A B a b)
-      ≡ (λ (A0 : Type),
-             λ (B0 : A0 → Type),
-               λ (s : sigT A0 B0),
-                 sig_ind
-                   A0 B0
-                   (λ (s0 : sigT A0 B0),
-                      B0
-                        ((λ (A1 : Type),
-                            λ (B1 : A1 → Type),
-                              λ (s1 : sigT A1 B1),
-                                sig_ind
-                                  A1 B1 (λ (_ : sigT A1 B1), A1)
-                                  ((λ (X : Type),
-                                      λ (Y : X → Type),
-                                        λ (x : X), λ (y : Y x), x) 
-                                     A1 B1) s1) A0 B0 s0))
-                   (λ (x : A0), λ (y : B0 x), y) s) A B (existT A B a b)
+  : projT2 A B (existT A B a b) ≡
+    (λ (A0 : Type) (B0 : A0 → Type) (s : sigT A0 B0), sig_ind A0 B0
+         (λ (s0 : sigT A0 B0), B0
+              ((λ (A1 : Type) (B1 : A1 → Type) (s1 : sigT A1 B1), sig_ind
+                    A1 B1 (λ (_ : sigT A1 B1), A1)
+                    ((λ (X : Type) (Y : X → Type) (x : X) (_ : Y x), x) A1
+                    B1) s1) A0 B0 s0)) (λ (x : A0) (y : B0 x), y) s) A B
+    (existT A B a b)

--- a/tests/beta-sum.m31.ref
+++ b/tests/beta-sum.m31.ref
@@ -3,21 +3,14 @@ Constant inl is declared.
 Constant inr is declared.
 Constant sum_rect is declared.
 ⊢ sum_rect
-  : Π (A : Type),
-      Π (B : Type),
-        Π (P : sum A B → Type),
-          (Π (a : A), P (inl A B a)) →
-            (Π (b : B), P (inr A B b)) → Π (t : sum A B), P t
+  : Π (A : Type) (B : Type) (P : sum A B → Type),
+        (Π (a : A), P (inl A B a)) → (Π (b : B), P (inr A B b)) →
+        Π (t : sum A B), P t
 Constant sum_iota_l is declared.
 Constant sum_iota_r is declared.
-⊢ λ (A : Type),
-      λ (B : Type),
-        λ (P : sum A B → Type),
-          λ (l : Π (a : A), P (inl A B a)),
-            λ (r : Π (b : B), P (inr A B b)), λ (b : B), refl (r b)
-  : Π (A : Type),
-      Π (B : Type),
-        Π (P : sum A B → Type),
-          Π (l : Π (a : A), P (inl A B a)),
-            Π (r : Π (b : B), P (inr A B b)),
-              Π (b : B), r b ≡ sum_rect A B P l r (inr A B b)
+⊢ λ (A : Type) (B : Type) (P : sum A B → Type)
+    (l : Π (a : A), P (inl A B a)) (r : Π (b : B), P (inr A B b)) (b : B),
+        refl (r b)
+  : Π (A : Type) (B : Type) (P : sum A B → Type)
+    (l : Π (a : A), P (inl A B a)) (r : Π (b : B), P (inr A B b)) (b : B),
+        r b ≡ sum_rect A B P l r (inr A B b)

--- a/tests/check-lambda.m31.ref
+++ b/tests/check-lambda.m31.ref
@@ -5,6 +5,6 @@ Constant f is declared.
 Constant g is declared.
 Constant a is declared.
 ⊢ λ (y : B a), g a y : Π (y : B a), C a y
-⊢ λ (x : A), λ (y : B x), g x y : Π (x : A), Π (y : B x), C x y
-⊢ λ (x : A), λ (y : B x), g x y : Π (x : A), Π (y : B x), C x y
-⊢ λ (x : A), λ (y : B x), g x y : Π (x : A), Π (y : B x), C x y
+⊢ λ (x : A) (y : B x), g x y : Π (x : A) (y : B x), C x y
+⊢ λ (x : A) (y : B x), g x y : Π (x : A) (y : B x), C x y
+⊢ λ (x : A) (y : B x), g x y : Π (x : A) (y : B x), C x y

--- a/tests/church.m31.ref
+++ b/tests/church.m31.ref
@@ -1,56 +1,55 @@
 Nat is defined.
 ⊢ Π (X : Type), (X → X) → X → X : Type
 zero is defined.
-⊢ λ (A : Type), λ (s : A → A), λ (z : A), z
+⊢ λ (A : Type) (_ : A → A) (z : A), z
   : Π (X : Type), (X → X) → X → X
 one is defined.
-⊢ λ (A : Type), λ (s : A → A), λ (z : A), s z
+⊢ λ (A : Type) (s : A → A) (z : A), s z
   : Π (X : Type), (X → X) → X → X
 two is defined.
-⊢ λ (A : Type), λ (s : A → A), λ (z : A), s (s z)
+⊢ λ (A : Type) (s : A → A) (z : A), s (s z)
   : Π (X : Type), (X → X) → X → X
 three is defined.
-⊢ λ (A : Type), λ (s : A → A), λ (z : A), s (s (s z))
+⊢ λ (A : Type) (s : A → A) (z : A), s (s (s z))
   : Π (X : Type), (X → X) → X → X
 succ is defined.
-⊢ λ (n : Π (X : Type), (X → X) → X → X),
-      λ (B : Type), λ (s : B → B), λ (z : B), s (n B s z)
+⊢ λ (n : Π (X : Type), (X → X) → X → X) (B : Type) (s : B → B)
+    (z : B), s (n B s z)
   : (Π (X : Type), (X → X) → X → X) →
-      Π (X : Type), (X → X) → X → X
+    Π (X : Type), (X → X) → X → X
 succ' is defined.
-⊢ λ (n : Π (X : Type), (X → X) → X → X),
-      λ (A : Type), λ (s : A → A), λ (z : A), n A s (s z)
+⊢ λ (n : Π (X : Type), (X → X) → X → X) (A : Type) (s : A → A)
+    (z : A), n A s (s z)
   : (Π (X : Type), (X → X) → X → X) →
-      Π (X : Type), (X → X) → X → X
+    Π (X : Type), (X → X) → X → X
 add is defined.
-⊢ λ (m : Π (X : Type), (X → X) → X → X),
-      λ (n : Π (X : Type), (X → X) → X → X),
-        λ (A : Type), λ (s : A → A), λ (z : A), m A s (n A s z)
+⊢ λ (m : Π (X : Type), (X → X) → X → X)
+    (n : Π (X : Type), (X → X) → X → X) (A : Type) (s : A → A)
+    (z : A), m A s (n A s z)
   : (Π (X : Type), (X → X) → X → X) →
-      (Π (X : Type), (X → X) → X → X) →
-        Π (X : Type), (X → X) → X → X
+    (Π (X : Type), (X → X) → X → X) →
+    Π (X : Type), (X → X) → X → X
 mult is defined.
-⊢ λ (m : Π (X : Type), (X → X) → X → X),
-      λ (n : Π (X : Type), (X → X) → X → X),
-        λ (A : Type), λ (s : A → A), m A (n A s)
+⊢ λ (m : Π (X : Type), (X → X) → X → X)
+    (n : Π (X : Type), (X → X) → X → X) (A : Type) (s : A → A), m A
+        (n A s)
   : (Π (X : Type), (X → X) → X → X) →
-      (Π (X : Type), (X → X) → X → X) →
-        Π (X : Type), (X → X) → X → X
+    (Π (X : Type), (X → X) → X → X) →
+    Π (X : Type), (X → X) → X → X
 Constant N is declared.
 Constant Z is declared.
 Constant S is declared.
-⊢ refl ((λ (n : Π (X : Type), (X → X) → X → X),
-             λ (B : Type), λ (s : B → B), λ (z : B), s (n B s z))
-            (λ (A : Type), λ (s : A → A), λ (z : A), s (s (s z))) N S Z)
-  : (λ (m : Π (X : Type), (X → X) → X → X),
-       λ (n : Π (X : Type), (X → X) → X → X),
-         λ (A : Type), λ (s : A → A), λ (z : A), m A s (n A s z))
-      (λ (A : Type), λ (s : A → A), λ (z : A), s z)
-      (λ (A : Type), λ (s : A → A), λ (z : A), s (s (s z))) N S Z
-      ≡ (λ (m : Π (X : Type), (X → X) → X → X),
-             λ (n : Π (X : Type), (X → X) → X → X),
-               λ (A : Type), λ (s : A → A), m A (n A s))
-            ((λ (n : Π (X : Type), (X → X) → X → X),
-                λ (A : Type), λ (s : A → A), λ (z : A), n A s (s z))
-               (λ (A : Type), λ (s : A → A), λ (z : A), s z))
-            (λ (A : Type), λ (s : A → A), λ (z : A), s (s z)) N S Z
+⊢ refl
+    ((λ (n : Π (X : Type), (X → X) → X → X) (B : Type) (s : B → B)
+      (z : B), s (n B s z))
+    (λ (A : Type) (s : A → A) (z : A), s (s (s z))) N S Z)
+  : (λ (m : Π (X : Type), (X → X) → X → X)
+     (n : Π (X : Type), (X → X) → X → X) (A : Type) (s : A → A)
+     (z : A), m A s (n A s z)) (λ (A : Type) (s : A → A) (z : A), s z)
+    (λ (A : Type) (s : A → A) (z : A), s (s (s z))) N S Z ≡
+    (λ (m : Π (X : Type), (X → X) → X → X)
+     (n : Π (X : Type), (X → X) → X → X) (A : Type) (s : A → A), m A
+         (n A s))
+    ((λ (n : Π (X : Type), (X → X) → X → X) (A : Type) (s : A → A)
+      (z : A), n A s (s z)) (λ (A : Type) (s : A → A) (z : A), s z))
+    (λ (A : Type) (s : A → A) (z : A), s (s z)) N S Z

--- a/tests/compose.m31.ref
+++ b/tests/compose.m31.ref
@@ -1,12 +1,9 @@
 id is defined.
-⊢ λ (A : Type), λ (x : A), x : Π (A : Type), A → A
+⊢ λ (A : Type) (x : A), x : Π (A : Type), A → A
 compose is defined.
-⊢ λ (A : Type),
-      λ (B : Type),
-        λ (C : Type),
-          λ (g : B → C), λ (f : A → B), λ (x : A), g (f x)
-  : Π (A : Type),
-      Π (B : Type), Π (C : Type), (B → C) → (A → B) → A → C
+⊢ λ (A : Type) (B : Type) (C : Type) (g : B → C) (f : A → B) (x : A),
+        g (f x)
+  : Π (A : Type) (B : Type) (C : Type), (B → C) → (A → B) → A → C
 Constant X is declared.
 Constant Y is declared.
 Constant Z is declared.
@@ -16,32 +13,15 @@ Constant f is declared.
 Constant g is declared.
 Constant h is declared.
 ⊢ refl (g (f x))
-  : g (f x)
-      ≡ (λ (A : Type),
-             λ (B : Type),
-               λ (C : Type),
-                 λ (g0 : B → C),
-                   λ (f0 : A → B), λ (x0 : A), g0 (f0 x0)) X Y Z g f x
+  : g (f x) ≡
+    (λ (A : Type) (B : Type) (C : Type) (g0 : B → C) (f0 : A → B)
+     (x0 : A), g0 (f0 x0)) X Y Z g f x
 ⊢ refl (h (g (f x)))
-  : (λ (A : Type),
-       λ (B : Type),
-         λ (C : Type),
-           λ (g0 : B → C), λ (f0 : A → B), λ (x0 : A), g0 (f0 x0))
-      X Z W h
-      ((λ (A : Type),
-          λ (B : Type),
-            λ (C : Type),
-              λ (g0 : B → C), λ (f0 : A → B), λ (x0 : A), g0 (f0 x0))
-         X Y Z g f) x
-      ≡ (λ (A : Type),
-             λ (B : Type),
-               λ (C : Type),
-                 λ (g0 : B → C),
-                   λ (f0 : A → B), λ (x0 : A), g0 (f0 x0))
-            X Y W
-            ((λ (A : Type),
-                λ (B : Type),
-                  λ (C : Type),
-                    λ (g0 : B → C),
-                      λ (f0 : A → B), λ (x0 : A), g0 (f0 x0)) Y Z W h g)
-            f x
+  : (λ (A : Type) (B : Type) (C : Type) (g0 : B → C) (f0 : A → B)
+     (x0 : A), g0 (f0 x0)) X Z W h
+    ((λ (A : Type) (B : Type) (C : Type) (g0 : B → C) (f0 : A → B)
+      (x0 : A), g0 (f0 x0)) X Y Z g f) x ≡
+    (λ (A : Type) (B : Type) (C : Type) (g0 : B → C) (f0 : A → B)
+     (x0 : A), g0 (f0 x0)) X Y W
+    ((λ (A : Type) (B : Type) (C : Type) (g0 : B → C) (f0 : A → B)
+      (x0 : A), g0 (f0 x0)) Y Z W h g) f x

--- a/tests/congruence.m31.ref
+++ b/tests/congruence.m31.ref
@@ -1,10 +1,5 @@
 congr is defined.
-⊢ λ (A : Type),
-      λ (f : A → A),
-        λ (g : A → A),
-          λ (u : A),
-            λ (v : A), λ (eqf : f ≡ g), λ (equ : u ≡ v), refl (f u)
-  : Π (A : Type),
-      Π (f : A → A),
-        Π (g : A → A),
-          Π (u : A), Π (v : A), f ≡ g → u ≡ v → f u ≡ g v
+⊢ λ (A : Type) (f : A → A) (g : A → A) (u : A) (v : A) (_ : f ≡ g)
+    (_ : u ≡ v), refl (f u)
+  : Π (A : Type) (f : A → A) (g : A → A) (u : A) (v : A), f ≡ g → u
+        ≡ v → f u ≡ g v

--- a/tests/context-subst.m31.ref
+++ b/tests/context-subst.m31.ref
@@ -3,8 +3,8 @@ x is defined.
 P is defined.
 y is defined.
 x₁₀ : A 
-y₁₃ : (λ (z : A), A) x₁₀ 
-⊢ y₁₃ : (λ (z : A), A) x₁₀
+y₁₃ : (λ (_ : A), A) x₁₀ 
+⊢ y₁₃ : (λ (_ : A), A) x₁₀
 Constant f is declared.
 x₁₀ : A 
 P₁₂ : A → Type 

--- a/tests/equal_fun.m31.ref
+++ b/tests/equal_fun.m31.ref
@@ -2,7 +2,6 @@ Constant A is declared.
 Constant B is declared.
 Constant f is declared.
 foo is defined.
-⊢ refl (λ (x : A), λ (y : B x), f x (f x y))
-  : (λ (x : A), λ (y : B x), f x (f x y))
-      ≡ (λ (g : Π (x : A), B x → B x),
-             λ (x : A), λ (y : B x), g x (g x y)) f
+⊢ refl (λ (x : A) (y : B x), f x (f x y))
+  : (λ (x : A) (y : B x), f x (f x y)) ≡
+    (λ (g : Π (x : A), B x → B x) (x : A) (y : B x), g x (g x y)) f

--- a/tests/eta-pair.m31.ref
+++ b/tests/eta-pair.m31.ref
@@ -8,8 +8,8 @@ Constant Pair_eta is declared.
 Constant C is declared.
 Constant D is declared.
 Constant p is declared.
-⊢ λ (c : C), λ (d : D), refl c
-  : Π (c : C), Π (d : D), Fst C D (Pair C D c d) ≡ c
-⊢ λ (c : C), λ (d : D), refl d
-  : Π (c : C), Π (d : D), Snd C D (Pair C D c d) ≡ d
+⊢ λ (c : C) (_ : D), refl c
+  : Π (c : C) (d : D), Fst C D (Pair C D c d) ≡ c
+⊢ λ (c : C) (d : D), refl d
+  : Π (c : C) (d : D), Snd C D (Pair C D c d) ≡ d
 ⊢ refl p : p ≡ Pair C D (Fst C D p) (Snd C D p)

--- a/tests/eta-unit.m31.ref
+++ b/tests/eta-unit.m31.ref
@@ -1,2 +1,2 @@
 Constant unit_eta is declared.
-⊢ λ (x : unit), refl {} : Π (x : unit), x ≡ {}
+⊢ λ (_ : unit), refl {} : Π (x : unit), x ≡ {}

--- a/tests/extensionality.m31.ref
+++ b/tests/extensionality.m31.ref
@@ -1,24 +1,16 @@
 eqext is defined.
-⊢ λ (A : Type),
-      λ (a : A), λ (b : A), λ (p : a ≡ b), λ (q : a ≡ b), refl p
-  : Π (A : Type),
-      Π (a : A), Π (b : A), Π (p : a ≡ b), Π (q : a ≡ b), p ≡ q
+⊢ λ (A : Type) (a : A) (b : A) (p : a ≡ b) (_ : a ≡ b), refl p
+  : Π (A : Type) (a : A) (b : A) (p : a ≡ b) (q : a ≡ b), p ≡ q
 funext is defined.
-⊢ λ (A : Type),
-      λ (B : A → Type),
-        λ (f : Π (x : A), B x),
-          λ (g : Π (x : A), B x), λ (eq : Π (x : A), f x ≡ g x), refl f
-  : Π (A : Type),
-      Π (B : A → Type),
-        Π (f : Π (x : A), B x),
-          Π (g : Π (x : A), B x), (Π (x : A), f x ≡ g x) → f ≡ g
+⊢ λ (A : Type) (B : A → Type) (f : Π (x : A), B x)
+    (g : Π (x : A), B x) (_ : Π (x : A), f x ≡ g x), refl f
+  : Π (A : Type) (B : A → Type) (f : Π (x : A), B x)
+    (g : Π (x : A), B x), (Π (x : A), f x ≡ g x) → f ≡ g
 Constant A is declared.
 Constant B is declared.
 Signature cow is declared.
 cowext is defined.
-⊢ λ (a : cow),
-      λ (b : cow),
-        λ (ppppppppp : a.head ≡ b.head),
-          λ (qqqqqqqq : a.tail ≡ b.tail), refl a
-  : Π (a : cow),
-      Π (b : cow), a.head ≡ b.head → a.tail ≡ b.tail → a ≡ b
+⊢ λ (a : cow) (b : cow) (_ : a.head ≡ b.head) (_ : a.tail ≡ b.tail),
+        refl a
+  : Π (a : cow) (b : cow), a.head ≡ b.head → a.tail ≡ b.tail → a ≡
+        b

--- a/tests/generic.m31.ref
+++ b/tests/generic.m31.ref
@@ -7,13 +7,12 @@ ankle is defined.
 ⊢ {person = dwarf, pet = urist} : cat
 ((⊢ cat : Type), [(⊢ dwarf : Type), (⊢ urist : dwarf)])
 [(person, (person₁₆ : Type 
-           ⊢ person₁₆ : Type), (⊢ Type : Type)),
- (pet,
-  (person₁₆ : Type 
-   pet₁₇ : person₁₆ 
-   ⊢ pet₁₇ : person₁₆),
-  (person₁₆ : Type 
-   ⊢ person₁₆ : Type))]
+           ⊢ person₁₆ : Type), (⊢ Type : Type)), (pet,
+(person₁₆ : Type 
+ pet₁₇ : person₁₆ 
+ ⊢ pet₁₇ : person₁₆),
+(person₁₆ : Type 
+ ⊢ person₁₆ : Type))]
 ((⊢ {person = dwarf, pet = urist} : cat), pet)
 tt
 ⊢ {person = dwarf, pet = urist} : cat

--- a/tests/handle-op-under-lambda.m31.ref
+++ b/tests/handle-op-under-lambda.m31.ref
@@ -4,4 +4,4 @@ Constant C is declared.
 Constant a is declared.
 Constant f is declared.
 Operation gimme is declared.
-⊢ λ (b : B), f a : B → C
+⊢ λ (_ : B), f a : B → C

--- a/tests/infixes.m31.ref
+++ b/tests/infixes.m31.ref
@@ -16,30 +16,25 @@ Constant unit_singleton is declared.
 unit_mon is defined.
 ( ++ ) is defined.
 ( * ) is defined.
-⊢ refl {T = unit, ( + ) = λ (x0 : unit), λ (y : unit), {},
-          assoc = λ (x0 : unit),
-                    λ (y : unit),
-                      λ (z : unit),
-                        unit_singleton
-                          ((λ (x1 : unit), λ (y0 : unit), {})
-                             x0 ((λ (x1 : unit), λ (y0 : unit), {}) y z))
-                          ((λ (x1 : unit), λ (y0 : unit), {})
-                             ((λ (x1 : unit), λ (y0 : unit), {}) x0 y) z)}.( + )
-  : {T = unit, ( + ) = λ (x0 : unit), λ (y : unit), {},
-     assoc = λ (x0 : unit),
-               λ (y : unit),
-                 λ (z : unit),
-                   unit_singleton
-                     ((λ (x1 : unit), λ (y0 : unit), {})
-                        x0 ((λ (x1 : unit), λ (y0 : unit), {}) y z))
-                     ((λ (x1 : unit), λ (y0 : unit), {})
-                        ((λ (x1 : unit), λ (y0 : unit), {}) x0 y) z)}.( + )
-      ≡ {T = unit, ( + ) = λ (x0 : unit), λ (y : unit), {},
-           assoc = λ (x0 : unit),
-                     λ (y : unit),
-                       λ (z : unit),
-                         unit_singleton
-                           ((λ (x1 : unit), λ (y0 : unit), {})
-                              x0 ((λ (x1 : unit), λ (y0 : unit), {}) y z))
-                           ((λ (x1 : unit), λ (y0 : unit), {})
-                              ((λ (x1 : unit), λ (y0 : unit), {}) x0 y) z)}.( + )
+⊢ refl
+    {T = unit,
+     ( + ) = λ (_ : unit) (_ : unit), {},
+     assoc =
+     λ (x0 : unit) (y : unit) (z : unit), unit_singleton
+         ((λ (_ : unit) (_ : unit), {}) x0 ((λ (_ : unit) (_ : unit), {}) y
+         z)) ((λ (_ : unit) (_ : unit), {}) ((λ (_ : unit) (_ : unit), {})
+         x0 y) z)}.( + )
+  : {T = unit,
+     ( + ) = λ (_ : unit) (_ : unit), {},
+     assoc =
+     λ (x0 : unit) (y : unit) (z : unit), unit_singleton
+         ((λ (_ : unit) (_ : unit), {}) x0 ((λ (_ : unit) (_ : unit), {}) y
+         z)) ((λ (_ : unit) (_ : unit), {}) ((λ (_ : unit) (_ : unit), {})
+         x0 y) z)}.( + ) ≡
+    {T = unit,
+     ( + ) = λ (_ : unit) (_ : unit), {},
+     assoc =
+     λ (x0 : unit) (y : unit) (z : unit), unit_singleton
+         ((λ (_ : unit) (_ : unit), {}) x0 ((λ (_ : unit) (_ : unit), {}) y
+         z)) ((λ (_ : unit) (_ : unit), {}) ((λ (_ : unit) (_ : unit), {})
+         x0 y) z)}.( + )

--- a/tests/lambda-nesting.m31.ref
+++ b/tests/lambda-nesting.m31.ref
@@ -1,5 +1,5 @@
 f is defined.
 g is defined.
-⊢ refl (λ (T : Type), λ (U : Type), λ (x : T), λ (y : U), x)
-  : (λ (T : Type), λ (U : Type), λ (x : T), λ (y : U), x)
-      ≡ (λ (T : Type), λ (U : Type), λ (x : T), λ (y : U), x)
+⊢ refl (λ (T : Type) (U : Type) (x : T) (_ : U), x)
+  : (λ (T : Type) (U : Type) (x : T) (_ : U), x) ≡
+    (λ (T : Type) (U : Type) (x : T) (_ : U), x)

--- a/tests/match_spine_trailing-nested_e-spine.m31.ref
+++ b/tests/match_spine_trailing-nested_e-spine.m31.ref
@@ -3,22 +3,21 @@ Constant unit_rect is declared.
 Constant unit_iota_top is declared.
 it is defined.
 ⊢ refl {}
-  : (λ (T : Type), unit_rect (λ (m : unit), T → T) (λ (x : T), x))
-      unit {} {}
-      ≡ {}
+  : (λ (T : Type), unit_rect (λ (_ : unit), T → T) (λ (x : T), x)) unit
+    {} {} ≡ {}
 ⊢ refl {}
-  : {}
-      ≡ (λ (T : Type), unit_rect (λ (m : unit), T → T) (λ (x : T), x))
-            unit {} {}
+  : {} ≡
+    (λ (T : Type), unit_rect (λ (_ : unit), T → T) (λ (x : T), x)) unit
+    {} {}
 ⊢ refl {}
-  : {}
-      ≡ (λ (T : Type), unit_rect (λ (m : unit), T → T) (λ (x : T), x))
-            unit {} {}
+  : {} ≡
+    (λ (T : Type), unit_rect (λ (_ : unit), T → T) (λ (x : T), x)) unit
+    {} {}
 ⊢ refl {}
-  : {}
-      ≡ (λ (T : Type), unit_rect (λ (m : unit), T → T) (λ (x : T), x))
-            unit {} {}
+  : {} ≡
+    (λ (T : Type), unit_rect (λ (_ : unit), T → T) (λ (x : T), x)) unit
+    {} {}
 ⊢ refl {}
-  : {}
-      ≡ (λ (T : Type), unit_rect (λ (m : unit), T → T) (λ (x : T), x))
-            unit {} {}
+  : {} ≡
+    (λ (T : Type), unit_rect (λ (_ : unit), T → T) (λ (x : T), x)) unit
+    {} {}

--- a/tests/meta-match.m31.ref
+++ b/tests/meta-match.m31.ref
@@ -6,8 +6,8 @@ Constant c is declared.
 Data constructor lam is declared.
 lam (x₁₂ : A 
      ⊢ x₁₂ : A) (⊢ A : Type) (⊢ a : A)
-    (((x'₁₁ : A 
-       ⊢ x'₁₁ : A), (⊢ A : Type)), (⊢ A : Type))
+(((x'₁₁ : A 
+   ⊢ x'₁₁ : A), (⊢ A : Type)), (⊢ A : Type))
 Constant list is declared.
 Constant Nil is declared.
 Constant Cons is declared.

--- a/tests/references.m31.ref
+++ b/tests/references.m31.ref
@@ -2,5 +2,4 @@ Data constructor banana is declared.
 Data constructor apple is declared.
 x is defined.
 tt
-ref
-3 := [apple, banana]
+ref 3 := [apple, banana]

--- a/tests/untagged_functional_arg.m31.ref
+++ b/tests/untagged_functional_arg.m31.ref
@@ -1,5 +1,5 @@
 G is defined.
 G' is defined.
-⊢ refl (λ (T : Type), λ (g : T → T), λ (x : T), g x)
-  : (λ (T : Type), λ (g : T → T), λ (x : T), g x)
-      ≡ (λ (T' : Type), λ (g : T' → T'), λ (x : T'), g x)
+⊢ refl (λ (T : Type) (g : T → T) (x : T), g x)
+  : (λ (T : Type) (g : T → T) (x : T), g x) ≡
+    (λ (T' : Type) (g : T' → T') (x : T'), g x)

--- a/tests/user-equal.m31.ref
+++ b/tests/user-equal.m31.ref
@@ -3,6 +3,6 @@ Constant a is declared.
 Constant b is declared.
 Constant f is declared.
 test is defined.
-⊢ refl (f b a) : (λ (x : A), λ (y : A), f y x) a b ≡ f b a
+⊢ refl (f b a) : (λ (x : A) (y : A), f y x) a b ≡ f b a
 Constant eq is declared.
 ⊢ eq a : f a a ≡ b


### PR DESCRIPTION
This closes #195.

Summary:
* print repeated lambdas as a single one, and similarly for products
* use `Format.fprintf` instead of the wrapper `Print.print` when no
  parentheses are involved
* generally the output is more compact (fewer line breaks and less indentation)