### PR TITLE
Fix fail toplevel command

### DIFF
--- a/src/nucleus/eval.ml
+++ b/src/nucleus/eval.ml
@@ -935,7 +935,7 @@ let rec exec_cmd base_dir interactive c =
      return ())
 
   | Syntax.TopFail c ->
-     Value.catch (comp_value c) >>= begin function
+     Value.catch (fun () -> comp_value (Lazy.force c)) >>= begin function
      | Error.Err err ->
         (if interactive then Format.printf "The command failed with error:\n%t@." (Error.print err));
         return ()

--- a/src/nucleus/value.ml
+++ b/src/nucleus/value.ml
@@ -139,7 +139,7 @@ let top_bind m f env =
 
 let catch m env =
   try
-    let x,env = m env in
+    let x,env = m () env in
     Error.OK x, env
   with
     | Error.Error err ->

--- a/src/nucleus/value.mli
+++ b/src/nucleus/value.mli
@@ -67,7 +67,7 @@ val bind: 'a result -> ('a -> 'b result)  -> 'b result
 val top_bind : 'a toplevel -> ('a -> 'b toplevel) -> 'b toplevel
 
 (** Catch errors. The state is not changed if the command fails. *)
-val catch : 'a toplevel -> ('a,Error.details) Error.res toplevel
+val catch : (unit -> 'a toplevel) -> ('a,Error.details) Error.res toplevel
 
 val top_return : 'a -> 'a toplevel
 val return : 'a -> 'a result

--- a/src/parser/desugar.ml
+++ b/src/parser/desugar.ml
@@ -720,7 +720,7 @@ let toplevel (env : Value.env) bound (d', loc) =
       Syntax.TopDo c
 
     | Input.TopFail c ->
-      let c = comp ~yield:false env bound c in
+      let c = lazy (comp ~yield:false env bound c) in
       Syntax.TopFail c
 
     | Input.Quit -> Syntax.Quit

--- a/src/syntax.mli
+++ b/src/syntax.mli
@@ -113,7 +113,7 @@ and toplevel' =
   | TopHandle of (Name.ident * top_op_case) list
   | TopLet of Name.ident * comp (** global let binding *)
   | TopDo of comp (** evaluate a computation *)
-  | TopFail of comp
+  | TopFail of comp Lazy.t (** desugaring is suspended to allow catching errors *)
   | Verbosity of int
   | Include of string list * bool (** the boolean is [true] if the files should be included only once *)
   | Quit (** quit the toplevel *)


### PR DESCRIPTION
`fail lambda x, x` didn't work as expected (probably due to some annoying monad stuff).
Desugaring a `fail` has also been made lazy, so now `fail x` (when `x` not bound) catches the error.
(Parsing errors cannot be caught, eg `fail fail`)