### PR TITLE
Fix `where` substitution

### DIFF
--- a/src/nucleus/eval.ml
+++ b/src/nucleus/eval.ml
@@ -159,16 +159,22 @@ let rec infer (c',loc) =
        infer c)
 
   | Syntax.Where (c1, c2, c3) ->
-    infer c2 >>= as_atom ~loc >>= fun (ctxa, a, ta) ->
-    infer c1 >>= as_term ~loc >>= fun (Jdg.Term (ctx, e1, t1)) ->
+    infer c2 >>= as_atom ~loc >>= fun (_, a, _) ->
+    infer c1 >>= fun v1 ->
+    as_term ~loc v1 >>= fun (Jdg.Term (ctx, e1, t1)) ->
     Value.lookup_penv >>= fun penv ->
-    let ctx = Context.join ~penv ~loc ctxa ctx in
-    check c3 (Jdg.mk_ty ctx ta) >>= fun (ctx, e2) ->
-    let ctx_s = Context.substitute ~penv ~loc a (ctx,e2,ta) in
-    let te_s = Tt.substitute [a] [e2] e1 in
-    let ty_s = Tt.substitute_ty [a] [e2] t1 in
-    let j_s = Jdg.mk_term ctx_s te_s ty_s in
-    Value.return_term j_s
+    begin match Context.lookup_ty a ctx with
+    | None -> infer c3 >>=
+       as_term ~loc:(snd c3) >>= fun _ ->
+       Value.return v1
+    | Some ta ->
+       check c3 (Jdg.mk_ty ctx ta) >>= fun (ctx, e2) ->
+       let ctx_s = Context.substitute ~penv ~loc a (ctx,e2,ta) in
+       let te_s = Tt.substitute [a] [e2] e1 in
+       let ty_s = Tt.substitute_ty [a] [e2] t1 in
+       let j_s = Jdg.mk_term ctx_s te_s ty_s in
+       Value.return_term j_s
+    end
 
   | Syntax.Match (c, cases) ->
      infer c >>=

--- a/tests/substitution-ignore-atom-type.m31
+++ b/tests/substitution-ignore-atom-type.m31
@@ -1,0 +1,10 @@
+(* PR #268 *)
+
+let T = assume T : Type in T
+let P = assume P : T → Type in P
+constant A : Type
+constant B : A → Type
+
+do (P where T = A) where P = B
+
+do (P where T = A) where (P where T = A) = B

--- a/tests/substitution-ignore-atom-type.m31.ref
+++ b/tests/substitution-ignore-atom-type.m31.ref
@@ -1,0 +1,6 @@
+T is defined.
+P is defined.
+Constant A is declared.
+Constant B is declared.
+⊢ B : A → Type
+⊢ B : A → Type


### PR DESCRIPTION
In `c₁ where c₂ = c₃`, if `c₂ ~~> Γ₂ ⊢ x : T₂` we used to use `T₂` as
type of `x`. This type is used to run `c₃` in checking mode and to make
sure the substitution is well-typed.

Using `T₂` does not have the intended behaviour though; instead the type
of `x` in `Γ₁` should be used.

In the below example, the first `do` fails without this commit.

```
let T = assume T : Type in T
let P = assume P : T → Type in P
constant A : Type
constant B : A → Type

do (P where T = A) where P = B

do (P where T = A) where (P where T = A) = B
```