### PR TITLE
Reinstate `lambda x y : A, ...` notation.

### DIFF
--- a/src/parser/parser.mly
+++ b/src/parser/parser.mly
@@ -267,17 +267,24 @@ structure_clause :
   | x=var_name AS y=name EQ c=term                 { (x, Some y, Some c) }
 
 typed_binder:
-  | LPAREN xs=name+ COLON t=ty_term RPAREN  { List.map (fun x -> (x, t)) xs }
+  | LPAREN xs=name+ COLON t=ty_term RPAREN         { List.map (fun x -> (x, t)) xs }
 
 maybe_typed_binder:
-  | x=name           { [(x, None)] }
-  | LPAREN xs=name+ COLON t=ty_term RPAREN  { List.map (fun x -> (x, Some t)) xs }
+  | x=name                                         { [(x, None)] }
+  | LPAREN xs=name+ COLON t=ty_term RPAREN         { List.map (fun x -> (x, Some t)) xs }
 
 prod_abstraction:
-  | lst=nonempty_list(typed_binder)   { List.concat lst }
+  | lst=nonempty_list(typed_binder)
+    { List.concat lst }
+  | lst=nonempty_list(name) COLON t=ty_term
+    { List.map (fun x -> (x, t)) lst }
 
 lambda_abstraction:
-  | lst=nonempty_list(maybe_typed_binder) { List.concat lst }
+  | lst=nonempty_list(maybe_typed_binder) t=overall_binder?
+    { List.map (fun (x, u) -> (x, match u with None -> t | Some _ -> u)) (List.concat lst) }
+
+overall_binder:
+  | COLON t=ty_term { t }
 
 handler_cases:
   | BAR lst=separated_nonempty_list(BAR, handler_case)  { lst }

--- a/tests/binders.m31
+++ b/tests/binders.m31
@@ -1,0 +1,19 @@
+(* Various ways of writing binders *)
+constant A : Type
+constant F : A -> Type
+
+do (lambda x f, f x) : A -> (A -> A) -> A
+
+do lambda (x y z : A) (f g h : A -> A -> A), f y x
+
+do lambda x y z : A, y
+
+do lambda x y (f : A -> A -> A) z w : A, f x w
+
+(* This one is a bit strange *)
+do lambda x y (f : F x -> F y) : A, f
+
+(* Ways of writing products *)
+do forall A B C : Type, A -> B -> C
+do forall (A B C : Type), A -> B -> C
+do forall (A : Type) (B : Type) (C : Type), A -> B -> C

--- a/tests/binders.m31.ref
+++ b/tests/binders.m31.ref
@@ -1,0 +1,15 @@
+Constant A is declared.
+Constant F is declared.
+⊢ λ (x : A) (f : A → A), f x : A → (A → A) → A
+⊢ λ (x : A) (y : A) (_ : A) (f : A → A → A) (_ : A → A → A) (_ : A
+        → A → A), f y x
+  : A → A → A → (A → A → A) → (A → A → A) → (A → A → A)
+    → A
+⊢ λ (_ : A) (y : A) (_ : A), y : A → A → A → A
+⊢ λ (x : A) (_ : A) (f : A → A → A) (_ : A) (w : A), f x w
+  : A → A → (A → A → A) → A → A → A
+⊢ λ (x : A) (y : A) (f : F x → F y), f
+  : Π (x : A) (y : A), (F x → F y) → F x → F y
+⊢ Π (A0 : Type) (B : Type) (C : Type), A0 → B → C : Type
+⊢ Π (A0 : Type) (B : Type) (C : Type), A0 → B → C : Type
+⊢ Π (A0 : Type) (B : Type) (C : Type), A0 → B → C : Type


### PR DESCRIPTION
Also `forall A B : Type, ...` is back. The only wiredness is that we can
now write `lambda x y (a : F x) z w : A, ....` but I guess we could call it
a feature.