### PR TITLE
Only guess signature of structure in infer mode

### DIFF
--- a/src/nucleus/eval.ml
+++ b/src/nucleus/eval.ml
@@ -39,15 +39,6 @@ let as_ident ~loc v =
   Value.return s
 
 
-let list_combine3 =
-  let rec fold acc l1 l2 l3 = match l1,l2,l3 with
-    | [],[],[] -> List.rev acc
-    | x1::l1, x2::l2, x3::l3 -> fold ((x1,x2,x3)::acc) l1 l2 l3
-    | _,_,_ -> raise (Invalid_argument "list_combine3")
-  in
-  fun l1 l2 l3 -> fold [] l1 l2 l3
-
-
 (** Evaluate a computation -- infer mode. *)
 let rec infer (c',loc) =
   match c' with
@@ -277,8 +268,16 @@ let rec infer (c',loc) =
     Value.lookup_signature ~loc s >>= fun def ->
     fold Context.empty [] [] [] [] (List.combine def xcs)
 
-  | Syntax.Structure (s, xcs) ->
+  | Syntax.Structure lxcs ->
     (* In infer mode the structure must be fully specified. *)
+    let rec prefold ls xcs = function
+      | [] -> List.rev ls, List.rev xcs
+      | (l,x,Some c)::rem -> prefold (l::ls) ((x,c)::xcs) rem
+      | (l,_,None)::_ ->
+        Error.runtime ~loc "Field %t must be specified in infer mode." (Name.print_ident l)
+    in
+    let ls, xcs = prefold [] [] lxcs in
+    Value.find_signature ~loc ls >>= fun (s,lxts) ->
     let rec fold ctx shares es xcs lxts =
       match xcs, lxts with
         | [], [] ->
@@ -289,20 +288,16 @@ let rec infer (c',loc) =
           let j_str = Jdg.mk_term ctx str t_str in
           Value.return_term j_str
 
-        | (x, Some c) :: xcs, (_, _, t) :: lxts ->
+        | (x, c) :: lxcs, (_, _, t) :: lxts ->
           let t_inst = Tt.instantiate_ty es t in
           let jty = Jdg.mk_ty ctx t_inst in
           check c jty >>= fun (ctx, e) ->
           Value.add_bound x (Value.mk_term (Jdg.mk_term ctx e t_inst))
-          (fold ctx ((Tt.Inl x)::shares) (e::es) xcs lxts)
-
-        | (_,None) :: _, (l,_,_) :: _ ->
-          Error.runtime ~loc "missing field value for %t" (Name.print_ident l)
+          (fold ctx ((Tt.Inl x)::shares) (e::es) lxcs lxts)
 
         | _::_, [] -> Error.typing ~loc "this structure has too many fields"
         | [], _::_ -> Error.typing ~loc "this structure has too few fields"
     in
-    Value.lookup_signature ~loc s >>= fun lxts ->
     fold Context.empty [] [] xcs lxts
 
   | Syntax.Projection (c,p) ->
@@ -606,40 +601,63 @@ and check ((c',loc) as c) (Jdg.Ty (_, t_check') as t_check) : (Context.t * Tt.te
                          (pte e) (pte e1)
      end
 
-  | Syntax.Structure (s,xcs) ->
-    Equal.Monad.run (Equal.as_signature t_check) >>= fun ((ctx,((s',shares) as s_sig)),hyps) ->
-    if Name.eq_ident s s'
-    then
-      Value.lookup_signature ~loc s >>= fun s_def ->
-      (* [res] is only the explicit fields, [es] instantiates the types *)
-      let rec fold ctx res es = function
-        | [] ->
-          let res = List.rev res in
-          let e = Tt.mk_structure ~loc s_sig res in
-          let e = Tt.mention_atoms hyps e in
-          Value.return (ctx,e)
-        | ((_,_,t),Tt.Inr e,(x,None))::rem ->
-          let e = Tt.instantiate res e
-          and t = Tt.instantiate_ty es t in
-          let j = Jdg.mk_term ctx e t in
-          Value.add_bound x (Value.mk_term j)
-          (fold ctx res (e::es) rem)
-        | ((_,_,t),Tt.Inl _,(x,Some c))::rem ->
-          let t = Tt.instantiate_ty es t in
-          let jt = Jdg.mk_ty ctx t in
-          check c jt >>= fun (ctx,e) ->
-          let j = Jdg.mk_term ctx e t in
-          Value.add_bound x (Value.mk_term j)
-          (fold ctx (e::res) (e::es) rem)
-        | ((l,_,_),Tt.Inl _,(_,None))::rem ->
-          Error.runtime ~loc "Field %t must be specified" (Name.print_ident l)
-        | ((l,_,_),Tt.Inr _,(_,Some _))::rem ->
-          Error.runtime ~loc "Field %t is constrained and must not be specified" (Name.print_ident l)
-      in
-      fold ctx [] [] (list_combine3 s_def shares xcs)
-    else
-      Error.typing ~loc "This structure belongs to signature %t, but it should be in signature %t"
-        (Name.print_ident s) (Name.print_ident s')
+  | Syntax.Structure lxcs ->
+    Equal.Monad.run (Equal.as_signature t_check) >>= fun ((ctx,((s,shares) as s_sig)),hyps) ->
+    Value.lookup_signature ~loc s >>= fun s_def ->
+    (* Set up to skip fields not mentioned in [lxcs] *)
+    let rec align fields s_data = function
+      | [] ->
+        let rec complete fields = function
+          | [] -> List.rev fields
+          | ((_,Tt.Inr _) as data)::s_data ->
+            complete ((data,None)::fields) s_data
+          | ((l,_,_),Tt.Inl _)::_ -> Error.runtime ~loc "Field %t missing"
+                                                (Name.print_ident l)
+        in
+        complete fields s_data
+      | (l,x,c)::lxcs ->
+        let rec find fields = function
+          | (((l',_,_),_) as data)::s_data ->
+            if Name.eq_ident l l'
+            then
+              align ((data,Some (x,c))::fields) s_data lxcs
+            else
+              find ((data,None)::fields) s_data
+          | [] -> Error.runtime ~loc "Field %t does not appear in signature %t"
+                                (Name.print_ident l) (Name.print_ident s)
+        in
+        find fields s_data    
+    in
+    (* [res] is only the explicit fields, [es] instantiates the types *)
+    let rec fold ctx res es = function
+      | [] ->
+        let res = List.rev res in
+        let e = Tt.mk_structure ~loc s_sig res in
+        let e = Tt.mention_atoms hyps e in
+        Value.return (ctx,e)
+      | (((_,_,t),Tt.Inr e),Some (x,None))::rem ->
+        let e = Tt.instantiate res e
+        and t = Tt.instantiate_ty es t in
+        let j = Jdg.mk_term ctx e t in
+        Value.add_bound x (Value.mk_term j)
+        (fold ctx res (e::es) rem)
+      | (((_,_,t),Tt.Inl _),Some (x,Some c))::rem ->
+        let t = Tt.instantiate_ty es t in
+        let jt = Jdg.mk_ty ctx t in
+        check c jt >>= fun (ctx,e) ->
+        let j = Jdg.mk_term ctx e t in
+        Value.add_bound x (Value.mk_term j)
+        (fold ctx (e::res) (e::es) rem)
+      | ((_,Tt.Inr e),None)::rem ->
+        let e = Tt.instantiate res e in
+        fold ctx res (e::es) rem
+      | (((l,_,_),Tt.Inl _),(None | Some (_,None)))::_ ->
+        Error.runtime ~loc "Field %t must be specified" (Name.print_ident l)
+      | (((l,_,_),Tt.Inr _),Some (_,Some _))::_ ->
+        Error.runtime ~loc "Field %t is constrained and must not be specified" (Name.print_ident l)
+    in
+    let fields = align [] (List.combine s_def shares) lxcs in
+    fold ctx [] [] fields
 
 and infer_lambda ~loc x u c =
   match u with
@@ -905,16 +923,10 @@ let rec exec_cmd base_dir interactive c =
         Error.typing "Constants may not depend on free variables" ~loc:(snd c)
 
   | Syntax.DeclSignature (s, lxcs) ->
-     begin
-       match Value.find_signature env (List.map (fun (l,_,_) -> l) lxcs) with
-       | Some s -> Error.syntax ~loc "signature %t already has these fields"
-                                  (Name.print_ident s)
-       | None ->
-          comp_signature ~loc lxcs >>= fun lxts ->
-          Value.add_signature ~loc s lxts  >>= fun () ->
-          (if interactive then Format.printf "Signature %t is declared.@." (Name.print_ident s) ;
-           return ())
-     end
+    comp_signature ~loc lxcs >>= fun lxts ->
+    Value.add_signature ~loc s lxts  >>= fun () ->
+    (if interactive then Format.printf "Signature %t is declared.@." (Name.print_ident s) ;
+      return ())
 
   | Syntax.TopHandle lst ->
     fold (fun () (op, xc) ->

--- a/src/nucleus/value.ml
+++ b/src/nucleus/value.ml
@@ -317,9 +317,9 @@ let lookup_signature ~loc x env =
    | Some def -> Return def, env.state
    | None -> Error.impossible ~loc "Unknown signature %t" (Name.print_ident x)
 
-let find_signature env ls =
+let find_signature ~loc ls env =
   let rec fold = function
-    | [] -> None
+    | [] -> Error.runtime ~loc "No signature has these exact fields."
     | (s, DeclSignature s_def) :: lst ->
        let rec cmp lst1 lst2 =
          match lst1, lst2 with
@@ -327,10 +327,10 @@ let find_signature env ls =
          | l1::lst1, (l2,_,_)::lst2 -> Name.eq_ident l1 l2 && cmp lst1 lst2
          | [],_::_ | _::_,[] -> false
        in
-       if cmp ls s_def then Some s else fold lst
+       if cmp ls s_def then s, s_def else fold lst
     | (_, (DeclConstant _ | DeclData _ | DeclOperation _)) :: lst -> fold lst
   in
-  fold env.dynamic.decls
+  Return (fold env.dynamic.decls), env.state
 
 let lookup_abstracting env = Return env.dynamic.abstracting, env.state
 

--- a/src/nucleus/value.ml
+++ b/src/nucleus/value.ml
@@ -356,14 +356,19 @@ let add_free ~loc x (Jdg.Ty (ctx, t)) m env =
 (** generate a fresh atom of type [t] and bind it to [x],
     and record that the atom will be abstracted.
     NB: This is an effectful computation, as it increases a global counter. *)
-let add_abstracting ~loc x (Jdg.Ty (ctx, t)) m env =
+let add_abstracting ~loc ?(bind=true) x (Jdg.Ty (ctx, t)) m env =
   let y, ctx = Context.add_fresh ctx x t in
-  let ya = Tt.mk_atom ~loc y in
-  let jyt = Jdg.mk_term ctx ya t in
-  let env = add_bound0 x (mk_term jyt) env in
-  let env = { env with
-              dynamic = { env.dynamic with
-                          abstracting = jyt :: env.dynamic.abstracting } }
+  let env =
+    if not bind
+    then
+      env
+    else
+      let ya = Tt.mk_atom ~loc y in
+      let jyt = Jdg.mk_term ctx ya t in
+      let env = add_bound0 x (mk_term jyt) env in
+      { env with
+                dynamic = { env.dynamic with
+                            abstracting = jyt :: env.dynamic.abstracting } }
   in
   m ctx y env
 

--- a/src/nucleus/value.mli
+++ b/src/nucleus/value.mli
@@ -152,7 +152,7 @@ val get_signature : Name.signature -> env -> Tt.sig_def option
 val lookup_signature : loc:Location.t -> Name.ident -> Tt.sig_def result
 
 (** Find a signature with the given labels (in this exact order) *)
-val find_signature : env -> Name.label list -> Name.signature option
+val find_signature : loc:Location.t -> Name.label list -> (Name.signature * Tt.sig_def) result
 
 (** Lookup abstracting variables. *)
 val lookup_abstracting : Jdg.term list result

--- a/src/nucleus/value.mli
+++ b/src/nucleus/value.mli
@@ -176,7 +176,7 @@ val add_free: loc:Location.t -> Name.ident -> Jdg.ty -> (Context.t -> Name.atom 
 (** [add_abstracting ~loc x t] generates a fresh atom [y] from identifier [x] and marks
     it as abstracting (which means we intend to abstract it later).
     It then runs [f y] in the environment with [x] bound to [y]. *)
-val add_abstracting: loc:Location.t -> Name.ident -> Jdg.ty ->
+val add_abstracting: loc:Location.t -> ?bind:bool -> Name.ident -> Jdg.ty ->
                      (Context.t -> Name.atom -> 'a result) -> 'a result
 
 (** Add an operation with the given arity.

--- a/src/syntax.mli
+++ b/src/syntax.mli
@@ -18,7 +18,7 @@ and tt_pattern' =
   | Tt_Eq of tt_pattern * tt_pattern
   | Tt_Refl of tt_pattern
   | Tt_Signature of Name.signature (* TODO easy matching of signatures and structures with constraints *)
-  | Tt_Structure of Name.signature * tt_pattern list 
+  | Tt_Structure of (Name.label * tt_pattern) list 
   | Tt_Projection of tt_pattern * Name.ident
   (** Matching [Signature s={li as xi : Ai} with lj = ej] is matching [((s,[li,xi:Ai]),[either yk or ej])]
       where [yk] is used to instantiate non-constrained labels in later constraints. *)
@@ -73,9 +73,10 @@ and comp' =
   | Refl of comp
   (** [s with li as xi = maybe ci] with every previous [xj] bound in [ci] (including the constrained ones) *)
   | Signature of Name.signature * (Name.ident * comp option) list
-  (** [{ li as xi = maybe ci } : s with lj = ej] with previous [xj] bound in [ci].
-      Must be evaluated in checking mode unless fully explicit. *)
-  | Structure of Name.signature * (Name.ident * comp option) list
+  (** [{ li as xi = maybe ci } ] with previous [xj] bound in [ci].
+      In checking mode, constrained fields may be omitted in which case they are not bound in the computations.
+      In infer mode all fields must be present and explicit. *)
+  | Structure of (Name.label * Name.ident * comp option) list
   | Projection of comp * Name.label
   | Yield of comp
   | Hypotheses

--- a/src/syntax.mli
+++ b/src/syntax.mli
@@ -71,8 +71,8 @@ and comp' =
   | Prod of Name.ident * comp * comp
   | Eq of comp * comp
   | Refl of comp
-  (** [s with li as xi = maybe ci] with every previous [xj] bound in [ci] (including the constrained ones) *)
-  | Signature of Name.signature * (Name.ident * comp option) list
+  (** [s with li as xi = maybe ci] with every previous [xj] bound in [ci] (including the constrained ones). *)
+  | Signature of Name.signature * (Name.ident * comp option) option list
   (** [{ li as xi = maybe ci } ] with previous [xj] bound in [ci].
       In checking mode, constrained fields may be omitted in which case they are not bound in the computations.
       In infer mode all fields must be present and explicit. *)

--- a/std/equal.m31
+++ b/std/equal.m31
@@ -132,6 +132,13 @@ let rec collector quants lhs rhs =
                   collector quants e1 e2)
               end
 
+            | (|- _proj ?e1 ?l, |- _proj ?e2 ?l) =>
+              match (e1, e2) with
+                ((|- _ : ?t1), (|- _ : ?t2)) =>
+                  collector quants t1 t2 >?= (fun quants =>
+                  collector quants e1 e2)
+              end
+
             (* TODO structures *)
             | _ => None
           end

--- a/tests/signature-shadow.m31
+++ b/tests/signature-shadow.m31
@@ -25,3 +25,21 @@ let s_copy = { } : copy using x = a end
 
 fail refl { } : s_orig == s_copy
 
+
+constant B : Type
+constant b : B
+
+signature prod = { x : A, y : B }
+
+do { x = a } : prod using y = b end
+
+signature wrap = { T : Type, T' : Type, v : T }
+
+constant exfalso : forall T : Type, T
+operation inhab 0
+
+(* Not mentioning a field is no guarantee against it being used. We could also grab it from hypotheses. *)
+do { T = A, T' = B } : (handle wrap using v = inhab end with
+  | inhab : ?T => yield (exfalso T)
+  end)
+

--- a/tests/signature-shadow.m31
+++ b/tests/signature-shadow.m31
@@ -1,0 +1,27 @@
+
+constant A : Type
+constant a : A
+
+let proj_x = fun v => v.x
+
+signature orig = { x : A }
+
+do { x = a }
+
+do { } : orig using x = a end
+
+do { x as y } : orig using x as z = a end
+
+do proj_x {x = a}
+
+signature copy = { x : A }
+
+do { x = a }
+
+do { x = a } : orig
+
+let s_orig = { } : orig using x = a end
+let s_copy = { } : copy using x = a end
+
+fail refl { } : s_orig == s_copy
+

--- a/tests/signature-shadow.m31.ref
+++ b/tests/signature-shadow.m31.ref
@@ -1,0 +1,17 @@
+Constant A is declared.
+Constant a is declared.
+proj_x is defined.
+Signature orig is declared.
+⊢ {x = a} : orig
+⊢ {} : orig using x = a end
+⊢ {} : orig using x = a end
+⊢ {x = a}.x : A
+Signature copy is declared.
+⊢ {x = a} : copy
+⊢ {x = a} : orig
+s_orig is defined.
+s_copy is defined.
+The command failed with error:
+File "./signature-shadow.m31", line 26, characters 27-32: Typing error
+  the expression {} should have type orig using x = a end but has type
+  copy using x = a end

--- a/tests/signature-shadow.m31.ref
+++ b/tests/signature-shadow.m31.ref
@@ -15,3 +15,11 @@ The command failed with error:
 File "./signature-shadow.m31", line 26, characters 27-32: Typing error
   the expression {} should have type orig using x = a end but has type
   copy using x = a end
+Constant B is declared.
+Constant b is declared.
+Signature prod is declared.
+⊢ {x = a} : prod using x and y = b end
+Signature wrap is declared.
+Constant exfalso is declared.
+Operation inhab is declared.
+⊢ {T = A, T' = B} : wrap using T and T' and v = exfalso T end


### PR DESCRIPTION
This allows omitting fields from structure definitions and constraint lists (only non generic syntax).
