### PR TITLE
Structures with sharing constraints

### DIFF
--- a/etc/andromeda.lang
+++ b/etc/andromeda.lang
@@ -90,34 +90,42 @@
 	  <keyword>false</keyword>
 	</context>
 	<context id="keywords" style-ref="keyword">
+    <keyword>_sig</keyword>
+    <keyword>_struct</keyword>
+    <keyword>_proj</keyword>
+    <keyword>_atom</keyword>
     <keyword>as</keyword>
     <keyword>assume</keyword>
     <keyword>and</keyword>
-    <keyword>check</keyword>
     <keyword>constant</keyword>
-    <keyword>context</keyword>
     <keyword>congruence</keyword>
+    <keyword>context</keyword>
     <keyword>data</keyword>
+    <keyword>do</keyword>
     <keyword>end</keyword>
+    <keyword>extensionality</keyword>
     <keyword>external</keyword>
     <keyword>finally</keyword>
     <keyword>fail</keyword>
     <keyword>handle</keyword>
     <keyword>handler</keyword>
+    <keyword>hypotheses</keyword>
     <keyword>let</keyword>
     <keyword>match</keyword>
-    <keyword>reduce</keyword>
+    <keyword>reduction</keyword>
     <keyword>forall</keyword>
     <keyword>yield</keyword>
     <keyword>fun</keyword>
     <keyword>lambda</keyword>
     <keyword>in</keyword>
+    <keyword>occurs</keyword>
     <keyword>operation</keyword>
     <keyword>rec</keyword>
-    <keyword>refl</keyword>
     <keyword>ref</keyword>
+    <keyword>refl</keyword>
+    <keyword>signature</keyword>
+    <keyword>using</keyword>
     <keyword>Type</keyword>
-    <keyword>typeof</keyword>
     <keyword>val</keyword>
     <keyword>where</keyword>
     <keyword>with</keyword>

--- a/examples/esystems.m31
+++ b/examples/esystems.m31
@@ -1,14 +1,5 @@
 (* Egbert's E-systems *)
-operation hippy 0
-
-handle
-  | equal ?a ?b : _ =>
-      match equal a b with
-      | None => assume ξ : a ≡ b in yield (Some ξ)
-      | Some ?ζ => yield (Some ζ)
-      end
-  | hippy : ?t => assume Ξ : t in yield Ξ
-end
+#include_once "../std/hippy.m31"
 
 signature catWithTerms = {
 

--- a/src/nucleus/equal.ml
+++ b/src/nucleus/equal.ml
@@ -136,14 +136,14 @@ let equal_signature ~loc ctx (s1,shares1) (s2,shares2) =
       | [] ->
         context_multiabstract ~loc ctx yts >!= fun ctx ->
         Opt.return ctx
-      | ((_,x,t),None,None)::rem ->
+      | ((_,_,t),(x,None),(_,None))::rem ->
         let t = Tt.instantiate_ty vs t in
         let jt = Jdg.mk_ty ctx t in
         Opt.add_abstracting ~loc x jt (fun ctx y ->
         let y1 = Tt.mk_atom ~loc y in
         let y2 = Tt.mention_atoms hyps y1 in
         fold ctx hyps ((y,t)::yts) (y1::vs) (y1::ys1) (y2::ys2) rem)
-      | ((_,_,t),Some e1,Some e2)::rem ->
+      | ((_,_,t),(_,Some e1),(_,Some e2))::rem ->
         let t = Tt.instantiate_ty vs t
         and e1 = Tt.instantiate ys1 e1
         and e2 = Tt.instantiate ys2 e2 in
@@ -152,7 +152,7 @@ let equal_signature ~loc ctx (s1,shares1) (s2,shares2) =
         Opt.locally (equal ctx e1 e2 t) >?= fun (ctx,hyps') ->
         let hyps = AtomSet.union hyps hyps' in
         fold ctx hyps yts (e1::vs) ys1 ys2 rem
-      | (_,None,Some _)::_ | (_,Some _,None)::_ -> Opt.fail
+      | (_,(_,None),(_,Some _))::_ | (_,(_,Some _),(_,None))::_ -> Opt.fail
     in
     fold ctx AtomSet.empty [] [] [] [] (list_combine3 s_def shares1 shares2)
   else
@@ -292,7 +292,7 @@ let extensionality ~loc ctx e1 e2 (Tt.Ty t') =
        [projs] instantiate constraints *)
     let rec fold ctx hyps es projs = function
         | [] -> Opt.return ctx
-        | ((l, _, t), None) :: rem ->
+        | ((l, _, t), (_,None)) :: rem ->
           let t = Tt.instantiate_ty es t in
           let e1_proj = Tt.mk_projection ~loc:e1.Tt.loc e1 s' l in
           let e2_proj = Tt.mk_projection ~loc:e2.Tt.loc e2 s' l in
@@ -300,7 +300,7 @@ let extensionality ~loc ctx e1 e2 (Tt.Ty t') =
           Opt.locally (equal ctx e1_proj e2_proj t) >?= fun (ctx, hyps') ->
           let hyps = AtomSet.union hyps hyps' in
           fold ctx hyps (e1_proj :: es) (e1_proj :: projs) rem
-        | (_,Some e) :: rem ->
+        | (_,(_,Some e)) :: rem ->
           let e = Tt.instantiate projs e in
           fold ctx hyps (e::es) projs rem
     in

--- a/src/nucleus/equal.ml
+++ b/src/nucleus/equal.ml
@@ -136,14 +136,14 @@ let equal_signature ~loc ctx (s1,shares1) (s2,shares2) =
       | [] ->
         context_multiabstract ~loc ctx yts >!= fun ctx ->
         Opt.return ctx
-      | ((_,_,t),(x,None),(_,None))::rem ->
+      | ((_,_,t),(Tt.Inl x),(Tt.Inl _))::rem ->
         let t = Tt.instantiate_ty vs t in
         let jt = Jdg.mk_ty ctx t in
         Opt.add_abstracting ~loc x jt (fun ctx y ->
         let y1 = Tt.mk_atom ~loc y in
         let y2 = Tt.mention_atoms hyps y1 in
         fold ctx hyps ((y,t)::yts) (y1::vs) (y1::ys1) (y2::ys2) rem)
-      | ((_,_,t),(_,Some e1),(_,Some e2))::rem ->
+      | ((_,_,t),(Tt.Inr e1),(Tt.Inr e2))::rem ->
         let t = Tt.instantiate_ty vs t
         and e1 = Tt.instantiate ys1 e1
         and e2 = Tt.instantiate ys2 e2 in
@@ -152,7 +152,7 @@ let equal_signature ~loc ctx (s1,shares1) (s2,shares2) =
         Opt.locally (equal ctx e1 e2 t) >?= fun (ctx,hyps') ->
         let hyps = AtomSet.union hyps hyps' in
         fold ctx hyps yts (e1::vs) ys1 ys2 rem
-      | (_,(_,None),(_,Some _))::_ | (_,(_,Some _),(_,None))::_ -> Opt.fail
+      | (_,Tt.Inl _,Tt.Inr _)::_ | (_,Tt.Inr _,Tt.Inl _)::_ -> Opt.fail
     in
     fold ctx AtomSet.empty [] [] [] [] (list_combine3 s_def shares1 shares2)
   else
@@ -292,7 +292,7 @@ let extensionality ~loc ctx e1 e2 (Tt.Ty t') =
        [projs] instantiate constraints *)
     let rec fold ctx hyps es projs = function
         | [] -> Opt.return ctx
-        | ((l, _, t), (_,None)) :: rem ->
+        | ((l, _, t), Tt.Inl _) :: rem ->
           let t = Tt.instantiate_ty es t in
           let e1_proj = Tt.mk_projection ~loc:e1.Tt.loc e1 s' l in
           let e2_proj = Tt.mk_projection ~loc:e2.Tt.loc e2 s' l in
@@ -300,7 +300,7 @@ let extensionality ~loc ctx e1 e2 (Tt.Ty t') =
           Opt.locally (equal ctx e1_proj e2_proj t) >?= fun (ctx, hyps') ->
           let hyps = AtomSet.union hyps hyps' in
           fold ctx hyps (e1_proj :: es) (e1_proj :: projs) rem
-        | (_,(_,Some e)) :: rem ->
+        | (_,Tt.Inr e) :: rem ->
           let e = Tt.instantiate projs e in
           fold ctx hyps (e::es) projs rem
     in

--- a/src/nucleus/equal.mli
+++ b/src/nucleus/equal.mli
@@ -44,5 +44,5 @@ val as_eq : Jdg.ty -> (Context.t * Tt.ty * Tt.term * Tt.term) Monad.t
 val as_prod : Jdg.ty -> (Context.t * Tt.ty Tt.ty_abstraction) Monad.t
 
 (** Convert a type to a signature. *)
-val as_signature : Jdg.ty -> (Context.t * Name.signature) Monad.t
+val as_signature : Jdg.ty -> (Context.t * Tt.signature) Monad.t
 

--- a/src/nucleus/eval.ml
+++ b/src/nucleus/eval.ml
@@ -530,7 +530,7 @@ and check ((c',loc) as c) (Jdg.Ty (ctx_check, t_check') as t_check) : (Context.t
         | None ->
            Value.print_term >>= fun pte ->
            Value.print_ty >>= fun pty ->
-           Error.typing ~loc:(e.Tt.loc)
+           Error.typing ~loc
                         "the expression %t should have type@ %t@ but has type@ %t"
                         (pte e) (pty t_check') (pty t')
       end
@@ -545,7 +545,7 @@ and check ((c',loc) as c) (Jdg.Ty (ctx_check, t_check') as t_check) : (Context.t
               | None ->
                  Value.print_term >>= fun pte ->
                  Value.print_ty >>= fun pty ->
-                 Error.typing ~loc:(e'.Tt.loc)
+                 Error.typing ~loc
                               "the expression %t should have type@ %t@ but has type@ %t"
                               (pte e') (pty t_check') (pty t')
             end

--- a/src/nucleus/eval.ml
+++ b/src/nucleus/eval.ml
@@ -267,11 +267,11 @@ let rec infer (c',loc) =
             let je = Jdg.mk_term ctx e t in
             let e_abs = Tt.abstract ys e in
             Value.add_bound x (Value.mk_term je)
-            (fold ctx ((x,Some e_abs) :: vs) (e::es) ys ts rem)
+            (fold ctx ((Tt.Inr e_abs) :: vs) (e::es) ys ts rem)
           | None ->
             Value.add_abstracting ~loc x jt (fun ctx y ->
             let ey = Tt.mk_atom ~loc y in
-            fold ctx ((x,None)::vs) (ey::es) (y::ys) (t::ts) rem)
+            fold ctx ((Tt.Inl x)::vs) (ey::es) (y::ys) (t::ts) rem)
         end
     in
     Value.lookup_signature ~loc s >>= fun def ->
@@ -279,11 +279,11 @@ let rec infer (c',loc) =
 
   | Syntax.Structure (s, xcs) ->
     (* In infer mode the structure must be fully specified. *)
-    let rec fold ctx nones es xcs lxts =
+    let rec fold ctx shares es xcs lxts =
       match xcs, lxts with
         | [], [] ->
           let es = List.rev es in
-          let s = (s,List.rev nones) in
+          let s = (s,List.rev shares) in
           let str = Tt.mk_structure ~loc s es in
           let t_str = Tt.mk_signature_ty ~loc s in
           let j_str = Jdg.mk_term ctx str t_str in
@@ -294,7 +294,7 @@ let rec infer (c',loc) =
           let jty = Jdg.mk_ty ctx t_inst in
           check c jty >>= fun (ctx, e) ->
           Value.add_bound x (Value.mk_term (Jdg.mk_term ctx e t_inst))
-          (fold ctx ((x,None)::nones) (e::es) xcs lxts)
+          (fold ctx ((Tt.Inl x)::shares) (e::es) xcs lxts)
 
         | (_,None) :: _, (l,_,_) :: _ ->
           Error.runtime ~loc "missing field value for %t" (Name.print_ident l)
@@ -365,7 +365,7 @@ let rec infer (c',loc) =
   | Syntax.GenSig (c1,c2) ->
     check_ty c1 >>= fun j1 ->
     Equal.Monad.run (Equal.as_signature j1) >>= fun ((_,(s,shares)),_) ->
-    if List.for_all (fun (_,share) -> share = None) shares
+    if List.for_all (function | Tt.Inl _ -> true | Tt.Inr _ -> false) shares
     then
       infer c2 >>= as_list ~loc >>= fun xes ->
       Value.lookup_signature ~loc s >>= fun def ->
@@ -380,7 +380,7 @@ let rec infer (c',loc) =
           Value.return_term j
         | (l,_,t)::def, xe::xes ->
           begin match Value.as_sum ~loc xe with
-            | Value.Inl vx ->
+            | Tt.Inl vx ->
               as_atom ~loc vx >>= fun (ctx',y,ty) ->
               let t = Tt.instantiate_ty es t in
               (* TODO use handled equal? *)
@@ -390,19 +390,19 @@ let rec infer (c',loc) =
                 let ctx = Context.join ~penv ~loc ctx ctx' in
                 let ey = Tt.mk_atom ~loc y in
                 let x = Name.ident_of_atom y in
-                fold ctx ((x,None)::vs) (ey::es) (y::ys) (t::ts) def xes
+                fold ctx ((Tt.Inl x)::vs) (ey::es) (y::ys) (t::ts) def xes
               else
                 Value.print_ty >>= fun pty ->
                 Error.typing ~loc "bad non-constraint for field %t: types %t and %t do not match"
                   (Name.print_ident l) (pty t) (pty ty)
-            | Value.Inr ve ->
+            | Tt.Inr ve ->
               as_term ~loc ve >>= fun (Jdg.Term (ctx',e,te)) ->
               let t = Tt.instantiate_ty es t in
               require_equal_ty ~loc (Jdg.mk_ty ctx t) (Jdg.mk_ty ctx' te) >>= begin function
                 | Some (ctx,hyps) ->
                   let e = Tt.mention_atoms hyps e in
                   let e_abs = Tt.abstract ys e in
-                  fold ctx ((l,Some e_abs) :: vs) (e::es) ys ts def xes
+                  fold ctx ((Tt.Inr e_abs) :: vs) (e::es) ys ts def xes
                 | None ->
                   Value.print_ty >>= fun pty ->
                   Error.typing ~loc "bad constraint for field %t: types %t and %t do not match"
@@ -429,7 +429,7 @@ let rec infer (c',loc) =
         let e = Tt.mention_atoms hyps e in
         let j = Jdg.mk_term ctx e target in
         Value.return_term j
-      | ((l,_,t),(_,None))::s_data,v::vs ->
+      | ((l,_,t),Tt.Inl _)::s_data,v::vs ->
         as_term ~loc v >>= fun (Jdg.Term (ctx',e,te)) ->
         let t = Tt.instantiate_ty es t in
         require_equal_ty ~loc (Jdg.mk_ty ctx t) (Jdg.mk_ty ctx' te) >>= begin function
@@ -441,10 +441,10 @@ let rec infer (c',loc) =
             Error.typing ~loc "bad field %t: types %t and %t do not match"
               (Name.print_ident l) (pty t) (pty te)
         end
-      | ((_,_,t),(_,Some e))::s_data, vs ->
+      | ((_,_,t),Tt.Inr e)::s_data, vs ->
         let e = Tt.instantiate res e in
         fold ctx res (e::es) vs s_data
-      | (_,(_,None))::_,[] ->
+      | (_,Tt.Inl _)::_,[] ->
         Error.runtime ~loc "too few fields"
       | [], _::_ ->
         Error.runtime ~loc "too many fields"
@@ -622,22 +622,22 @@ and check ((c',loc) as c) (Jdg.Ty (ctx_check, t_check') as t_check) : (Context.t
           let e = Tt.mk_structure ~loc s_sig res in
           let e = Tt.mention_atoms hyps e in
           Value.return (ctx,e)
-        | ((_,_,t),(_,Some e),(x,None))::rem ->
+        | ((_,_,t),Tt.Inr e,(x,None))::rem ->
           let e = Tt.instantiate res e
           and t = Tt.instantiate_ty es t in
           let j = Jdg.mk_term ctx e t in
           Value.add_bound x (Value.mk_term j)
           (fold ctx res (e::es) rem)
-        | ((_,_,t),(_,None),(x,Some c))::rem ->
+        | ((_,_,t),Tt.Inl _,(x,Some c))::rem ->
           let t = Tt.instantiate_ty es t in
           let jt = Jdg.mk_ty ctx t in
           check c jt >>= fun (ctx,e) ->
           let j = Jdg.mk_term ctx e t in
           Value.add_bound x (Value.mk_term j)
           (fold ctx (e::res) (e::es) rem)
-        | ((l,_,_),(_,None),(_,None))::rem ->
+        | ((l,_,_),Tt.Inl _,(_,None))::rem ->
           Error.runtime ~loc "Field %t must be specified" (Name.print_ident l)
-        | ((l,_,_),(_,Some _),(_,Some _))::rem ->
+        | ((l,_,_),Tt.Inr _,(_,Some _))::rem ->
           Error.runtime ~loc "Field %t is constrained and must not be specified" (Name.print_ident l)
       in
       fold ctx [] [] (list_combine3 s_def shares xcs)

--- a/src/nucleus/eval.ml
+++ b/src/nucleus/eval.ml
@@ -649,7 +649,9 @@ and match_cases ~loc cases v =
 and match_op_cases ~loc op cases vs checking =
   let rec fold = function
     | [] ->
-      Value.operation op vs
+      Value.operation op vs >>= fun v ->
+      Value.lookup_continuation ~loc >>= fun k ->
+      Value.apply_closure k v
     | (xs, ps, pt, c) :: cases ->
       Matching.match_op_pattern ps pt vs checking >>= begin function
         | Some vs ->

--- a/src/nucleus/external.ml
+++ b/src/nucleus/external.ml
@@ -14,6 +14,18 @@ let externals =
           Value.return_unit
         )) ;
 
+    ("print_signature", fun loc ->
+      Value.return_closure (fun v ->
+          let Jdg.Term (_,e,_) = Value.as_term ~loc v in
+          match e.Tt.term with
+            | Tt.Signature (s,_) ->
+              Value.lookup_signature ~loc s >>= fun s_def ->
+              Value.lookup_penv >>= fun penv ->
+              Format.printf "%t = {@[<hv>%t@]}@." (Name.print_ident s) (Tt.print_sig_def ~penv s_def) ;
+              Value.return_unit
+            | _ -> Error.runtime ~loc "this term should be a signature"
+        )) ;
+
     ("time", fun loc ->
       Value.return_closure (fun _ ->
         let time = ref 0. in

--- a/src/nucleus/matching.ml
+++ b/src/nucleus/matching.ml
@@ -165,20 +165,19 @@ let rec collect_tt_pattern env xvs (p',_) ctx ({Tt.term=e';loc;_} as e) t =
     begin match Value.get_signature (fst s) env with
       | Some s_def ->
         (* build the list of explicit terms
-           [es] instantiate the types, [exs] the constraints *)
-        let rec fold vs es exs = function
+           [es] instantiate the types *)
+        let rec fold vs es = function
           | [] -> Value.from_list (List.rev vs)
           | ((_,_,t),e)::rem ->
             let t = Tt.instantiate_ty es t
-            and e,exs = match e with
-              | Tt.Explicit e -> e,e::exs
-              | Tt.Shared e -> Tt.instantiate exs e,exs
+            and e = match e with
+              | Tt.Explicit e | Tt.Shared e -> e
             in
             let je = Jdg.mk_term ctx e t in
             let v = Value.mk_term je in
-            fold (v::vs) (e::es) exs rem
+            fold (v::vs) (e::es) rem
         in
-        let lv = fold [] [] [] (List.combine s_def (Tt.struct_combine ~loc str)) in
+        let lv = fold [] [] (List.combine s_def (Tt.struct_combine ~loc str)) in
         collect_pattern env xvs lp lv
 
       | None -> Error.impossible ~loc "matching structure of unknown signature %t" (Name.print_ident (fst s))

--- a/src/nucleus/matching.ml
+++ b/src/nucleus/matching.ml
@@ -123,16 +123,16 @@ let rec collect_tt_pattern env xvs (p',_) ctx ({Tt.term=e';loc;_} as e) t =
     begin match Value.get_signature s env with
       | Some s_def ->
         (* first build a representation of the signature definition *)
-        let rec fold ctx nones res ys = function
+        let rec fold ctx shares res ys = function
           | [] ->
-            let js = Jdg.term_of_ty (Jdg.mk_ty Context.empty (Tt.mk_signature_ty ~loc (s,List.rev nones))) in
+            let js = Jdg.term_of_ty (Jdg.mk_ty Context.empty (Tt.mk_signature_ty ~loc (s,List.rev shares))) in
             Value.mk_tuple [Value.mk_term js;Value.from_list (List.rev res)]
           | (l,x,t)::rem ->
             let t = Tt.unabstract_ty ys t in
             let y,ctx = Context.add_fresh ctx x t in
             let jy = Jdg.mk_term ctx (Tt.mk_atom ~loc y) t in
             let v = Value.mk_tuple [Value.mk_ident l;Value.mk_term jy] in
-            fold ctx ((x,None)::nones) (v::res) (y::ys) rem
+            fold ctx ((Tt.Inl x)::shares) (v::res) (y::ys) rem
         in
         let vbase = fold Context.empty [] [] [] s_def in
         (* Build a representation of the constraints *)
@@ -140,18 +140,18 @@ let rec collect_tt_pattern env xvs (p',_) ctx ({Tt.term=e';loc;_} as e) t =
           | [] ->
             let lv = Value.from_list (List.rev lv) in
             Value.mk_tuple [vbase;lv]
-          | ((_,_,t),(x,None))::rem ->
+          | ((_,_,t),(Tt.Inl x))::rem ->
             let t = Tt.instantiate_ty es t in
             let y,ctx = Context.add_fresh ctx x t in
             let y = Tt.mk_atom ~loc y in
             let jy = Jdg.mk_term ctx y t in
-            let v = Value.from_sum (Value.Inl (Value.mk_term jy)) in
+            let v = Value.from_sum (Tt.Inl (Value.mk_term jy)) in
             fold ctx (v::lv) (y::es) (y::ys) rem
-          | ((_,_,t),(_,Some e))::rem ->
+          | ((_,_,t),(Tt.Inr e))::rem ->
             let t = Tt.instantiate_ty es t
             and e = Tt.instantiate ys e in
             let je = Jdg.mk_term ctx e t in
-            let v = Value.from_sum (Value.Inr (Value.mk_term je)) in
+            let v = Value.from_sum (Tt.Inr (Value.mk_term je)) in
             fold ctx (v::lv) (e::es) ys rem
         in
         let v = fold ctx [] [] [] (List.combine s_def shares) in

--- a/src/nucleus/simplify.ml
+++ b/src/nucleus/simplify.ml
@@ -113,12 +113,12 @@ and apply ~loc env h x a b e =
 and project ~loc env e s l =
   let e = term env e in
   match e.Tt.term with
-    | Tt.Structure (s',es) when Name.eq_ident s s' ->
-      begin match Value.get_signature s env with
+    | Tt.Structure ((s',_) as str) when Tt.alpha_equal_sig s s' ->
+      begin match Value.get_signature (fst s) env with
         | Some s_def ->
-          Tt.field_value ~loc s_def es l
+          Tt.field_value ~loc s_def str l
         | None ->
-          Error.impossible ~loc "unknown signature %t encountered in Simplify.project" (Name.print_ident s)
+          Error.impossible ~loc "unknown signature %t encountered in Simplify.project" (Name.print_ident (fst s))
       end
 
     | Tt.Constant _

--- a/src/nucleus/tt.ml
+++ b/src/nucleus/tt.ml
@@ -637,8 +637,10 @@ and print_share ~penv lshare ppf = match lshare with
 and print_shares ~penv lshares ppf = match lshares with
   | [] -> ()
   | [lshare] -> print_share ~penv lshare ppf
-  | ((_,(x,_)) as lshare) :: lshares ->
+  | ((_,(x,None)) as lshare) :: lshares ->
     Format.fprintf ppf "%t and %t" (print_share ~penv lshare) (print_shares ~penv:(add_forbidden x penv) lshares)
+  | ((_,(_,Some _)) as lshare) :: lshares ->
+    Format.fprintf ppf "%t and %t" (print_share ~penv lshare) (print_shares ~penv lshares)
 
 and print_sig ~penv (s,shares) ppf =
   if List.for_all (fun (_,x) -> x = None) shares then Name.print_ident s ppf

--- a/src/nucleus/tt.ml
+++ b/src/nucleus/tt.ml
@@ -627,7 +627,7 @@ and print_sig_def ~penv xts ppf =
 
 and print_share ~penv lshare next ppf = match lshare with
   | l,None -> next (add_forbidden l penv) ppf
-  | l, Some e -> Format.fprintf ppf "%t = %t;%t" (Name.print_ident l) (print_term ~penv e) (next penv)
+  | l, Some e -> Format.fprintf ppf "%t = %t and %t" (Name.print_ident l) (print_term ~penv e) (next penv)
 
 (* TODO fix printing, esp bound variables *)
 and print_shares ~penv lshares ppf = match lshares with
@@ -638,7 +638,7 @@ and print_shares ~penv lshares ppf = match lshares with
 and print_sig ~penv (s,shares) ppf =
   if List.for_all (fun x -> x = None) shares then Name.print_ident s ppf
   else
-  Print.print ppf "%t with %t" (Name.print_ident s) (print_shares ~penv (List.combine (penv.sigs s) shares))
+  Print.print ppf "%t using %t end" (Name.print_ident s) (print_shares ~penv (List.combine (penv.sigs s) shares))
 
 and print_structure_clause ~penv (l,e) ppf =
   Format.fprintf ppf "@[<hov>%t@ =@ %t@]"

--- a/src/nucleus/tt.ml
+++ b/src/nucleus/tt.ml
@@ -636,7 +636,7 @@ and print_shares ~penv lshares ppf = match lshares with
   | lshare :: lshares -> print_share ~penv lshare (fun penv -> print_shares ~penv lshares) ppf
 
 and print_sig ~penv (s,shares) ppf =
-  if shares = [] then Name.print_ident s ppf
+  if List.for_all (fun x -> x = None) shares then Name.print_ident s ppf
   else
   Print.print ppf "%t with %t" (Name.print_ident s) (print_shares ~penv (List.combine (penv.sigs s) shares))
 

--- a/src/nucleus/tt.mli
+++ b/src/nucleus/tt.mli
@@ -1,5 +1,9 @@
 (** Abstract syntax of value types and terms *)
 
+type ('a,'b) sum =
+  | Inl of 'a
+  | Inr of 'b
+
 (** An [('a, 'b) abstraction] is a ['b] bound by (x, 'a) *)
 type ('a, 'b) abstraction = (Name.ident * 'a) * 'b
 
@@ -62,9 +66,10 @@ and 'a ty_abstraction = (ty, 'a) abstraction
 and sig_def = (Name.label * Name.ident * ty) list
 
 (** A signature with sharing constraints [s with li = vi], the [li] are implicit.
-    [vi] is [None] when [li] has no constraint, [Some ei] when it has one.
-    In that case the previous non-constrained labels are bound in [ei]. *)
-and signature = Name.signature * (Name.ident * term option) list
+    [vi] is [Inl xi] when [li] has no constraint, then [xi] is bound in future constraints,
+            [Inr ei] when it has one.
+*)
+and signature = Name.signature * (Name.ident, term) sum list
 
 (** A structure [s,es] where [es] are the values of the non constrained fields of [s].
     The [es] do not bind labels. *)

--- a/src/nucleus/tt.mli
+++ b/src/nucleus/tt.mli
@@ -152,7 +152,7 @@ type struct_field =
   | Shared of term
   | Explicit of term
 
-(* TODO should this instantiate the constraints? *)
+(** Return the list of terms defining the structure, with constraints fully instantiated. *)
 val struct_combine : loc:Location.t -> structure -> struct_field list
 
 (** Makes the projection, even when the field is constrained. *)

--- a/src/nucleus/tt.mli
+++ b/src/nucleus/tt.mli
@@ -40,14 +40,15 @@ and term' = private
   | Refl of ty * term
 
   (** signature, also known as structure type *)
-  | Signature of Name.signature
+  | Signature of signature
 
   (** structure, also known as record or module *)
   | Structure of structure
 
-  (** a projection [e s .xi] means that we project field [xi] of [e] and [e] has type
-      [Signature s]. *)
-  | Projection of term * Name.signature * Name.label
+  (** a projection [e s .li] means that we project field [li] of [e]
+      where [e] has type [Signature s].
+      [li] must not be a constrained field of [s]. *)
+  | Projection of term * signature * Name.label
 
 (** Since we have [Type : Type] we do not distinguish terms from types,
     so the type of type [ty] is just a synonym for the type of terms.
@@ -58,9 +59,16 @@ and ty = private
 (** A ['a ty_abstraction] is a n abstraction where the [a1, ..., an] are types *)
 and 'a ty_abstraction = (ty, 'a) abstraction
 
-and signature = (Name.label * Name.ident * ty) list
+and sig_def = (Name.label * Name.ident * ty) list
 
-and structure = Name.signature * term list
+(** A signature with sharing constraints [s with li = vi], the [li] are implicit.
+    [vi] is [None] when [li] has no constraint, [Some ei] when it has one.
+    In that case the previous non-constrained labels are bound in [ei]. *)
+and signature = Name.signature * term option list
+
+(** A structure [s,es] where [es] are the values of the non constrained fields of [s].
+    The [es] do not bind labels. *)
+and structure = signature * term list
 
 (** Term constructors, these do not check for legality of constructions. *)
 val mk_atom: loc:Location.t -> Name.atom -> term
@@ -74,10 +82,10 @@ val mk_prod_ty: loc:Location.t -> Name.ident -> ty -> ty -> ty
 val mk_eq: loc:Location.t -> ty -> term -> term -> term
 val mk_eq_ty: loc:Location.t -> ty -> term -> term -> ty
 val mk_refl: loc:Location.t -> ty -> term -> term
-val mk_signature : loc:Location.t -> Name.signature -> term
-val mk_signature_ty : loc:Location.t -> Name.signature -> ty
-val mk_structure : loc:Location.t -> Name.signature -> term list -> term
-val mk_projection : loc:Location.t -> term -> Name.signature -> Name.ident -> term
+val mk_signature : loc:Location.t -> signature -> term
+val mk_signature_ty : loc:Location.t -> signature -> ty
+val mk_structure : loc:Location.t -> signature -> term list -> term
+val mk_projection : loc:Location.t -> term -> signature -> Name.ident -> term
 
 (** Coerce a value to a type (does not check whether this is legal). *)
 val ty : term -> ty
@@ -133,15 +141,20 @@ val assumptions_term : term -> Name.AtomSet.t
 (** The assumptions used by a type. *)
 val assumptions_ty : ty -> Name.AtomSet.t
 
-(** Module stuff *)
+(** Structure stuff *)
 
-(** [field_value s_def lst p] returns the value of field [p] in the record [lst]
-    whose type is described by the signature definition [s_def]. *)
-val field_value : loc:Location.t -> signature -> term list -> Name.label -> term
+type struct_field =
+  | Shared of term
+  | Explicit of term
+
+val struct_combine : loc:Location.t -> structure -> struct_field list
+
+(** Makes the projection, even when the field is constrained. *)
+val field_value : loc:Location.t -> sig_def -> structure -> Name.label -> term
 
 (** [field_type s s_def e p] where [e : Signature s] and [s_def] is the definition
     of [s] computes the type of [e.p] *)
-val field_type : loc:Location.t -> Name.signature -> signature -> term -> Name.label -> ty
+val field_type : loc:Location.t -> sig_def -> signature -> term -> Name.label -> ty
 
 (** [alpha_equal e1 e2] returns [true] if term [e1] and [e2] are alpha equal. *)
 val alpha_equal: term -> term -> bool
@@ -149,11 +162,13 @@ val alpha_equal: term -> term -> bool
 (** [alpha_equal_ty t1 t2] returns [true] if types [t1] and [t2] are alpha equal. *)
 val alpha_equal_ty: ty -> ty -> bool
 
+val alpha_equal_sig : signature -> signature -> bool
+
 type print_env =
   { forbidden : Name.ident list ;
     sigs : Name.signature -> Name.label list }
 
 val print_ty : ?max_level:int -> penv:print_env -> ty -> Format.formatter -> unit
 val print_term : ?max_level:int -> penv:print_env -> term -> Format.formatter -> unit
-val print_signature : penv:print_env -> signature -> Format.formatter -> unit
+val print_sig_def : penv:print_env -> sig_def -> Format.formatter -> unit
 

--- a/src/nucleus/tt.mli
+++ b/src/nucleus/tt.mli
@@ -154,8 +154,8 @@ val struct_combine : loc:Location.t -> structure -> struct_field list
 val field_value : loc:Location.t -> sig_def -> structure -> Name.label -> term
 
 (** [field_type s s_def e p] where [e : Signature s] and [s_def] is the definition
-    of [s] computes the type of [e.p] *)
-val field_type : loc:Location.t -> sig_def -> signature -> term -> Name.label -> ty
+    of [s] computes the value and type of [e.p], taking it from the constraints if possible. *)
+val field_project : loc:Location.t -> sig_def -> signature -> term -> Name.label -> term*ty
 
 (** [alpha_equal e1 e2] returns [true] if term [e1] and [e2] are alpha equal. *)
 val alpha_equal: term -> term -> bool

--- a/src/nucleus/tt.mli
+++ b/src/nucleus/tt.mli
@@ -147,6 +147,7 @@ type struct_field =
   | Shared of term
   | Explicit of term
 
+(* TODO should this instantiate the constraints? *)
 val struct_combine : loc:Location.t -> structure -> struct_field list
 
 (** Makes the projection, even when the field is constrained. *)

--- a/src/nucleus/tt.mli
+++ b/src/nucleus/tt.mli
@@ -64,6 +64,7 @@ and sig_def = (Name.label * Name.ident * ty) list
 (** A signature with sharing constraints [s with li = vi], the [li] are implicit.
     [vi] is [None] when [li] has no constraint, [Some ei] when it has one.
     In that case the previous non-constrained labels are bound in [ei]. *)
+(* TODO keep the idents from syntax for printing purposes *)
 and signature = Name.signature * term option list
 
 (** A structure [s,es] where [es] are the values of the non constrained fields of [s].

--- a/src/nucleus/tt.mli
+++ b/src/nucleus/tt.mli
@@ -64,8 +64,7 @@ and sig_def = (Name.label * Name.ident * ty) list
 (** A signature with sharing constraints [s with li = vi], the [li] are implicit.
     [vi] is [None] when [li] has no constraint, [Some ei] when it has one.
     In that case the previous non-constrained labels are bound in [ei]. *)
-(* TODO keep the idents from syntax for printing purposes *)
-and signature = Name.signature * term option list
+and signature = Name.signature * (Name.ident * term option) list
 
 (** A structure [s,es] where [es] are the values of the non constrained fields of [s].
     The [es] do not bind labels. *)

--- a/src/nucleus/value.ml
+++ b/src/nucleus/value.ml
@@ -1,9 +1,5 @@
 (** Runtime values and results *)
 
-type ('a,'b) sum =
-  | Inl of 'a
-  | Inr of 'b
-
 (* Information about a toplevel declaration *)
 type decl =
   | DeclConstant of Tt.ty
@@ -222,8 +218,8 @@ let as_option ~loc = function
     Error.runtime ~loc "expected an option but got %s" (name_of v)
 
 let as_sum ~loc = function
-  | Tag (t,[x]) when (Name.eq_ident t name_inl) -> Inl x
-  | Tag (t,[x]) when (Name.eq_ident t name_inr) -> Inr x
+  | Tag (t,[x]) when (Name.eq_ident t name_inl) -> Tt.Inl x
+  | Tag (t,[x]) when (Name.eq_ident t name_inr) -> Tt.Inr x
   | (Term _ | Closure _ | Handler _ | Tag _ | List _ | Tuple _ | Ref _ | String _ | Ident _) as v ->
     Error.runtime ~loc "expected a sum but got %s" (name_of v)
 
@@ -240,8 +236,8 @@ let from_option = function
 let from_list lst = List lst
 
 let from_sum = function
-  | Inl x -> Tag (name_inl, [x])
-  | Inr x -> Tag (name_inr, [x])
+  | Tt.Inl x -> Tag (name_inl, [x])
+  | Tt.Inr x -> Tag (name_inr, [x])
 
 let list_nil = List []
 

--- a/src/nucleus/value.ml
+++ b/src/nucleus/value.ml
@@ -73,8 +73,8 @@ type 'a toplevel = env -> 'a*env
 let name_some = Name.make "Some"
 let name_none = Name.make "None"
 let name_unit = Name.make "tt"
-let name_inl  = Name.make "inl"
-let name_inr  = Name.make "inr"
+let name_inl  = Name.make "Inl"
+let name_inr  = Name.make "Inr"
 
 let predefined_tags = [
   (name_some, 1);

--- a/src/nucleus/value.ml
+++ b/src/nucleus/value.ml
@@ -5,7 +5,7 @@ type decl =
   | DeclConstant of Tt.ty
   | DeclData of int
   | DeclOperation of int
-  | DeclSignature of Tt.signature
+  | DeclSignature of Tt.sig_def
 
 type dynamic = {
   decls : (Name.ident * decl) list ;
@@ -508,8 +508,8 @@ let print_env env =
                           k
         | (x, DeclSignature s) ->
            Format.fprintf ppf "@[<hov 4>signature %t %t@]@\n"
-                          (Name.print_ident x)
-                          (Tt.print_signature ~penv s)
+                       (Name.print_ident x)
+                       (Tt.print_sig_def ~penv s)
       )
       (List.rev env.dynamic.decls) ;
   in

--- a/src/nucleus/value.mli
+++ b/src/nucleus/value.mli
@@ -1,5 +1,9 @@
 (** Runtime values and results *)
 
+type ('a,'b) sum =
+  | Inl of 'a
+  | Inr of 'b
+
 (* Information about a toplevel declaration *)
 type decl =
   | DeclConstant of Tt.ty
@@ -101,10 +105,12 @@ val as_ident : loc:Location.t -> value -> Name.ident
 
 val as_option : loc:Location.t -> value -> value option
 val as_list : loc:Location.t -> value -> value list
+val as_sum : loc:Location.t -> value -> (value,value) sum
 
 (** Wrappers for making tags *)
 val from_option : value option -> value
 val from_list : value list -> value
+val from_sum : (value,value) sum -> value
 
 val list_nil : value
 val list_cons : value -> value list -> value

--- a/src/nucleus/value.mli
+++ b/src/nucleus/value.mli
@@ -1,9 +1,5 @@
 (** Runtime values and results *)
 
-type ('a,'b) sum =
-  | Inl of 'a
-  | Inr of 'b
-
 (* Information about a toplevel declaration *)
 type decl =
   | DeclConstant of Tt.ty
@@ -105,12 +101,12 @@ val as_ident : loc:Location.t -> value -> Name.ident
 
 val as_option : loc:Location.t -> value -> value option
 val as_list : loc:Location.t -> value -> value list
-val as_sum : loc:Location.t -> value -> (value,value) sum
+val as_sum : loc:Location.t -> value -> (value,value) Tt.sum
 
 (** Wrappers for making tags *)
 val from_option : value option -> value
 val from_list : value list -> value
-val from_sum : (value,value) sum -> value
+val from_sum : (value,value) Tt.sum -> value
 
 val list_nil : value
 val list_cons : value -> value list -> value

--- a/src/nucleus/value.mli
+++ b/src/nucleus/value.mli
@@ -5,7 +5,7 @@ type decl =
   | DeclConstant of Tt.ty
   | DeclData of int
   | DeclOperation of int
-  | DeclSignature of Tt.signature
+  | DeclSignature of Tt.sig_def
 
 (** Runtime environment *)
 type env
@@ -144,10 +144,10 @@ val get_data : Name.ident -> env -> int option
 val lookup_constant : loc:Location.t -> Name.ident -> Tt.ty result
 
 (** Lookup a signature definition *)
-val get_signature : Name.signature -> env -> Tt.signature option
+val get_signature : Name.signature -> env -> Tt.sig_def option
 
 (** Lookup a signature definition, monadically *)
-val lookup_signature : loc:Location.t -> Name.ident -> Tt.signature result
+val lookup_signature : loc:Location.t -> Name.ident -> Tt.sig_def result
 
 (** Find a signature with the given labels (in this exact order) *)
 val find_signature : env -> Name.label list -> Name.signature option
@@ -191,7 +191,7 @@ val add_constant : loc:Location.t -> Name.ident -> Tt.ty -> unit toplevel
 
 (** Add a signature declaration to the environment.
   Fails if the signature is already declared. *)
-val add_signature : loc:Location.t -> Name.signature -> Tt.signature -> unit toplevel
+val add_signature : loc:Location.t -> Name.signature -> Tt.sig_def -> unit toplevel
 
 (** Add a bound variable with the given name to the environment.
     Complain if then name is already used. *)

--- a/src/parser/input.mli
+++ b/src/parser/input.mli
@@ -23,12 +23,12 @@ and tt_pattern' =
   | Tt_Structure of (Name.label * tt_pattern) list
   | Tt_Projection of tt_pattern * Name.ident
   (** Generic matching *)
-  | Tt_GenSig of Name.ident option
-  | Tt_GenStruct of tt_pattern * Name.ident option
-  | Tt_GenProj of tt_pattern * Name.ident option
+  | Tt_GenSig of pattern
+  | Tt_GenStruct of tt_pattern * pattern
+  | Tt_GenProj of tt_pattern * pattern
   | Tt_GenAtom
 
-type pattern = pattern' * Location.t
+and pattern = pattern' * Location.t
 and pattern' =
   | Patt_Anonymous
   | Patt_As of pattern * Name.ident
@@ -71,14 +71,16 @@ and term' =
   | Prod of (Name.ident * ty) list * comp
   | Eq of comp * comp
   | Refl of comp
-  | Structure of (Name.ident * Name.ident option * comp) list
-  | Projection of comp * Name.ident
+  | Signature of Name.signature * (Name.label * Name.ident option * comp option) list
+  | Structure of (Name.label * Name.ident option * comp option) list
+  | Projection of comp * Name.label
   | Yield of comp
   | Hypotheses
   | Congruence of comp * comp
   | Extensionality of comp * comp
   | Reduction of comp
   | String of string
+  | GenSig of comp * comp
   | GenStruct of comp * comp
   | GenProj of comp * comp
   | Context of comp

--- a/src/parser/lexer.ml
+++ b/src/parser/lexer.ml
@@ -38,6 +38,7 @@ let reserved = [
   ("ref", REF) ;
   ("refl", REFL) ;
   ("signature", SIGNATURE) ;
+  ("using", USING) ;
   ("Type", TYPE) ;
   ("val", VAL) ;
   ("where", WHERE) ;

--- a/src/parser/parser.mly
+++ b/src/parser/parser.mly
@@ -156,7 +156,6 @@ plain_term:
   | HANDLER hcs=handler_cases END                              { Handler (hcs) }
   | e=app_term COLON t=ty_term                                 { Ascribe (e, t) }
   | e1=equal_term SEMICOLON e2=term                            { Sequence (e1, e2) }
-  | x=var_name USING cs=constraint_clauses END                 { Signature (x,cs) }
   | USIG c1=prefix_term c2=prefix_term                         { GenSig (c1,c2) }
   | USTRUCT c1=prefix_term c2=prefix_term                      { GenStruct (c1,c2) }
   | UPROJ c1=prefix_term c2=prefix_term                        { GenProj (c1,c2) }
@@ -173,6 +172,7 @@ plain_ty_term:
   | FUNCTION a=function_abstraction DARROW e=term    { Function (a, e) }
   | REC x=name a=function_abstraction DARROW e=term  { Rec (x, a, e) }
   | t1=equal_term ARROW t2=ty_term                   { Prod ([(Name.anonymous, t1)], t2) }
+  | x=var_name USING cs=constraint_clauses END                 { Signature (x,cs) }
 
 equal_term: mark_location(plain_equal_term) { $1 }
 plain_equal_term:

--- a/src/parser/parser.mly
+++ b/src/parser/parser.mly
@@ -41,6 +41,9 @@
 (* Let binding *)
 %token LET EQ AND IN
 
+(* Signatures *)
+%token USING
+
 (* Meta-level programming *)
 %token OPERATION
 %token DATA
@@ -153,6 +156,8 @@ plain_term:
   | HANDLER hcs=handler_cases END                              { Handler (hcs) }
   | e=app_term COLON t=ty_term                                 { Ascribe (e, t) }
   | e1=equal_term SEMICOLON e2=term                            { Sequence (e1, e2) }
+  | x=var_name USING cs=constraint_clauses END                 { Signature (x,cs) }
+  | USIG c1=prefix_term c2=prefix_term                         { GenSig (c1,c2) }
   | USTRUCT c1=prefix_term c2=prefix_term                      { GenStruct (c1,c2) }
   | UPROJ c1=prefix_term c2=prefix_term                        { GenProj (c1,c2) }
   | CONTEXT c=prefix_term                                      { Context c }
@@ -224,6 +229,15 @@ plain_simple_term:
   | e=simple_term DOT p=var_name                        { Projection (e, p) }
   | HYPOTHESES                                          { Hypotheses }
 
+constraint_clauses:
+| cs=separated_list(AND,constraint_clause) { cs }
+
+constraint_clause:
+  | l=var_name                      { (l,None,None) }
+  | l=var_name EQ c=term            { (l,None,Some c) }
+  | l=var_name AS y=name            { (l,Some y,None) }
+  | l=var_name AS y=name EQ c=term  { (l,Some y,Some c) }
+
 var_name:
   | NAME { $1 }
   | LPAREN op=PREFIXOP RPAREN  { fst op }
@@ -251,12 +265,14 @@ typed_names:
   | xs=name+ COLON t=ty_term  { List.map (fun x -> (x, t)) xs }
 
 signature_clause:
-  | x=name COLON t=ty_term           { (x, None, t) }
-  | x=name AS y=name COLON t=ty_term { (x, Some y, t) }
+  | x=var_name COLON t=ty_term           { (x, None, t) }
+  | x=var_name AS y=name COLON t=ty_term { (x, Some y, t) }
 
 structure_clause :
-  | x=name EQ c=term                           { (x, None, c) }
-  | x=name AS y=name EQ c=term                 { (x, Some y, c) }
+  | x=var_name                                     { (x, None, None) }
+  | x=var_name EQ c=term                           { (x, None, Some c) }
+  | x=var_name AS y=name                           { (x, Some y, None) }
+  | x=var_name AS y=name EQ c=term                 { (x, Some y, Some c) }
 
 binder:
   | LPAREN lst=separated_nonempty_list(COMMA, maybe_typed_names) RPAREN
@@ -412,9 +428,9 @@ prefix_tt_pattern: mark_location(plain_prefix_tt_pattern) { $1 }
 plain_prefix_tt_pattern:
   | p=plain_simple_tt_pattern                     { p }
   | REFL p=prefix_tt_pattern                      { Tt_Refl p }
-  | USIG x=patt_maybe_var                         { Tt_GenSig x }
-  | USTRUCT p=simple_tt_pattern x=patt_maybe_var  { Tt_GenStruct (p,x) }
-  | UPROJ p=simple_tt_pattern l=patt_maybe_var    { Tt_GenProj (p,l) }
+  | USIG x=simple_pattern                         { Tt_GenSig x }
+  | USTRUCT p=simple_tt_pattern x=simple_pattern  { Tt_GenStruct (p,x) }
+  | UPROJ p=simple_tt_pattern l=simple_pattern    { Tt_GenProj (p,l) }
   | op=PREFIXOP e=prefix_tt_pattern
     { let op = Tt_Name (fst op), snd op in Tt_Apply (op, e) }
 
@@ -444,10 +460,6 @@ plain_maybe_typed_tt_names:
 tt_name:
   | x=name                       { x, false }
   | x=patt_var                   { x, true  }
-
-patt_maybe_var:
-  | x=patt_var                   { Some x }
-  | UNDERSCORE                   { None }
 
 top_patt_maybe_var:
   | x=patt_var                   { x }

--- a/src/syntax.mli
+++ b/src/syntax.mli
@@ -71,15 +71,20 @@ and comp' =
   | Prod of Name.ident * comp * comp
   | Eq of comp * comp
   | Refl of comp
-  | Signature of Name.signature
-  | Structure of Name.signature * (Name.ident * comp) list
-  | Projection of comp * Name.ident
+  (** [s with li as xi = maybe ci] with every previous [xj] bound in [ci] (including the constrained ones) *)
+  | Signature of Name.signature * (Name.ident * comp option) list
+  (** [{ li as xi = maybe ci } : s with lj = ej] with previous [xj] bound in [ci].
+      Must be evaluated in checking mode unless fully explicit. *)
+  | Structure of Name.signature * (Name.ident * comp option) list
+  | Projection of comp * Name.label
   | Yield of comp
   | Hypotheses
   | Congruence of comp * comp
   | Extensionality of comp * comp
   | Reduction of comp
   | String of string
+  (** Inverts matching, except with just the name and not the definition of the signature *)
+  | GenSig of comp * comp
   | GenStruct of comp * comp
   | GenProj of comp * comp
   | Occurs of comp * comp

--- a/src/syntax.mli
+++ b/src/syntax.mli
@@ -17,15 +17,19 @@ and tt_pattern' =
   | Tt_Prod of Name.ident * bound option * tt_pattern option * tt_pattern
   | Tt_Eq of tt_pattern * tt_pattern
   | Tt_Refl of tt_pattern
-  | Tt_Signature of Name.signature
-  | Tt_Structure of Name.signature * tt_pattern list
+  | Tt_Signature of Name.signature (* TODO easy matching of signatures and structures with constraints *)
+  | Tt_Structure of Name.signature * tt_pattern list 
   | Tt_Projection of tt_pattern * Name.ident
-  | Tt_GenSig of bound option
-  | Tt_GenStruct of tt_pattern * bound option
-  | Tt_GenProj of tt_pattern * bound option
+  (** Matching [Signature s={li as xi : Ai} with lj = ej] is matching [((s,[li,xi:Ai]),[either yk or ej])]
+      where [yk] is used to instantiate non-constrained labels in later constraints. *)
+  | Tt_GenSig of pattern
+  (** Matching [Structure s, [es]] *)
+  | Tt_GenStruct of tt_pattern * pattern
+  (** Matching [Projection e, _, l] *)
+  | Tt_GenProj of tt_pattern * pattern
   | Tt_GenAtom
 
-type pattern = pattern' * Location.t
+and pattern = pattern' * Location.t
 and pattern' =
   | Patt_Anonymous
   | Patt_As of pattern * bound

--- a/src/utils/name.ml
+++ b/src/utils/name.ml
@@ -72,6 +72,8 @@ let fresh =
     else
       Atom (s, fixity, !counter)
 
+let ident_of_atom (Atom (s,fixity,_)) = Ident (s,fixity)
+
 (** Split a string into base and an optional numerical suffix, e.g.,
     ["x42"] is split into [("x", Some 42)], while ["xy"] is split into
     [("xy", None)]. *)

--- a/src/utils/name.mli
+++ b/src/utils/name.mli
@@ -44,6 +44,8 @@ val make : ?fixity:fixity -> string -> ident
 (** Generate a variant of a given name that is guaranteed to not yet exist. *)
 val fresh : ident -> atom
 
+val ident_of_atom : atom -> ident
+
 (** [refresh xs x] finds a nice variant of [x] that does not occur in [xs]. *)
 val refresh : ident list -> ident -> ident
 

--- a/std/equal.m31
+++ b/std/equal.m31
@@ -389,6 +389,49 @@ let rec do_whnf betas e =
               end
           end
       end
+    | |- _proj ?e0 ?l : ?t =>
+      match do_whnf betas e0 with
+        | Some (|- ?eq : _ == ?e0') =>
+          let e' = _proj e0' l in
+          let e' = e' : t in
+          let meq = handle congruence e e' with
+            | equal e0 e0' => yield (Some eq)
+            end
+          in
+          let eq = match meq with
+              | Some ?eq => eq : e == e'
+            end
+          in
+          match do_whnf betas e' with
+            | Some (|- ?eq' : _ == ?e'') =>
+              let eq = transitivity eq eq' in
+              Some eq
+            | None => Some eq
+          end
+        | None =>
+          match reduction e with
+            | Some (|- ?eq : _ == ?e') =>
+              match do_whnf betas e' with
+                | Some (|- ?eq' : _ == ?e'') =>
+                  let eq = transitivity eq eq' in
+                  Some eq
+                | None => Some eq
+              end
+            | None =>
+              (* e0 is in whnf and e is not a beta redex, so we only need to see if a beta hint applies to e *)
+              match step_at betas e with
+                | Some (|- ?eq : _ == ?e') =>
+                      match do_whnf betas e' with
+                    | Some (|- ?eq' : _ == ?e'') =>
+                      let eq = transitivity eq eq' in
+                      Some eq
+                    | None =>
+                      Some eq
+                  end
+                | None => None
+              end
+          end
+      end
     | |- _ : ?t =>
       match step_at betas e with
         | Some (|- ?eq : _ == ?e') =>
@@ -400,8 +443,6 @@ let rec do_whnf betas e =
           end
         | None =>
           None
-          (* TODO are there any non application cases where we need to reduce a subterm?
-             Projections but we can't match them yet. *)
       end
   end
 

--- a/std/equal.m31
+++ b/std/equal.m31
@@ -481,19 +481,42 @@ let rec equate_congr a b =
       end
   end
 
+(* if `x : A` and `eq : A == B` return `x : B` *)
+let convert = fun x eq => match eq with
+(*  | |- _ : ?t == ?t => x*)
+  | |- _ : _ == ?t =>
+    handle x : t with equal _ _ => yield (Some (symmetry eq)) end
+  end
+
+(* if `eq = (a == b : A)` and `eqt : A == B` return a witness of `(a == b : A) == (a == b : B)` *)
+let convert_eq = fun eq eqt => match (eq,eqt) with
+  | (_, |- _ : ?t == ?t) => refl eq
+  | (|- ?a == ?b, |- _ : _ == ?t) =>
+    let a' = convert a eqt and b' = convert b eqt in
+    let eq' = a' == b' in
+    match handle congruence eq eq' with equal _ _ => yield (Some eqt) end with
+    Some ?eq => eq
+    end
+end
+
 (* Try to show that [x] and [y] are equal by applying in succession:
    general hints, eta hints, and structural equality. *)
 let rec equate x y =
   (* x and y must have the same derived type *)
   let t = match (x, y) with ((|- _ : ?t), (|- _ : ?t)) => t end in
-  match hint_at gethints (x == y) with
-    | None =>
-      match (handle eta_at getetas x y t with equal ?a ?b => yield (equate a b) end) with
-        | Some ?eq => Some eq
-        | None =>
-          handle equate_congr x y with equal ?a ?b => yield (equate a b) end
-      end
-    | Some ?eq => Some eq
+  match (handle whnf_eq getbetas t with equal ?a ?b => yield (equate a b) end) with
+  |- ?eqt : _ == ?t' =>
+    let x = convert x eqt and y = convert y eqt in
+    match hint_at gethints (x == y) with
+      | None =>
+        match (handle eta_at getetas x y t with equal ?a ?b => yield (equate a b) end) with
+          | Some ?eq => Some eq
+          | None =>
+            handle equate_congr x y with equal ?a ?b => yield (equate a b) end
+        end
+      | Some (|- ?eq : ?teq) =>
+        Some (convert eq (convert_eq teq eqt))
+    end
   end
 
 let hint_provider = fun betas hints etas => handler

--- a/std/equal.m31
+++ b/std/equal.m31
@@ -283,7 +283,7 @@ let symmetry = fun eq =>
 (* As `symmetry` but for transitivity. *)
 let transitivity = fun eq1 eq2 =>
   match (eq1, eq2) with
-    | ((|- _ : ?a == ?b), (|- _ : _ == ?c)) =>
+    | ((|- _ : ?a == ?b), (|- _ : ?b == ?c)) =>
       match a with |- _ : ?t =>
         hide_witness (tran t a b c eq1 eq2)
       end
@@ -317,12 +317,16 @@ let rec hint_at hints e =
    operations that try to solve the resulting subproblems. Return `Some (⊢ p : a == b)` on
    success, or `None` otherwise. *)
 let rec eta_at etas a b t =
-  match etas with
-    | [] => None
-    | ?h :: ?rem =>
-      match generic_matcher h t with
-        | Some ?f => f a b
-        | None => eta_at rem a b t
+  match extensionality a b with
+    | Some ?eq => Some eq
+    | None =>
+      match etas with
+        | [] => None
+        | ?h :: ?rem =>
+          match generic_matcher h t with
+            | Some ?f => f a b
+            | None => eta_at rem a b t
+          end
       end
   end
 
@@ -460,7 +464,16 @@ let rec equate_congr a b =
   let betas = getbetas in
   match (whnf_eq betas a, whnf_eq betas b) with
     ((|- ?eqa : _ == ?a'), (|- ?eqb : _ == ?b')) =>
-      match congruence a' b' with
+      let r = match (a',b') with
+        | (|- ?a1 ?a2, |- ?b1 ?b2) =>
+          (* We need to compare the head structurally because of lambda extensionality *)
+          handle congruence a' b' with | equal a1 b1 => yield (equate_congr a1 b1) end
+        | (|- _proj ?a0 _, |- _proj ?b0 _) =>
+          handle congruence a' b' with | equal a0 b0 => yield (equate_congr a0 b0) end
+        | _ =>
+          congruence a' b'
+      end in
+      match r with
         | Some ?eq =>
           let eq = transitivity eqa (transitivity eq (symmetry eqb)) in
           Some eq

--- a/std/hacks.m31
+++ b/std/hacks.m31
@@ -1,0 +1,8 @@
+
+#include_once "utils.m31"
+
+let extract_labels = fun s => match s with
+  |- _sig ((_,?lst),_) =>
+    list_map (fun x => match x with (?l,_) => l end) lst
+  end
+

--- a/std/utils.m31
+++ b/std/utils.m31
@@ -33,14 +33,3 @@ let assoc_update = fun x v lst =>
     end
   in aux [] lst
 
-(** First projection *)
-let fst = fun v => match v with
-  | (?v, _) => v
-  end
-
-(** Second projection *)
-let snd = fun v => match v with
-  | (_, ?v) => v
-  end
-
-

--- a/tests/beta-pair.m31
+++ b/tests/beta-pair.m31
@@ -1,46 +1,46 @@
-constant Product : Type -> Type -> Type
+constant product : Type -> Type -> Type
 
-constant Pair :
+constant pair :
   Π (A B : Type),
-    A -> (B -> (Product A B))
+    A -> (B -> (product A B))
 
-constant Fst :
-  Π (X Y : Type), Product X Y -> X
+constant fst :
+  Π (X Y : Type), product X Y -> X
 
-constant beta_Fst :
+constant beta_fst :
   Π (U V : Type, u : U, v : V),
-    (Fst V U (Pair V U v u)) == v
+    (fst V U (pair V U v u)) == v
 
 constant C : Type
 constant D : Type
 constant c : C
 constant d : D
 
-(* just a Pair *)
+(* just a pair *)
 do
-  with local (lbeta beta_Fst) handle
-    (refl (Fst C D (Pair C D c d)))
+  with local (lbeta beta_fst) handle
+    (refl (fst C D (pair C D c d)))
          :
-         c == (Fst C D (Pair C D c d))
+         c == (fst C D (pair C D c d))
 
 (* change the order of the parameters *)
 do
-  with local (lbeta beta_Fst) handle
-       (refl (Fst D C (Pair D C d c)))
+  with local (lbeta beta_fst) handle
+       (refl (fst D C (pair D C d c)))
          :
-         d == (Fst D C (Pair D C d c))
+         d == (fst D C (pair D C d c))
 
 (* add a lambda redex in the proof *)
 do
-  with local (lbeta beta_Fst) handle
-    (refl (Fst C D (Pair C D ((λ (t : Type, x : t), x) C c) d)))
+  with local (lbeta beta_fst) handle
+    (refl (fst C D (pair C D ((λ (t : Type, x : t), x) C c) d)))
          :
-         c == (Fst C D (Pair C D c d))
+         c == (fst C D (pair C D c d))
 
 (* add a lambda redex in the type *)
 do
-  with local (lbeta beta_Fst) handle
-    (refl (Fst C D (Pair C D c d)))
+  with local (lbeta beta_fst) handle
+    (refl (fst C D (pair C D c d)))
          :
-         c == (Fst C D (Pair C D ((λ (t : Type, x : t), x) C c) d))
+         c == (fst C D (pair C D ((λ (t : Type, x : t), x) C c) d))
 

--- a/tests/beta-pair.m31.ref
+++ b/tests/beta-pair.m31.ref
@@ -1,14 +1,14 @@
-Constant Product is declared.
-Constant Pair is declared.
-Constant Fst is declared.
-Constant beta_Fst is declared.
+Constant product is declared.
+Constant pair is declared.
+Constant fst is declared.
+Constant beta_fst is declared.
 Constant C is declared.
 Constant D is declared.
 Constant c is declared.
 Constant d is declared.
-⊢ refl (Fst C D (Pair C D c d)) : c ≡ Fst C D (Pair C D c d)
-⊢ refl (Fst D C (Pair D C d c)) : d ≡ Fst D C (Pair D C d c)
-⊢ refl (Fst C D (Pair C D ((λ (t : Type) (x : t), x) C c) d))
-  : c ≡ Fst C D (Pair C D c d)
-⊢ refl (Fst C D (Pair C D c d))
-  : c ≡ Fst C D (Pair C D ((λ (t : Type) (x : t), x) C c) d)
+⊢ refl (fst C D (pair C D c d)) : c ≡ fst C D (pair C D c d)
+⊢ refl (fst D C (pair D C d c)) : d ≡ fst D C (pair D C d c)
+⊢ refl (fst C D (pair C D ((λ (t : Type) (x : t), x) C c) d))
+  : c ≡ fst C D (pair C D c d)
+⊢ refl (fst C D (pair C D c d))
+  : c ≡ fst C D (pair C D ((λ (t : Type) (x : t), x) C c) d)

--- a/tests/eta-pair.m31
+++ b/tests/eta-pair.m31
@@ -2,23 +2,23 @@
 
 constant prod : forall (_ _ : Type), Type
 
-constant Pair : forall (A B : Type) (_ : A) (_ : B), prod A B
+constant pair : forall (A B : Type) (_ : A) (_ : B), prod A B
 
-constant Fst : forall (X Y : Type, _ : prod X Y), X
-constant Snd : forall (X Y : Type) (_ : prod X Y), Y
+constant fst : forall (X Y : Type, _ : prod X Y), X
+constant snd : forall (X Y : Type) (_ : prod X Y), Y
 
-constant Pair_beta_Fst :
+constant pair_beta_fst :
   ∀ (U V : Type, u : U, v : V),
-    (Fst V U (Pair V U v u)) ≡ v
+    (fst V U (pair V U v u)) ≡ v
 
-constant Pair_beta_Snd :
+constant pair_beta_snd :
   ∀ (U V : Type) (u : U) (v : V),
-    (Snd V U (Pair V U v u)) ≡ u
+    (snd V U (pair V U v u)) ≡ u
 
-constant Pair_eta :
+constant pair_eta :
   ∀ (U V : Type) (x y : prod U V),
-    Fst U V x ≡ Fst U V y ->
-    Snd U V x ≡ Snd U V y ->
+    fst U V x ≡ fst U V y ->
+    snd U V x ≡ snd U V y ->
     x ≡ y
 
 constant C : Type
@@ -29,19 +29,19 @@ constant p : prod C D
 (* Beta rules. *)
 do
   (λ (c : C) (d : D),
-    with local (lbeta Pair_beta_Fst) handle
-      refl c : Fst C D (Pair C D c d) ≡ c)
+    with local (lbeta pair_beta_fst) handle
+      refl c : fst C D (pair C D c d) ≡ c)
 
 do
   (λ (c : C) (d : D),
-    with local (lbeta Pair_beta_Fst) handle
-    with local (lbeta Pair_beta_Snd) handle
-      refl d : Snd C D (Pair C D c d) ≡ d)
+    with local (lbeta pair_beta_fst) handle
+    with local (lbeta pair_beta_snd) handle
+      refl d : snd C D (pair C D c d) ≡ d)
 
-(* Surjective Pairing. *)
+(* Surjective pairing. *)
 do
-  with local (lbeta Pair_beta_Fst) handle
-  with local (lbeta Pair_beta_Snd) handle
-  with local (leta Pair_eta) handle
-     refl p : p ≡ Pair C D (Fst C D p) (Snd C D p)
+  with local (lbeta pair_beta_fst) handle
+  with local (lbeta pair_beta_snd) handle
+  with local (leta pair_eta) handle
+     refl p : p ≡ pair C D (fst C D p) (snd C D p)
 

--- a/tests/eta-pair.m31.ref
+++ b/tests/eta-pair.m31.ref
@@ -1,15 +1,15 @@
 Constant prod is declared.
-Constant Pair is declared.
-Constant Fst is declared.
-Constant Snd is declared.
-Constant Pair_beta_Fst is declared.
-Constant Pair_beta_Snd is declared.
-Constant Pair_eta is declared.
+Constant pair is declared.
+Constant fst is declared.
+Constant snd is declared.
+Constant pair_beta_fst is declared.
+Constant pair_beta_snd is declared.
+Constant pair_eta is declared.
 Constant C is declared.
 Constant D is declared.
 Constant p is declared.
 ⊢ λ (c : C) (_ : D), refl c
-  : Π (c : C) (d : D), Fst C D (Pair C D c d) ≡ c
+  : Π (c : C) (d : D), fst C D (pair C D c d) ≡ c
 ⊢ λ (c : C) (d : D), refl d
-  : Π (c : C) (d : D), Snd C D (Pair C D c d) ≡ d
-⊢ refl p : p ≡ Pair C D (Fst C D p) (Snd C D p)
+  : Π (c : C) (d : D), snd C D (pair C D c d) ≡ d
+⊢ refl p : p ≡ pair C D (fst C D p) (snd C D p)

--- a/tests/extensionality-auto.m31
+++ b/tests/extensionality-auto.m31
@@ -1,17 +1,14 @@
 let eqext =
    (lambda A a b p q,
-      (match extensionality p q with Some ?xi => xi end))
+      refl p)
    : forall (A : Type) (a b : A) (p q : a == b), p == q
 
 do eqext
 
 let funext =
-  (lambda A B f g eq,
-     (handle
-        match extensionality f g with Some ?xi => xi end
-      with
-      | equal (|- f ?x) (|- g ?x) => yield (Some (eq x))
-      end))
+  (lambda A B f g p,
+    with local (lhint p) handle
+    refl f : f == g)
   : forall (A : Type) (B : A -> Type) (f g : forall x : A, B x),
      (forall x : A, f x == g x) -> f == g
 
@@ -26,6 +23,6 @@ let cowext =
      with local (lbeta p) handle
      lambda (q : a.tail == b.tail),
        (with local (lbeta q) handle
-          match extensionality a b with Some ?xi => xi end)
+          refl a : a == b)
 
 do cowext

--- a/tests/extensionality-auto.m31.ref
+++ b/tests/extensionality-auto.m31.ref
@@ -1,0 +1,16 @@
+eqext is defined.
+⊢ λ (A : Type) (a : A) (b : A) (p : a ≡ b) (_ : a ≡ b), refl p
+  : Π (A : Type) (a : A) (b : A) (p : a ≡ b) (q : a ≡ b), p ≡ q
+funext is defined.
+⊢ λ (A : Type) (B : A → Type) (f : Π (x : A), B x)
+    (g : Π (x : A), B x) (_ : Π (x : A), f x ≡ g x), refl f
+  : Π (A : Type) (B : A → Type) (f : Π (x : A), B x)
+    (g : Π (x : A), B x), (Π (x : A), f x ≡ g x) → f ≡ g
+Constant A is declared.
+Constant B is declared.
+Signature cow is declared.
+cowext is defined.
+⊢ λ (a : cow) (b : cow) (_ : a.head ≡ b.head) (_ : a.tail ≡ b.tail),
+        refl a
+  : Π (a : cow) (b : cow), a.head ≡ b.head → a.tail ≡ b.tail → a ≡
+        b

--- a/tests/generic.m31
+++ b/tests/generic.m31
@@ -1,8 +1,8 @@
 
 signature cat = { person : Type, pet : person }
 
-let person_id = match cat with |- _sig ?l => match l with [(?x,_,_),_] => x end end
-let pet_id = match cat with |- _sig ?l => match l with [_,(?x,_,_)] => x end end
+let person_id = match cat with |- _sig ((_, [(?l,_),_]),_) => l end
+let pet_id = match cat with |- _sig ((_, [_,(?l,_)]),_) => l end
 
 constant dwarf : Type
 
@@ -42,8 +42,8 @@ do
 do _proj ankle pet_id
 
 let first_proj = fun v => match v with
-  |- _ : _sig ?s => match s with
-    | (?l,_,_)::_ =>
+  |- _ : _sig ((_,?s),_) => match s with
+    | (?l,_)::_ =>
       _proj v l
     end
   end
@@ -51,8 +51,8 @@ let first_proj = fun v => match v with
 do first_proj ankle
 
 let last_proj = fun v => match v with
-  |- _ : _sig ?s => match rev s with
-    | (?l,_,_)::_ =>
+  |- _ : _sig ((_,?s),_) => match rev s with
+    | (?l,_)::_ =>
       _proj v l
     end
   end
@@ -61,7 +61,7 @@ do last_proj ankle
 
 signature treasure = { gold : A }
 
-let gold_id = match treasure with |- _sig ?l => match l with [(?x,_,_)] => x end end
+let gold_id = match treasure with |- _sig ((_,[(?l,_)]),_) => l end
 
 fail _proj urist gold_id
 

--- a/tests/generic.m31.ref
+++ b/tests/generic.m31.ref
@@ -6,21 +6,25 @@ Constant urist is declared.
 ankle is defined.
 ⊢ {person = dwarf, pet = urist} : cat
 ((⊢ cat : Type), [(⊢ dwarf : Type), (⊢ urist : dwarf)])
-[(person, (person₁₆ : Type 
-           ⊢ person₁₆ : Type), (⊢ Type : Type)), (pet,
-(person₁₆ : Type 
- pet₁₇ : person₁₆ 
- ⊢ pet₁₇ : person₁₆),
-(person₁₆ : Type 
- ⊢ person₁₆ : Type))]
+(((⊢ cat : Type), [(person,
+(person₂₄ : Type 
+ ⊢ person₂₄ : Type)), (pet,
+(person₂₄ : Type 
+ pet₂₅ : person₂₄ 
+ ⊢ pet₂₅ : person₂₄))]), [Inl
+(person₂₆ : Type 
+ ⊢ person₂₆ : Type), Inl
+(person₂₆ : Type 
+ pet₂₇ : person₂₆ 
+ ⊢ pet₂₇ : person₂₆)])
 ((⊢ {person = dwarf, pet = urist} : cat), pet)
 tt
 ⊢ {person = dwarf, pet = urist} : cat
 The command failed with error:
-File "./generic.m31", line 33, characters 25-29: Typing error
-  the expression dwarf should have type dwarf but has type Type
+File "./generic.m31", line 33, characters 6-30: Typing error
+  bad field pet: types dwarf and Type do not match
 Constant A is declared.
-eq₁₈ : A ≡ cat 
+eq₄₀ : A ≡ cat 
 ⊢ {person = dwarf, pet = urist} : A
 ⊢ {person = dwarf, pet = urist}.pet : {person = dwarf, pet = urist}.person
 first_proj is defined.

--- a/tests/handle-pattern-default.m31
+++ b/tests/handle-pattern-default.m31
@@ -1,0 +1,9 @@
+
+operation O 1
+
+constant A : Type
+constant a b : A
+
+(* when an operation doesn't match, we need to bubble it upwards, then pass the result to the continuation *)
+do handle handle print [O b] with | O (|- a) => b end with | O ?x => yield tt end
+

--- a/tests/handle-pattern-default.m31.ref
+++ b/tests/handle-pattern-default.m31.ref
@@ -1,0 +1,6 @@
+Operation O is declared.
+Constant A is declared.
+Constant a is declared.
+Constant b is declared.
+[tt]
+tt

--- a/tests/sharing.m31
+++ b/tests/sharing.m31
@@ -1,0 +1,43 @@
+
+signature wrap = { T : Type, x : T }
+
+constant A : Type
+constant a : A
+
+do { T = A, x = a }
+
+do { T, x = a } : wrap using T = A and x end
+
+do { T, x } : wrap using T = A and x = a end
+
+constant exfalso : forall T : Type, T
+
+let exwrap = wrap using T as X and x = exfalso X end
+
+let bob = { T = A, x } : exwrap
+
+do bob
+
+do bob.x
+
+#include_once "../std/hacks.m31"
+
+let labels = extract_labels wrap
+
+let l_T = match labels with [?T,_] => T end
+let l_x = match labels with [_,?x] => x end
+
+let aT = assume T : Type in T
+
+let exwrap' = _sig wrap [(Inl aT),(Inr (exfalso aT))]
+
+do equal exwrap exwrap'
+
+let guy = _struct exwrap' [A]
+do equal bob guy
+
+let A' = _proj guy l_T
+do A'
+
+do _proj guy l_x
+

--- a/tests/sharing.m31.ref
+++ b/tests/sharing.m31.ref
@@ -2,12 +2,12 @@ Signature wrap is declared.
 Constant A is declared.
 Constant a is declared.
 ⊢ {T = A, x = a} : wrap
-⊢ {x = a} : wrap using T = A and  end
-⊢ {} : wrap using T = A and x = a and  end
+⊢ {x = a} : wrap using T = A and x end
+⊢ {} : wrap using T = A and x = a end
 Constant exfalso is declared.
 exwrap is defined.
 bob is defined.
-⊢ {T = A} : wrap using x = exfalso T and  end
+⊢ {T = A} : wrap using T as X and x = exfalso X end
 ⊢ exfalso {T = A}.T : {T = A}.T
 #including ../std/hacks.m31
 #processed ./../std/hacks.m31
@@ -17,8 +17,9 @@ l_x is defined.
 aT is defined.
 exwrap' is defined.
 Some
-(⊢ refl wrap using x = exfalso T and  end
-   : wrap using x = exfalso T and  end ≡ wrap using x = exfalso T and  end)
+(⊢ refl wrap using T and x = exfalso T end
+   : wrap using T as X and x = exfalso X end ≡ wrap using T and x = exfalso
+     T end)
 guy is defined.
 Some (⊢ refl {T = A} : {T = A} ≡ {T = A})
 A' is defined.

--- a/tests/sharing.m31.ref
+++ b/tests/sharing.m31.ref
@@ -1,0 +1,26 @@
+Signature wrap is declared.
+Constant A is declared.
+Constant a is declared.
+⊢ {T = A, x = a} : wrap
+⊢ {x = a} : wrap using T = A and  end
+⊢ {} : wrap using T = A and x = a and  end
+Constant exfalso is declared.
+exwrap is defined.
+bob is defined.
+⊢ {T = A} : wrap using x = exfalso T and  end
+⊢ exfalso {T = A}.T : {T = A}.T
+#including ../std/hacks.m31
+#processed ./../std/hacks.m31
+labels is defined.
+l_T is defined.
+l_x is defined.
+aT is defined.
+exwrap' is defined.
+Some
+(⊢ refl wrap using x = exfalso T and  end
+   : wrap using x = exfalso T and  end ≡ wrap using x = exfalso T and  end)
+guy is defined.
+Some (⊢ refl {T = A} : {T = A} ≡ {T = A})
+A' is defined.
+⊢ {T = A}.T : Type
+⊢ exfalso {T = A}.T : {T = A}.T

--- a/tests/struct-pair.m31
+++ b/tests/struct-pair.m31
@@ -1,0 +1,37 @@
+
+signature prod_s = { A : Type, B : Type, fst : A, snd : B }
+
+let prod = lambda A B : Type, prod_s using A = A and B = B and fst and snd end
+
+let pair = lambda (A B : Type) (x : A) (y : B),
+  { A, B,
+    fst = x,
+    snd = y } : prod A B
+
+let fst = lambda (A B : Type) (p : prod A B), p.fst
+let snd = lambda (A B : Type) (p : prod A B), p.snd
+
+let pair_fst_pr =
+  ∀ (U V : Type, u : U, v : V),
+    (fst V U (pair V U v u)) ≡ v
+
+do (lambda U V u v, refl v) : pair_fst_pr
+
+let pair_eta_pr =
+  ∀ (U V : Type) (x y : prod U V),
+    fst U V x ≡ fst U V y ->
+    snd U V x ≡ snd U V y ->
+    x ≡ y
+
+do (lambda (U V x y) (eq1 : x.fst == y.fst) (eq2 : x.snd == y.snd),
+  with local (lhint eq1) handle
+  with local (lhint eq2) handle
+  refl x : x == y) : pair_eta_pr
+
+constant C D : Type
+constant p q : prod C D
+
+fail refl p : p == q
+
+do refl p : p == pair C D (fst C D p) (snd C D p)
+

--- a/tests/struct-pair.m31.ref
+++ b/tests/struct-pair.m31.ref
@@ -1,0 +1,59 @@
+Signature prod_s is declared.
+prod is defined.
+pair is defined.
+fst is defined.
+snd is defined.
+pair_fst_pr is defined.
+⊢ λ (U : Type) (V : Type) (u : U) (v : V), refl v
+  : Π (U : Type) (V : Type) (u : U) (v : V),
+        (λ (A : Type) (B : Type)
+         (p : (λ (A0 : Type) (B0 : Type),
+                   prod_s using A = A0 and B = B0 and fst and snd end) A B),
+             p.fst) V U
+        ((λ (A : Type) (B : Type) (x : A) (y : B), {fst = x, snd = y}) V U v
+        u) ≡ v
+pair_eta_pr is defined.
+⊢ λ (U : Type) (V : Type)
+    (x : (λ (A : Type) (B : Type),
+              prod_s using A = A and B = B and fst and snd end) U V)
+    (y : (λ (A : Type) (B : Type),
+              prod_s using A = A and B = B and fst and snd end) U V)
+    (_ : x.fst ≡ y.fst) (_ : x.snd ≡ y.snd), refl x
+  : Π (U : Type) (V : Type)
+    (x : (λ (A : Type) (B : Type),
+              prod_s using A = A and B = B and fst and snd end) U V)
+    (y : (λ (A : Type) (B : Type),
+              prod_s using A = A and B = B and fst and snd end) U V),
+        (λ (A : Type) (B : Type)
+         (p : (λ (A0 : Type) (B0 : Type),
+                   prod_s using A = A0 and B = B0 and fst and snd end) A B),
+             p.fst) U V x ≡
+        (λ (A : Type) (B : Type)
+         (p : (λ (A0 : Type) (B0 : Type),
+                   prod_s using A = A0 and B = B0 and fst and snd end) A B),
+             p.fst) U V y →
+        (λ (A : Type) (B : Type)
+         (p : (λ (A0 : Type) (B0 : Type),
+                   prod_s using A = A0 and B = B0 and fst and snd end) A B),
+             p.snd) U V x ≡
+        (λ (A : Type) (B : Type)
+         (p : (λ (A0 : Type) (B0 : Type),
+                   prod_s using A = A0 and B = B0 and fst and snd end) A B),
+             p.snd) U V y → x ≡ y
+Constant C is declared.
+Constant D is declared.
+Constant p is declared.
+Constant q is declared.
+The command failed with error:
+File "./struct-pair.m31", line 34, characters 6-11: Typing error
+  failed to check that the term p is equal to q
+⊢ refl p
+  : p ≡ (λ (A : Type) (B : Type) (x : A) (y : B), {fst = x, snd = y}) C D
+    ((λ (A : Type) (B : Type)
+      (p0 : (λ (A0 : Type) (B0 : Type),
+                 prod_s using A = A0 and B = B0 and fst and snd end) A B),
+          p0.fst) C D p)
+    ((λ (A : Type) (B : Type)
+      (p0 : (λ (A0 : Type) (B0 : Type),
+                 prod_s using A = A0 and B = B0 and fst and snd end) A B),
+          p0.snd) C D p)

--- a/tests/tricky_spine.m31.ref
+++ b/tests/tricky_spine.m31.ref
@@ -11,6 +11,6 @@ Constant eq2 is declared.
 f is defined.
 ⊢ λ (n : Nat), iszero (succ n) : Nat → Bool
 ⊢ λ (n : Nat), iszero (succ n) : Nat → Nat
-File "./tricky_spine.m31", line 19, characters 9-38: Typing error
+File "./tricky_spine.m31", line 28, characters 34-34: Typing error
   the expression λ (n : Nat), iszero (succ n) should have type Nat → Nat
   but has type Nat → Bool


### PR DESCRIPTION
On top of #211.
This PR adds sharing constraints. Close #199.

On the programming language side:
- signature types are constructed as `s using li as xi = ei and ... end` where omitting the `= ei` means the field is unconstrained. Previous `xj` are bound to the appropriate value in `ei`. If `xi` is omitted it defaults to `li` as in structure and signature definitions.
- structures are constructed as `{ li as xi = ei }` with the `= ei` omitted for constrained fields. If any fields are omitted evaluation must be in checking mode.
- projecting a term `e` at field `p` when `e`'s type indicates a constraint on `p` produces not the term `e.p` but the constraint instantiated with the appropriate values.

In both cases all fields must be specified. eg
```
signature wrap : { T : Type, x : T }
do wrap using T = A and x end
```
The `and x` part may not be removed.
`{ T = A, x } : wrap using T, x = exfalso T end`
The `, x` part may not be removed.

This behaviour can probably be improved at least for trailing non constrained fields in a `using` statement.

The `using` keyword was chosen over the usual `with` to avoid conflicts.

The generic matcher `_sig` produces the term which is the signature with no sharing constraints, the signature definition and the list of sharing constraints.

On the TT side:
- a signature contains the list of sharing constraints as a `term option list` (should become `(Name.ident * term option) list` for better printing) which parallels the signature definition.
A field is faced with None when unconstrained and with `e` in which previous unconstrained fields are bound when constrained.
- a structure is just a signature plus the list of terms for unconstrained fields with no binding.
