### PR TITLE
Fix bullets AGAIN

### DIFF
--- a/code.md
+++ b/code.md
@@ -45,13 +45,13 @@ The source code can be found in `src`, in the following folders:
    constants, data constructors, and operations. It also looks up labels in signature definitions.
 3. `nucleus/eval.ml` evaluates `Syntax` to a `Value.result` which is either a final value
    or an operation. The possible values are:
-      * a `Value.Term` term judgement of the form `Γ ⊢ e : A`, see `Jdg.term`
-      * a function closure `Value.Closure`
-      * a handler `Value.Handler`
-      * a data constructor `Value.Tag`
-      * a `Value.List` of values
-      * a `Value.Tuple` of values
-      * a mutable `Value.Ref`
-      * a `Value.String`
-      * an identifier `Value.Ident`
+       * a `Value.Term` term judgement of the form `Γ ⊢ e : A`, see `Jdg.term`
+       * a function closure `Value.Closure`
+       * a handler `Value.Handler`
+       * a data constructor `Value.Tag`
+       * a `Value.List` of values
+       * a `Value.Tuple` of values
+       * a mutable `Value.Ref`
+       * a `Value.String`
+       * an identifier `Value.Ident`
 

--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -35,10 +35,6 @@ footer, header, hgroup, menu, nav, section {
   display: block;
 }
 
-ol, ul {
-  list-style: none;
-}
-
 table {
   border-collapse: collapse;
   border-spacing: 0;
@@ -201,7 +197,6 @@ ul, ol, dl {
 
 ul {
   list-style-position: inside;
-  list-style: disc;
   padding-left: 20px;
 }
 


### PR DESCRIPTION
It looks like jekyll on my OSX treats embedded bullets diffrently from Github, which wants one more level of indentation.