### PR TITLE
Fix handling

### DIFF
--- a/src/nucleus/eval.ml
+++ b/src/nucleus/eval.ml
@@ -649,7 +649,9 @@ and match_cases ~loc cases v =
 and match_op_cases ~loc op cases vs checking =
   let rec fold = function
     | [] ->
-      Value.operation op vs
+      Value.operation op vs >>= fun v ->
+      Value.lookup_continuation ~loc >>= fun k ->
+      Value.apply_closure k v
     | (xs, ps, pt, c) :: cases ->
       Matching.match_op_pattern ps pt vs checking >>= begin function
         | Some vs ->

--- a/tests/handle-pattern-default.m31
+++ b/tests/handle-pattern-default.m31
@@ -1,0 +1,9 @@
+
+operation O 1
+
+constant A : Type
+constant a b : A
+
+(* when an operation doesn't match, we need to bubble it upwards, then pass the result to the continuation *)
+do handle handle print [O b] with | O (|- a) => b end with | O ?x => yield tt end
+

--- a/tests/handle-pattern-default.m31.ref
+++ b/tests/handle-pattern-default.m31.ref
@@ -1,0 +1,6 @@
+Operation O is declared.
+Constant A is declared.
+Constant a is declared.
+Constant b is declared.
+[tt]
+tt


### PR DESCRIPTION
When we do
`handle ... with op p => ... end`
if we get an operation `op v` which doesn't match `op p` we need to do `yield (op v)` but we did `op v` instead.