### PR TITLE
Rename constructors for documentation

### DIFF
--- a/examples/struct-coerce.m31
+++ b/examples/struct-coerce.m31
@@ -13,9 +13,9 @@ let extract_fields str =
     | |- _struct (_sig (_,?shares)) ?terms =>
       let rec fold defined insts terms shares = match shares with
         | [] => rev defined
-        | (Inl ?x)::?shares =>
+        | (Unconstrained ?x)::?shares =>
           match terms with ?e::?terms => fold (e::defined) ((x,e)::insts) terms shares end
-        | (Inr ?e)::?shares =>
+        | (Constrained ?e)::?shares =>
           let e = instantiate insts e in
           fold (e::defined) insts terms shares
       end in
@@ -58,8 +58,8 @@ let struct_coerce str sig = match sig with
     let defined = extract_fields str in
     let rec fold terms defined shares = match (defined,shares) with
       | ([], []) => rev terms
-      | (?e::?defined,(Inl _)::?shares) => fold (e::terms) defined shares
-      | (_::?defined,(Inr _)::?shares) => fold terms defined shares
+      | (?e::?defined,(Unconstrained _)::?shares) => fold (e::terms) defined shares
+      | (_::?defined,(Constrained _)::?shares) => fold terms defined shares
     end in
     let terms = fold [] defined shares2 in
     _struct sig terms

--- a/src/nucleus/eval.ml
+++ b/src/nucleus/eval.ml
@@ -247,18 +247,18 @@ let rec infer (c',loc) =
             let je = Jdg.mk_term ctx e t in
             let e_abs = Tt.abstract ys e in
             Value.add_bound x (Value.mk_term je)
-            (fold ctx ((Tt.Inr e_abs) :: vs) (e::es) ys ts rem)
+            (fold ctx ((Tt.Constrained e_abs) :: vs) (e::es) ys ts rem)
           | None ->
             Value.add_abstracting ~loc x jt (fun ctx y ->
             let ey = Tt.mk_atom ~loc y in
-            fold ctx ((Tt.Inl x)::vs) (ey::es) (y::ys) (t::ts) rem)
+            fold ctx ((Tt.Unconstrained x)::vs) (ey::es) (y::ys) (t::ts) rem)
         end
       | ((_,x,t),None)::rem ->
         let t = Tt.instantiate_ty es t in
         let jt = Jdg.mk_ty ctx t in
         Value.add_abstracting ~loc ~bind:false x jt (fun ctx y ->
         let ey = Tt.mk_atom ~loc y in
-        fold ctx ((Tt.Inl x)::vs) (ey::es) (y::ys) (t::ts) rem)
+        fold ctx ((Tt.Unconstrained x)::vs) (ey::es) (y::ys) (t::ts) rem)
     in
     Value.lookup_signature ~loc s >>= fun def ->
     fold Context.empty [] [] [] [] (List.combine def xcs)
@@ -288,7 +288,7 @@ let rec infer (c',loc) =
           let jty = Jdg.mk_ty ctx t_inst in
           check c jty >>= fun (ctx, e) ->
           Value.add_bound x (Value.mk_term (Jdg.mk_term ctx e t_inst))
-          (fold ctx ((Tt.Inl x)::shares) (e::es) lxcs lxts)
+          (fold ctx ((Tt.Unconstrained x)::shares) (e::es) lxcs lxts)
 
         | _::_, [] -> Error.typing ~loc "this structure has too many fields"
         | [], _::_ -> Error.typing ~loc "this structure has too few fields"
@@ -354,7 +354,7 @@ let rec infer (c',loc) =
   | Syntax.GenSig (c1,c2) ->
     check_ty c1 >>= fun j1 ->
     Equal.as_signature j1 >>= fun ((_,(s,shares)),_) ->
-    if List.for_all (function | Tt.Inl _ -> true | Tt.Inr _ -> false) shares
+    if List.for_all (function | Tt.Unconstrained _ -> true | Tt.Constrained _ -> false) shares
     then
       infer c2 >>= as_list ~loc >>= fun xes ->
       Value.lookup_signature ~loc s >>= fun def ->
@@ -368,8 +368,8 @@ let rec infer (c',loc) =
           let j = Jdg.term_of_ty (Jdg.mk_ty ctx e) in
           Value.return_term j
         | (l,_,t)::def, xe::xes ->
-          begin match Value.as_sum ~loc xe with
-            | Tt.Inl vx ->
+          begin match Value.as_constrain ~loc xe with
+            | Tt.Unconstrained vx ->
               as_atom ~loc vx >>= fun (ctx',y,ty) ->
               let t = Tt.instantiate_ty es t in
               (* TODO use handled equal? *)
@@ -379,19 +379,19 @@ let rec infer (c',loc) =
                 let ctx = Context.join ~penv ~loc ctx ctx' in
                 let ey = Tt.mk_atom ~loc y in
                 let x = Name.ident_of_atom y in
-                fold ctx ((Tt.Inl x)::vs) (ey::es) (y::ys) (t::ts) def xes
+                fold ctx ((Tt.Unconstrained x)::vs) (ey::es) (y::ys) (t::ts) def xes
               else
                 Value.print_ty >>= fun pty ->
                 Error.typing ~loc "bad non-constraint for field %t: types %t and %t do not match"
                   (Name.print_ident l) (pty t) (pty ty)
-            | Tt.Inr ve ->
+            | Tt.Constrained ve ->
               as_term ~loc ve >>= fun (Jdg.Term (ctx',e,te)) ->
               let t = Tt.instantiate_ty es t in
               require_equal_ty ~loc (Jdg.mk_ty ctx t) (Jdg.mk_ty ctx' te) >>= begin function
                 | Some (ctx,hyps) ->
                   let e = Tt.mention_atoms hyps e in
                   let e_abs = Tt.abstract ys e in
-                  fold ctx ((Tt.Inr e_abs) :: vs) (e::es) ys ts def xes
+                  fold ctx ((Tt.Constrained e_abs) :: vs) (e::es) ys ts def xes
                 | None ->
                   Value.print_ty >>= fun pty ->
                   Error.typing ~loc "bad constraint for field %t: types %t and %t do not match"
@@ -418,7 +418,7 @@ let rec infer (c',loc) =
         let e = Tt.mention_atoms hyps e in
         let j = Jdg.mk_term ctx e target in
         Value.return_term j
-      | ((l,_,t),Tt.Inl _)::s_data,v::vs ->
+      | ((l,_,t),Tt.Unconstrained _)::s_data,v::vs ->
         as_term ~loc v >>= fun (Jdg.Term (ctx',e,te)) ->
         let t = Tt.instantiate_ty es t in
         require_equal_ty ~loc (Jdg.mk_ty ctx t) (Jdg.mk_ty ctx' te) >>= begin function
@@ -430,10 +430,10 @@ let rec infer (c',loc) =
             Error.typing ~loc "bad field %t: types %t and %t do not match"
               (Name.print_ident l) (pty t) (pty te)
         end
-      | ((_,_,t),Tt.Inr e)::s_data, vs ->
+      | ((_,_,t),Tt.Constrained e)::s_data, vs ->
         let e = Tt.instantiate res e in
         fold ctx res (e::es) vs s_data
-      | (_,Tt.Inl _)::_,[] ->
+      | (_,Tt.Unconstrained _)::_,[] ->
         Error.runtime ~loc "too few fields"
       | [], _::_ ->
         Error.runtime ~loc "too many fields"
@@ -516,7 +516,7 @@ and check ((c',loc) as c) (Jdg.Ty (_, t_check') as t_check) : (Context.t * Tt.te
   | Syntax.String _
   | Syntax.GenSig _
   | Syntax.GenStruct _
-  | Syntax.GenProj _ 
+  | Syntax.GenProj _
   | Syntax.Occurs _
   | Syntax.Context _
   | Syntax.Ident _ ->
@@ -609,10 +609,10 @@ and check ((c',loc) as c) (Jdg.Ty (_, t_check') as t_check) : (Context.t * Tt.te
       | [] ->
         let rec complete fields = function
           | [] -> List.rev fields
-          | ((_,Tt.Inr _) as data)::s_data ->
-            complete ((data,None)::fields) s_data
-          | ((l,_,_),Tt.Inl _)::_ -> Error.runtime ~loc "Field %t missing"
-                                                (Name.print_ident l)
+          | ((_,Tt.Constrained _) as data)::s_data ->
+             complete ((data,None)::fields) s_data
+          | ((l,_,_),Tt.Unconstrained _)::_ ->
+             Error.runtime ~loc "Field %t missing" (Name.print_ident l)
         in
         complete fields s_data
       | (l,x,c)::lxcs ->
@@ -626,7 +626,7 @@ and check ((c',loc) as c) (Jdg.Ty (_, t_check') as t_check) : (Context.t * Tt.te
           | [] -> Error.runtime ~loc "Field %t does not appear in signature %t"
                                 (Name.print_ident l) (Name.print_ident s)
         in
-        find fields s_data    
+        find fields s_data
     in
     (* [res] is only the explicit fields, [es] instantiates the types *)
     let rec fold ctx res es = function
@@ -635,25 +635,25 @@ and check ((c',loc) as c) (Jdg.Ty (_, t_check') as t_check) : (Context.t * Tt.te
         let e = Tt.mk_structure ~loc s_sig res in
         let e = Tt.mention_atoms hyps e in
         Value.return (ctx,e)
-      | (((_,_,t),Tt.Inr e),Some (x,None))::rem ->
+      | (((_,_,t),Tt.Constrained e),Some (x,None))::rem ->
         let e = Tt.instantiate res e
         and t = Tt.instantiate_ty es t in
         let j = Jdg.mk_term ctx e t in
         Value.add_bound x (Value.mk_term j)
         (fold ctx res (e::es) rem)
-      | (((_,_,t),Tt.Inl _),Some (x,Some c))::rem ->
+      | (((_,_,t),Tt.Unconstrained _),Some (x,Some c))::rem ->
         let t = Tt.instantiate_ty es t in
         let jt = Jdg.mk_ty ctx t in
         check c jt >>= fun (ctx,e) ->
         let j = Jdg.mk_term ctx e t in
         Value.add_bound x (Value.mk_term j)
         (fold ctx (e::res) (e::es) rem)
-      | ((_,Tt.Inr e),None)::rem ->
+      | ((_,Tt.Constrained e),None)::rem ->
         let e = Tt.instantiate res e in
         fold ctx res (e::es) rem
-      | (((l,_,_),Tt.Inl _),(None | Some (_,None)))::_ ->
+      | (((l,_,_),Tt.Unconstrained _),(None | Some (_,None)))::_ ->
         Error.runtime ~loc "Field %t must be specified" (Name.print_ident l)
-      | (((l,_,_),Tt.Inr _),Some (_,Some _))::_ ->
+      | (((l,_,_),Tt.Constrained _),Some (_,Some _))::_ ->
         Error.runtime ~loc "Field %t is constrained and must not be specified" (Name.print_ident l)
     in
     let fields = align [] (List.combine s_def shares) lxcs in
@@ -1027,4 +1027,3 @@ and use_file (filename, line_limit, interactive, once) =
       Value.push_file filename >>= fun () ->
       fold (fun () c -> exec_cmd base_dir interactive c) () cmds
     end
-

--- a/src/nucleus/matching.ml
+++ b/src/nucleus/matching.ml
@@ -135,7 +135,7 @@ let rec collect_tt_pattern env xvs (p',_) ctx ({Tt.term=e';loc;_} as e) t =
             let y,ctx = Context.add_fresh ctx x t in
             let jy = Jdg.mk_term ctx (Tt.mk_atom ~loc y) t in
             let v = Value.mk_tuple [Value.mk_ident l;Value.mk_term jy] in
-            fold ctx ((Tt.Inl x)::shares) (v::res) (y::ys) rem
+            fold ctx ((Tt.Unconstrained x)::shares) (v::res) (y::ys) rem
         in
         let vbase = fold Context.empty [] [] [] s_def in
         (* Build a representation of the constraints *)
@@ -143,18 +143,18 @@ let rec collect_tt_pattern env xvs (p',_) ctx ({Tt.term=e';loc;_} as e) t =
           | [] ->
             let lv = Value.mk_list (List.rev lv) in
             Value.mk_tuple [vbase;lv]
-          | ((_,_,t),(Tt.Inl x))::rem ->
+          | ((_,_,t),(Tt.Unconstrained x))::rem ->
             let t = Tt.instantiate_ty es t in
             let y,ctx = Context.add_fresh ctx x t in
             let y = Tt.mk_atom ~loc y in
             let jy = Jdg.mk_term ctx y t in
-            let v = Value.from_sum (Tt.Inl (Value.mk_term jy)) in
+            let v = Value.from_constrain (Tt.Unconstrained (Value.mk_term jy)) in
             fold ctx (v::lv) (y::es) (y::ys) rem
-          | ((_,_,t),(Tt.Inr e))::rem ->
+          | ((_,_,t),(Tt.Constrained e))::rem ->
             let t = Tt.instantiate_ty es t
             and e = Tt.instantiate ys e in
             let je = Jdg.mk_term ctx e t in
-            let v = Value.from_sum (Tt.Inr (Value.mk_term je)) in
+            let v = Value.from_constrain (Tt.Constrained (Value.mk_term je)) in
             fold ctx (v::lv) (e::es) ys rem
         in
         let v = fold ctx [] [] [] (List.combine s_def shares) in

--- a/src/nucleus/tt.ml
+++ b/src/nucleus/tt.ml
@@ -1,8 +1,8 @@
 (** The abstract syntax of Andromedan type theory (TT). *)
 
-type ('a,'b) sum =
-  | Inl of 'a
-  | Inr of 'b
+type ('a,'b) constrain =
+  | Unconstrained of 'a
+  | Constrained of 'b
 
 type ('a, 'b) abstraction = (Name.ident * 'a) * 'b
 
@@ -37,7 +37,7 @@ and 'a ty_abstraction = (ty, 'a) abstraction
 
 and sig_def = (Name.label * Name.ident * ty) list
 
-and signature = Name.signature * (Name.ident, term) sum list
+and signature = Name.signature * (Name.ident, term) constrain list
 
 and structure = signature * term list
 
@@ -98,8 +98,8 @@ let mk_refl ~loc t e =
 let assumptions_sig (_,shares) =
   let rec fold lvl acc = function
     | [] -> acc
-    | (Inl _) :: shares -> fold (lvl+1) acc shares
-    | (Inr e) :: shares ->
+    | (Unconstrained _) :: shares -> fold (lvl+1) acc shares
+    | (Constrained e) :: shares ->
       let acc = Assumption.union acc (Assumption.bind lvl e.assumptions) in
       fold lvl acc shares
   in
@@ -206,10 +206,10 @@ and at_var_ty atom bound hyps ~lvl (Ty a) =
 and at_var_sig atom bound hyps ~lvl (s, shares) =
   let rec fold lvl res = function
     | [] -> s, List.rev res
-    | (Inl x) :: shares -> fold (lvl+1) ((Inl x)::res) shares
-    | (Inr e) :: shares ->
+    | (Unconstrained x) :: shares -> fold (lvl+1) ((Unconstrained x)::res) shares
+    | (Constrained e) :: shares ->
       let e = at_var atom bound hyps ~lvl e in
-      fold lvl ((Inr e)::res) shares
+      fold lvl ((Constrained e)::res) shares
   in
   fold lvl [] shares
 
@@ -323,8 +323,8 @@ and occurs_ty k (Ty t) = occurs k t
 and occurs_shares k shares =
   let rec fold acc k = function
     | [] -> acc
-    | (Inl _) :: shares -> fold acc (k+1) shares
-    | (Inr e) :: shares -> let acc = acc + occurs k e in fold acc k shares
+    | (Unconstrained _) :: shares -> fold acc (k+1) shares
+    | (Constrained e) :: shares -> let acc = acc + occurs k e in fold acc k shares
   in
   fold 0 k shares
 
@@ -406,11 +406,11 @@ and alpha_equal_sig (s1,shares1) (s2,shares2) =
   Name.eq_ident s1 s2 &&
   let rec fold lst1 lst2 = match lst1, lst2 with
     | [], [] -> true
-    | (Inl _)::lst1, (Inl _)::lst2 -> fold lst1 lst2
-    | (Inr e1) :: lst1, (Inr e2) :: lst2 ->
+    | (Unconstrained _)::lst1, (Unconstrained _)::lst2 -> fold lst1 lst2
+    | (Constrained e1) :: lst1, (Constrained e2) :: lst2 ->
       alpha_equal e1 e2 &&
       fold lst1 lst2
-    | (Inl _) :: _, (Inr _) :: _ | (Inr _) :: _, (Inl _) :: _ -> false
+    | (Unconstrained _) :: _, (Constrained _) :: _ | (Constrained _) :: _, (Unconstrained _) :: _ -> false
     | [], _:: _ | _ :: _, [] -> Error.impossible ~loc:Location.unknown "alpha_equal_sig: malformed signatures"
   in
   fold shares1 shares2
@@ -670,8 +670,8 @@ and print_sig_def ~penv xts ppf =
         (print_sig_def ~penv:(add_forbidden y penv) lst)
 
 and print_share ~penv lshare ppf = match lshare with
-  | l, Inl x -> print_label l x ppf
-  | l, Inr e -> Format.fprintf ppf "%t@ =@ %t" (Name.print_ident l) (print_term ~penv e)
+  | l, Unconstrained x -> print_label l x ppf
+  | l, Constrained e -> Format.fprintf ppf "%t@ =@ %t" (Name.print_ident l) (print_term ~penv e)
 
 and print_selected_shares ~penv lshares ppf =
   match lshares with
@@ -680,31 +680,31 @@ and print_selected_shares ~penv lshares ppf =
     print_selected_shares ~penv:(add_forbidden Name.anonymous penv) lshares ppf
   | (l,Some share) :: rem when (List.for_all (fun (_,maybe) -> maybe = None) rem) ->
     print_share ~penv (l,share) ppf
-  | (l, Some ((Inl x) as share)) :: lshares ->
+  | (l, Some ((Unconstrained x) as share)) :: lshares ->
     let x = Name.refresh penv.forbidden x in
     Format.fprintf ppf "%t,@ %t" (print_share ~penv (l,share))
                                  (print_selected_shares ~penv:(add_forbidden x penv) lshares)
-  | (l, Some ((Inr _) as share)) :: lshares ->
+  | (l, Some ((Constrained _) as share)) :: lshares ->
     Format.fprintf ppf "%t,@ %t" (print_share ~penv (l,share))
                                  (print_selected_shares ~penv lshares)
 
 and print_shares ~penv s_def shares ppf =
   let rec select acc = function
     | [] -> List.rev acc
-    | ((Inl x) as share) :: shares ->
+    | ((Unconstrained x) as share) :: shares ->
       if occurs_shares 0 shares > 0
       then
         select (Some share :: acc) shares
       else
         select (None::acc) shares
-    | ((Inr _) as share) :: shares ->
+    | ((Constrained _) as share) :: shares ->
       select (Some share :: acc) shares
   in
   let lshares = List.combine s_def (select [] shares) in
   print_selected_shares ~penv lshares ppf
 
 and print_sig ~penv (s,shares) ppf =
-  if List.for_all (function | Inl _ -> true | Inr _ -> false) shares
+  if List.for_all (function | Unconstrained _ -> true | Constrained _ -> false) shares
   then
     Name.print_ident s ppf
   else
@@ -719,8 +719,8 @@ and print_structure ?max_level ~penv (s,shares) es ppf =
   let ls = penv.sigs s in
   let rec fold acc es ls shares = match ls, shares with
     | [], [] -> List.rev acc
-    | _::ls, (Inr _) :: shares -> fold acc es ls shares
-    | l::ls, (Inl _) :: shares ->
+    | _::ls, (Constrained _) :: shares -> fold acc es ls shares
+    | l::ls, (Unconstrained _) :: shares ->
       begin match es with
         | [] -> Error.impossible ~loc:Location.unknown "print_structure: malformed structure"
         | e::es -> fold ((l,e)::acc) es ls shares
@@ -744,10 +744,10 @@ let struct_combine ~loc ((_,shares),es) =
      We assume we work on a valid structure so no need to check that no [es] remain at the end. *)
   let rec fold fields exs es = function
     | [] -> List.rev fields
-    | (Inr e) :: shares ->
+    | (Constrained e) :: shares ->
       let e = instantiate exs e in
       fold ((Shared e)::fields) exs es shares
-    | (Inl _) :: shares ->
+    | (Unconstrained _) :: shares ->
       begin match es with
         | [] -> Error.impossible ~loc "struct_combine: malformed structure"
         | e::es -> fold ((Explicit e)::fields) (e::exs) es shares
@@ -780,14 +780,14 @@ let field_project ~loc s_def ((_,shares) as s) trm p =
       if Name.eq_ident p l
       then
         let e = match e with
-          | Inr e -> instantiate projs e
-          | Inl _ -> mk_projection ~loc trm s l
+          | Constrained e -> instantiate projs e
+          | Unconstrained _ -> mk_projection ~loc trm s l
         and t = instantiate_ty vs t in
         e,t
       else
         let e,projs = match e with
-          | Inr e -> instantiate projs e,projs
-          | Inl _ ->
+          | Constrained e -> instantiate projs e,projs
+          | Unconstrained _ ->
             let e = mk_projection ~loc trm s l in
             e,(e::projs)
         in

--- a/src/nucleus/tt.mli
+++ b/src/nucleus/tt.mli
@@ -1,8 +1,8 @@
 (** Abstract syntax of value types and terms *)
 
-type ('a,'b) sum =
-  | Inl of 'a
-  | Inr of 'b
+type ('a,'b) constrain =
+  | Unconstrained of 'a
+  | Constrained of 'b
 
 (** An [('a, 'b) abstraction] is a ['b] bound by (x, 'a) *)
 type ('a, 'b) abstraction = (Name.ident * 'a) * 'b
@@ -66,10 +66,10 @@ and 'a ty_abstraction = (ty, 'a) abstraction
 and sig_def = (Name.label * Name.ident * ty) list
 
 (** A signature with sharing constraints [s with li = vi], the [li] are implicit.
-    [vi] is [Inl xi] when [li] has no constraint, then [xi] is bound in future constraints,
-            [Inr ei] when it has one.
+    [vi] is [Unconstrained xi] when [li] has no constraint, then [xi] is bound in future constraints,
+            [Constrained ei] when it has one.
 *)
-and signature = Name.signature * (Name.ident, term) sum list
+and signature = Name.signature * (Name.ident, term) constrain list
 
 (** A structure [s,es] where [es] are the values of the non constrained fields of [s].
     The [es] do not bind labels. *)

--- a/src/nucleus/value.ml
+++ b/src/nucleus/value.ml
@@ -81,16 +81,16 @@ and handler = {
 type 'a toplevel = env -> 'a * env
 
 (** Predeclared *)
-let name_some = Name.make "Some"
-let name_none = Name.make "None"
-let name_inl  = Name.make "Inl"
-let name_inr  = Name.make "Inr"
+let name_some          = Name.make "Some"
+let name_none          = Name.make "None"
+let name_unconstrained = Name.make "Unconstrained"
+let name_constrained   = Name.make "Constrained"
 
 let predefined_tags = [
-  (name_some, 1);
-  (name_none, 0);
-  (name_inl,  1);
-  (name_inr,  1)
+  (name_some,          1);
+  (name_none,          0);
+  (name_unconstrained, 1);
+  (name_constrained,   1);
 ]
 
 let name_equal        = Name.make "equal"
@@ -249,15 +249,15 @@ let as_option ~loc = function
   | (Term _ | Closure _ | Handler _ | Tag _ | List _ | Tuple _ | Ref _ | String _ | Ident _) as v ->
     Error.runtime ~loc "expected an option but got %s" (name_of v)
 
-let from_sum = function
-  | Tt.Inl x -> Tag (name_inl, [x])
-  | Tt.Inr x -> Tag (name_inr, [x])
+let from_constrain = function
+  | Tt.Unconstrained x -> Tag (name_unconstrained, [x])
+  | Tt.Constrained x -> Tag (name_constrained, [x])
 
-let as_sum ~loc = function
-  | Tag (t,[x]) when (Name.eq_ident t name_inl) -> Tt.Inl x
-  | Tag (t,[x]) when (Name.eq_ident t name_inr) -> Tt.Inr x
+let as_constrain ~loc = function
+  | Tag (t,[x]) when (Name.eq_ident t name_unconstrained) -> Tt.Unconstrained x
+  | Tag (t,[x]) when (Name.eq_ident t name_constrained) -> Tt.Constrained x
   | (Term _ | Closure _ | Handler _ | Tag _ | List _ | Tuple _ | Ref _ | String _ | Ident _) as v ->
-    Error.runtime ~loc "expected a sum but got %s" (name_of v)
+    Error.runtime ~loc "expected a constrain but got %s" (name_of v)
 
 (** Operations *)
 

--- a/src/nucleus/value.mli
+++ b/src/nucleus/value.mli
@@ -109,8 +109,8 @@ val as_list : loc:Location.t -> value -> value list
 val from_option : value option -> value
 val as_option : loc:Location.t -> value -> value option
 
-val from_sum : (value,value) Tt.sum -> value
-val as_sum : loc:Location.t -> value -> (value,value) Tt.sum
+val from_constrain : (value,value) Tt.constrain -> value
+val as_constrain : loc:Location.t -> value -> (value,value) Tt.constrain
 
 (** Operations *)
 val operation : Name.ident -> ?checking:Jdg.ty -> value list -> value comp

--- a/std/equal.m31
+++ b/std/equal.m31
@@ -44,7 +44,7 @@ data lazy 0
      (when we descend in `forall x : A, B` and `forall y : A', B'`,
      we know that `A' == B'` but only under the instantiation, so we can't combine `x` and `y`.
      We also are not allowed to instantiate a pattern variable to any term that depends on `x` or `y`)
-   
+
    TODO occurs check (currently we might instantiate `x := f y`, `y := g x`)
 *)
 
@@ -159,14 +159,14 @@ let rec inst_sides quants x y =
 
 let rec collector_shares collector pop quants s1 s2 = match (s1, s2) with
     | ([], []) => Some (pop_rigids pop quants)
-    | ((Inl ?a)::?s1, (Inl ?b)::?s2) => (* non constrained *)
+    | ((Unconstrained ?a)::?s1, (Unconstrained ?b)::?s2) => (* non constrained *)
       let quants = add_paired_rigids a b quants in
       collector_shares collector (Some pop) quants s1 s2
-    | ((Inr ?a)::?s1, (Inr ?b)::?s2) => (* constrained *)
+    | ((Constrained ?a)::?s1, (Constrained ?b)::?s2) => (* constrained *)
       collector quants a b >?= (fun quants =>
       collector_shares collector pop quants s1 s2)
-    | ((Inl _)::_, (Inr _)::_) => None
-    | ((Inr _)::_, (Inl _)::_) => None
+    | ((Unconstrained _)::_, (Constrained _)::_) => None
+    | ((Constrained _)::_, (Unconstrained _)::_) => None
   end
 
 let rec collector_struct collector quants l1 l2 = match (l1,l2) with
@@ -177,7 +177,7 @@ let rec collector_struct collector quants l1 l2 = match (l1,l2) with
   end
 
 
-(* Update `quants` with values such that `lhs` matches `rhs`. 
+(* Update `quants` with values such that `lhs` matches `rhs`.
    Return updated `Some quants`, or `None` if `lhs` could not
    be made to match `rhs`.
 
@@ -272,7 +272,7 @@ let rec apply_quants f quants = match quants with
 (* given `pat = (f,quants,lhs)`
    where `quants` is an instantiation (usually with only non instantiated pattern variables),
    match `e` with `lhs` and apply `f` to the resulting instantiation if successful.
-   
+
    `f` may be either a closure or a term with a product type.
 *)
 let generic_matcher pat e =
@@ -319,12 +319,12 @@ let process_hint =
 (* An eta hint is a term `e` of type `forall [xs] [a b : T] [eqs : ?? == ??], a == b`. It
   is used by matching `T` with the type of a target equality, then filling in `a` and `b`
   and solving the `eqs`.
-  
+
   If we have an equation `lhs == rhs` at type `T'` to solve through eta:
   * match `T` with `T'` to instantiate `xs` to `vs`
   * compute `e vs lhs rhs` to get a term of type `forall [eqs], lhs == rhs`
   * solve the `eqs`
-  
+
   TODO allow `eqs : forall [ys] ?? == ??`
   This is necessary eg for `funext` (which has `eq : forall x, f x == g x`)
 *)
@@ -485,11 +485,11 @@ let rec do_whnf betas reducing e =
               | Some ?eqt => use eqt in (e1' e2) : t
               | None => fail
             end
-            
+
             The other option would be to have unicity of typing primitives which,
             given a judgement (ctx |- e : t) derives a type t' from the annotations of e and from ctx such that (ctx |- e : t'),
             and then return ctx |- refl t : t == t' and ctx |- e : t'
-            
+
             then t' would be foo[e2/x] for both (e1 e2) and (e1' e2), problem solved (because e1, e1' : forall x : A, foo)
           *)
           let e' = e1' e2 in
@@ -623,7 +623,7 @@ let reducing_spine reducing e =
     | _ => compute_reducing reducing e
   end in
   fold e
-      
+
 
 (* Like `do_whnf betas e` except that it always returns the witness of equality between
    `e` and its normal form (so reflexivity if `e` is normal). *)
@@ -651,7 +651,7 @@ let rec equate_congr a b =
                   yield (equate_congr x y)
                 | lazy =>
                   yield (equal x y)
-              end                
+              end
           end
         | (|- _proj ?a0 _, |- _proj ?b0 _) =>
           handle congruence a' b' with | equal a0 b0 => yield (equate_congr a0 b0) end
@@ -1016,4 +1016,3 @@ let add_hints bs = fold (fun _ b => add_hint b) () bs
 let add_etas  bs = fold (fun _ b => add_eta b) () bs
 
 let fasteq _ = equality_in getstate
-

--- a/tests/everything.m31.ref
+++ b/tests/everything.m31.ref
@@ -71,7 +71,8 @@ x₄₄ : wrapped
 ⊢ a : A
 ⊢ a : A
 ((⊢ wrapped : Type, [(unwrap, unwrap₄₆ : A 
-                                ⊢ unwrap₄₆ : A)]), [Inr (⊢ a : A)])
+                                ⊢ unwrap₄₆ : A)]), [Constrained
+(⊢ a : A)])
 (⊢ {container with T = A} : Type, [⊢ a : A])
 (x₄₉ : wrapped 
  ⊢ x₄₉ : wrapped, unwrap)
@@ -122,8 +123,8 @@ The syntax is vaguely Coq-like. The strict equality is written with a double ==.
 
 data Some 1
 data None 0
-data Inl 1
-data Inr 1
+data Unconstrained 1
+data Constrained 1
 operation equal 2
 operation as_prod 1
 operation as_eq 1

--- a/tests/generic.m31.ref
+++ b/tests/generic.m31.ref
@@ -10,9 +10,9 @@ ankle is defined.
                             ⊢ person₂₄ : Type), (pet,
 person₂₄ : Type 
 pet₂₅ : person₂₄ 
-⊢ pet₂₅ : person₂₄)]), [Inl
+⊢ pet₂₅ : person₂₄)]), [Unconstrained
 (person₂₆ : Type 
- ⊢ person₂₆ : Type), Inl
+ ⊢ person₂₆ : Type), Unconstrained
 (person₂₆ : Type 
  pet₂₇ : person₂₆ 
  ⊢ pet₂₇ : person₂₆)])

--- a/tests/sharing.m31
+++ b/tests/sharing.m31
@@ -25,7 +25,7 @@ let l_x = ident x
 
 let aT = assume T : Type in T
 
-let exwrap' = _sig wrap [(Inl aT),(Inr (exfalso aT))]
+let exwrap' = _sig wrap [(Unconstrained aT),(Constrained (exfalso aT))]
 
 do equal exwrap exwrap'
 


### PR DESCRIPTION
Rename `Inl' and `Inr' to `Unconstrained' and `Constrained' respectively
in signatures.