### PR TITLE
Unified Binding

### DIFF
--- a/src/nucleus/eval.ml
+++ b/src/nucleus/eval.ml
@@ -45,7 +45,7 @@ let rec infer (c',loc) =
        Value.lookup_bound ~loc i
 
     | Syntax.Dynamic x ->
-       Value.lookup_dynamic x
+       Value.lookup_dynamic_value x
 
     | Syntax.Type ->
        let e = Tt.mk_type ~loc in
@@ -233,7 +233,7 @@ let rec infer (c',loc) =
      let et' = Jdg.mk_term ctxe e' t' in
      Value.return_term et'
 
-  | Syntax.Signature (s,xcs) ->
+  | Syntax.Signature (s,xcs) -> assert false (* TODO
     (* [vs] are the constraints,
        [es] instantiate types,
        [ys:ts] are assumed for unconstrained fields *)
@@ -268,7 +268,7 @@ let rec infer (c',loc) =
         fold ctx ((Tt.Unconstrained x)::vs) (ey::es) (y::ys) (t::ts) rem)
     in
     Value.lookup_signature ~loc s >>= fun def ->
-    fold Context.empty [] [] [] [] (List.combine def xcs)
+    fold Context.empty [] [] [] [] (List.combine def xcs) *)
 
   | Syntax.Structure lxcs ->
     (* In infer mode the structure must be fully specified. *)
@@ -941,9 +941,8 @@ and topletrec_bind ~loc interactive fxcs =
   return ()
 
 let rec exec_cmd base_dir interactive c =
-  Value.top_get_env >>= fun env ->
-  Value.top_bound_names >>= fun xs ->
-  let (c', loc) = Desugar.toplevel env xs c in
+  Value.top_bound_info >>= fun bound ->
+  let (c', loc) = Desugar.toplevel bound c in
   match c' with
 
   | Syntax.DeclOperation (x, k) ->

--- a/src/nucleus/matching.ml
+++ b/src/nucleus/matching.ml
@@ -32,7 +32,7 @@ let rec collect_tt_pattern env xvs (p',_) ctx ({Tt.term=e';loc;_} as e) t =
      else raise Match_fail
 
   | Syntax.Tt_Dynamic x, _ ->
-     let v' = Value.get_dyn x env in
+     let v' = Value.get_dynamic_value x env in
      if Value.equal_value (Value.mk_term (Jdg.mk_term ctx e t)) v'
      then xvs
      else raise Match_fail

--- a/src/nucleus/tt.ml
+++ b/src/nucleus/tt.ml
@@ -23,7 +23,7 @@ and term' =
   | Type
   | Atom of Name.atom
   | Bound of bound
-  | Constant of Name.ident
+  | Constant of Name.constant
   | Lambda of (term * ty) ty_abstraction
   | Apply of term * ty ty_abstraction * term
   | Prod of ty ty_abstraction

--- a/src/nucleus/tt.mli
+++ b/src/nucleus/tt.mli
@@ -28,7 +28,7 @@ and term' = private
   | Bound of bound
 
   (** a constant *)
-  | Constant of Name.ident
+  | Constant of Name.constant
 
   (** a lambda abstraction [fun (x1 : t1) -> e : t] *)
   | Lambda of (term * ty) ty_abstraction

--- a/src/nucleus/value.ml
+++ b/src/nucleus/value.ml
@@ -4,13 +4,13 @@ type ref = Store.key
 
 type dyn = Store.key
 
-(* Information about a toplevel declaration *)
-type decl =
-  | DeclConstant of Tt.ty
-  | DeclData of int
-  | DeclOperation of int
-  | DeclSignature of Tt.sig_def
-  | DeclDynamic of dyn
+type bound_info =
+  | BoundVal
+  | BoundConst of Name.constant
+  | BoundData of Name.data * int
+  | BoundOp of Name.operation * int
+  | BoundSig of Name.signature
+  | BoundDyn of dyn
 
 (** This module defines 2 monads:
     - the computation monad [comp], providing operations and an environment of which part is dynamically scoped.
@@ -31,21 +31,27 @@ type env = {
 }
 
 and dynamic = {
-  decls : (Name.ident * decl) list ;
-  (* Toplevel declaration *)
+  (* Toplevel declarations *)
+  constants : (Name.constant * Tt.ty) list;
+  datas : (Name.data * int) list;
+  operations : (Name.operation * int) list;
+  signatures : (Name.signature * Tt.sig_def) list;
 
-  abstracting : value list;
   (* The list of judgments about atoms which are going to be abstracted. We
      should avoid creating atoms which depends on these, as this will prevent
      abstraction from working. The list is in the reverse order from
      abstraction, i.e., the inner-most abstracted variable appears first in the
      list. *)
+  abstracting : value list;
 
+  (* Current values of dynamic variables *)
   vars : value Store.t
 }
 
 and lexical = {
-  bound : (Name.ident * value) list;
+  context : (Name.ident * bound_info) list;
+  bound : value list;
+
   continuation : (value,value) closure option;
 
   (* The following are only modified at the top level *)
@@ -286,49 +292,24 @@ let operation_as_signature v =
 
 (** Interact with the environment *)
 
-let top_bound_names env = List.map fst env.lexical.bound, env
+let top_bound_info env = env.lexical.context, env
 
 let top_get_env env = env, env
 
 let get_env env = Return env, env.state
 
-let get_decl x env =
-  let rec get = function
-    | [] -> None
-    | (y,v) :: lst ->
-       if Name.eq_ident x y then Some v else get lst
-  in
-  get env.dynamic.decls
-
 let get_operation x env =
-  match get_decl x env with
-  | None -> None
-  | Some (DeclOperation k) -> Some k
-  | Some (DeclData _ | DeclConstant _ | DeclSignature _ | DeclDynamic _) -> None
+  Name.assoc_ident x env.dynamic.operations
 
 let get_data x env =
-  match get_decl x env with
-  | None -> None
-  | Some (DeclData k) -> Some k
-  | Some (DeclOperation _ | DeclConstant _ | DeclSignature _ | DeclDynamic _) -> None
+  Name.assoc_ident x env.dynamic.datas
 
 let get_constant x env =
-  match get_decl x env with
-  | None -> None
-  | Some (DeclConstant c) -> Some c
-  | Some (DeclData _ | DeclOperation _ | DeclSignature _ | DeclDynamic _) -> None
+  Name.assoc_ident x env.dynamic.constants
 
 let get_signature x env =
-  match get_decl x env with
-  | None -> None
-  | Some (DeclSignature s) -> Some s
-  | Some (DeclData _ | DeclOperation _ | DeclConstant _ | DeclDynamic _) -> None
+  Name.assoc_ident x env.dynamic.signatures
 
-let get_dynamic x env =
-  match get_decl x env with
-    | None -> None
-    | Some (DeclDynamic y) -> Some y
-    | Some (DeclData _ | DeclOperation _ | DeclConstant _ | DeclSignature _) -> None
 
 let lookup_constant ~loc x env =
   match get_constant x env with
@@ -343,7 +324,7 @@ let lookup_signature ~loc x env =
 let find_signature ~loc ls env =
   let rec fold = function
     | [] -> Error.runtime ~loc "No signature has these exact fields."
-    | (s, DeclSignature s_def) :: lst ->
+    | (s, s_def) :: lst ->
        let rec cmp lst1 lst2 =
          match lst1, lst2 with
          | [], [] -> true
@@ -351,27 +332,29 @@ let find_signature ~loc ls env =
          | [],_::_ | _::_,[] -> false
        in
        if cmp ls s_def then s, s_def else fold lst
-    | (_, (DeclConstant _ | DeclData _ | DeclOperation _ | DeclDynamic _)) :: lst -> fold lst
   in
-  Return (fold env.dynamic.decls), env.state
+  Return (fold env.dynamic.signatures), env.state
 
 let lookup_abstracting env = Return env.dynamic.abstracting, env.state
 
 let get_bound ~loc k env =
   try
-    snd (List.nth env.lexical.bound k)
+    List.nth env.lexical.bound k
   with
+  (* TODO is there a point in having this? *)
   | Failure _ -> Error.impossible ~loc "invalid de Bruijn index %d" k
 
-let get_dyn x env = Store.lookup x env.dynamic.vars
+let get_dynamic_value x env = Store.lookup x env.dynamic.vars
 
 let lookup_bound ~loc k env =
   Return (get_bound ~loc k env), env.state
 
-let lookup_dynamic x env =
-  Return (get_dyn x env), env.state
+let lookup_dynamic_value x env =
+  Return (get_dynamic_value x env), env.state
 
-let add_bound0 x v env = {env with lexical = { env.lexical with bound = (x,v)::env.lexical.bound } }
+let add_bound0 x v env = {env with lexical = { env.lexical with
+                                               context = (x, BoundVal) :: env.lexical.context;
+                                               bound = v :: env.lexical.bound } }
 
 let add_free ~loc x (Jdg.Ty (ctx, t)) m env =
   let y, ctx = Context.add_fresh ctx x t in
@@ -397,40 +380,43 @@ let add_abstracting ~loc ?(bind=true) x (Jdg.Ty (ctx, t)) m env =
 let is_known x env =
   if Name.eq_ident Name.anonymous x then false
   else
-    let rec is_bound = function
-      | [] -> false
-      | (y,_) :: lst -> Name.eq_ident x y || is_bound lst
-    in
-    is_bound env.lexical.bound ||
-    (match get_decl x env with
-     | None -> false
-     | Some _ -> true)
+    match Name.assoc_ident x env.lexical.context with
+      | Some _ -> true
+      | None -> false
 
 let add_operation0 ~loc x k env =
   if is_known x env
   then Error.runtime ~loc "%t is already declared" (Name.print_ident x)
-  else { env with dynamic = {env.dynamic with decls = (x, DeclOperation k) :: env.dynamic.decls }} 
+  else
+  { env with dynamic = {env.dynamic with operations = (x, k) :: env.dynamic.operations };
+             lexical = {env.lexical with context = (x, BoundOp (x, k)) :: env.lexical.context } }
 
 let add_operation ~loc x k env = (),add_operation0 ~loc x k env
 
 let add_data0 ~loc x k env =
   if is_known x env
   then Error.runtime ~loc "%t is already declared" (Name.print_ident x)
-  else { env with dynamic = {env.dynamic with decls = (x, DeclData k) :: env.dynamic.decls }}
+  else
+  { env with dynamic = {env.dynamic with datas = (x, k) :: env.dynamic.datas };
+             lexical = {env.lexical with context = (x, BoundData (x, k)) :: env.lexical.context } }
 
 let add_data ~loc x k env = (), add_data0 ~loc x k env
 
-let add_constant0 ~loc x ytsu env =
+let add_constant0 ~loc x t env =
   if is_known x env
   then Error.runtime ~loc "%t is already declared" (Name.print_ident x)
-  else { env with dynamic = {env.dynamic with decls = (x, DeclConstant ytsu) :: env.dynamic.decls }}
+  else
+  { env with dynamic = {env.dynamic with constants = (x, t) :: env.dynamic.constants };
+             lexical = {env.lexical with context = (x, BoundConst x) :: env.lexical.context } }
 
-let add_constant ~loc x ytsu env = (), add_constant0 ~loc x ytsu env
+let add_constant ~loc x t env = (), add_constant0 ~loc x t env
 
 let add_signature0 ~loc s s_def env =
   if is_known s env
   then Error.runtime ~loc "%t is already declared" (Name.print_ident s)
-  else {env with dynamic = {env.dynamic with decls = (s, DeclSignature s_def) :: env.dynamic.decls}}
+  else
+  { env with dynamic = {env.dynamic with signatures = (s, s_def) :: env.dynamic.signatures };
+             lexical = {env.lexical with context = (s, BoundSig s) :: env.lexical.context } }
 
 let add_signature ~loc s s_def env = (), add_signature0 ~loc s s_def env
 
@@ -479,9 +465,8 @@ let add_dynamic0 ~loc x v env =
   then Error.runtime ~loc "%t is already declared" (Name.print_ident x)
   else
     let y,vars = Store.fresh v env.dynamic.vars in
-    { env with dynamic = {env.dynamic with
-        decls = (x, DeclDynamic y) :: env.dynamic.decls;
-        vars }}
+    { env with dynamic = {env.dynamic with vars };
+               lexical = {env.lexical with context = (x, BoundDyn y) :: env.lexical.context } }
 
 let add_dynamic ~loc x v env = (), add_dynamic0 ~loc x v env
 
@@ -527,7 +512,7 @@ let included f env =
 
 (** Generate a printing environment from runtime environment *)
 let get_penv env =
-  { Tt.forbidden = List.map fst env.lexical.bound @ List.map fst env.dynamic.decls ;
+  { Tt.forbidden = List.map fst env.lexical.context ;
     Tt.sigs = (fun s ->
                match get_signature s env with
                  | None -> Error.impossible ~loc:Location.unknown "get_penv: unknown signature %t" (Name.print_ident s)
@@ -639,41 +624,43 @@ let print_ty env =
 let print_env env =
   let print env ppf =
     let penv = get_penv env in
-    List.iter
-      (function
-        | (x, DeclConstant t) ->
+    List.iter (fun (x,t) ->
            Format.fprintf ppf "@[<hov 4>constant %t@;<1 -2>%t@]@\n"
                           (Name.print_ident x)
-                          (Tt.print_ty ~penv t)
-        | (x, DeclData k) ->
+                          (Tt.print_ty ~penv t))
+      env.dynamic.constants ;
+    List.iter (fun (x,k) ->
            Format.fprintf ppf "@[<hov 4>data %t %d@]@\n"
                           (Name.print_ident x)
-                          k
-        | (x, DeclOperation k) ->
+                          k)
+      env.dynamic.datas ;
+    List.iter (fun (x,k) ->
            Format.fprintf ppf "@[<hov 4>operation %t %d@]@\n"
                           (Name.print_ident x)
-                          k
-        | (x, DeclSignature s) ->
+                          k)
+      env.dynamic.operations ;
+    List.iter (fun (x,s) ->
            Format.fprintf ppf "@[<hov 4>signature %t %t@]@\n"
                        (Name.print_ident x)
-                       (Tt.print_sig_def ~penv s)
-        | (x, DeclDynamic _) ->
-          Format.fprintf ppf "@[<hov 4>dynamic %t@]@\n" (Name.print_ident x)
-      )
-      (List.rev env.dynamic.decls) ;
+                       (Tt.print_sig_def ~penv s))
+      env.dynamic.signatures ;
   in
   print env, env
 
 (* The empty environment *)
 let empty = {
   lexical = {
+    context = [] ;
     bound = [] ;
     handle = [] ;
     continuation = None ;
     files = [] ;
   } ;
   dynamic = {
-    decls = [] ;
+    constants = [] ;
+    datas = [] ;
+    operations = [] ;
+    signatures = [] ;
     abstracting = [] ;
     vars = Store.empty ;
   } ;

--- a/src/nucleus/value.ml
+++ b/src/nucleus/value.ml
@@ -294,22 +294,13 @@ let operation_as_signature v =
 
 let top_bound_info env = env.lexical.context, env
 
-let top_get_env env = env, env
-
 let get_env env = Return env, env.state
-
-let get_operation x env =
-  Name.assoc_ident x env.dynamic.operations
-
-let get_data x env =
-  Name.assoc_ident x env.dynamic.datas
 
 let get_constant x env =
   Name.assoc_ident x env.dynamic.constants
 
 let get_signature x env =
   Name.assoc_ident x env.dynamic.signatures
-
 
 let lookup_constant ~loc x env =
   match get_constant x env with

--- a/src/nucleus/value.mli
+++ b/src/nucleus/value.mli
@@ -1,15 +1,25 @@
 (** Runtime values and computations *)
 
+(** The type of an AML reference. *)
 type ref
+
+(** The type of an AML dynamically scoped variable. *)
 type dyn
 
-(* Information about a toplevel declaration *)
-type decl =
-  | DeclConstant of Tt.ty
-  | DeclData of int
-  | DeclOperation of int
-  | DeclSignature of Tt.sig_def
-  | DeclDynamic of dyn
+(** A name may refer to: *)
+type bound_info =
+  (** A bound value (the index being the number of bound values before it) *)
+  | BoundVal
+  (** The constant [a] *)
+  | BoundConst of Name.constant
+  (** The data constructor [C] with arity [n] *)
+  | BoundData of Name.data * int
+  (** The operation [op] with arity [n] *)
+  | BoundOp of Name.operation * int
+  (** The signature [s] *)
+  | BoundSig of Name.signature
+  (** The dynamic variable [x] *)
+  | BoundDyn of dyn
 
 (** Runtime environment *)
 type env
@@ -128,16 +138,13 @@ val operation_as_signature : value -> value comp
 (** Interact with the environment *)
 
 (** Known bound variables *)
-val top_bound_names : Name.ident list toplevel
+val top_bound_info : (Name.ident * bound_info) list toplevel
 
 (** Extract the current environment (for desugaring) *)
 val top_get_env : env toplevel
 
 (** Extract the current environment (for matching) *)
 val get_env : env comp
-
-(** Lookup a data constructor. *)
-val get_decl : Name.ident -> env -> decl option
 
 (** Lookup an operation *)
 val get_operation : Name.ident -> env -> int option
@@ -159,21 +166,18 @@ val lookup_signature : loc:Location.t -> Name.ident -> Tt.sig_def comp
 (** Find a signature with the given labels (in this exact order) *)
 val find_signature : loc:Location.t -> Name.label list -> (Name.signature * Tt.sig_def) comp
 
-(** Lookup a dynamic variable by name. *)
-val get_dynamic : Name.ident -> env -> dyn option
-
 (** Lookup abstracting variables. *)
 val lookup_abstracting : value list comp
 
 (** Lookup a free variable by its de Bruijn index *)
 val lookup_bound : loc:Location.t -> int -> value comp
 
-val lookup_dynamic : dyn -> value comp
+val lookup_dynamic_value : dyn -> value comp
 
 (** For matching *)
 val get_bound : loc:Location.t -> int -> env -> value
 
-val get_dyn : dyn -> env -> value
+val get_dynamic_value : dyn -> env -> value
 
 (** Add a bound variable with given name to the environment. *)
 val add_bound : Name.ident -> value -> 'a comp -> 'a comp

--- a/src/nucleus/value.mli
+++ b/src/nucleus/value.mli
@@ -140,17 +140,8 @@ val operation_as_signature : value -> value comp
 (** Known bound variables *)
 val top_bound_info : (Name.ident * bound_info) list toplevel
 
-(** Extract the current environment (for desugaring) *)
-val top_get_env : env toplevel
-
 (** Extract the current environment (for matching) *)
 val get_env : env comp
-
-(** Lookup an operation *)
-val get_operation : Name.ident -> env -> int option
-
-(** Lookup a data constructor *)
-val get_data : Name.ident -> env -> int option
 
 (** Lookup a constant. *)
 val get_constant : Name.ident -> env -> Tt.ty option

--- a/src/nucleus/value.mli
+++ b/src/nucleus/value.mli
@@ -127,7 +127,7 @@ val from_constrain : (value,value) Tt.constrain -> value
 val as_constrain : loc:Location.t -> value -> (value,value) Tt.constrain
 
 (** Operations *)
-val operation : Name.ident -> ?checking:Jdg.ty -> value list -> value comp
+val operation : Name.operation -> ?checking:Jdg.ty -> value list -> value comp
 
 val operation_equal : value -> value -> value comp
 
@@ -144,15 +144,15 @@ val top_bound_info : (Name.ident * bound_info) list toplevel
 val get_env : env comp
 
 (** Lookup a constant. *)
-val get_constant : Name.ident -> env -> Tt.ty option
+val get_constant : Name.constant -> env -> Tt.ty option
 
-val lookup_constant : loc:Location.t -> Name.ident -> Tt.ty comp
+val lookup_constant : loc:Location.t -> Name.constant -> Tt.ty comp
 
 (** Lookup a signature definition *)
 val get_signature : Name.signature -> env -> Tt.sig_def option
 
 (** Lookup a signature definition, monadically *)
-val lookup_signature : loc:Location.t -> Name.ident -> Tt.sig_def comp
+val lookup_signature : loc:Location.t -> Name.signature -> Tt.sig_def comp
 
 (** Find a signature with the given labels (in this exact order) *)
 val find_signature : loc:Location.t -> Name.label list -> (Name.signature * Tt.sig_def) comp

--- a/src/parser/desugar.ml
+++ b/src/parser/desugar.ml
@@ -1,13 +1,64 @@
 (** Conversion from sugared to desugared input syntax *)
 
-module IntSet = Set.Make (struct
-                    type t = int
-                    let compare = compare
-                  end)
+(** Bound variable management *)
+module Bound = struct
+
+  type bound_info =
+    | Val of int
+    | Const of Name.constant
+    | Data of Name.data * int
+    | Op of Name.operation * int
+    | Sig of Name.signature
+    | Dyn of Value.dyn
+
+  type t = { toplevel : (Name.ident * bound_info) list; locals : Name.ident list; depth : int }
+
+  (** Add index information to the bound_info *)
+  let compute_indices bound =
+    let rec fold acc i = function
+      | [] -> List.rev acc
+      | (x,Value.BoundVal) :: rem -> fold ((x,Val i)::acc) (i+1) rem
+      | (x,Value.BoundConst c) :: rem -> fold ((x,Const c)::acc) i rem
+      | (x,Value.BoundData (c,k)) :: rem -> fold ((x,Data (c,k))::acc) i rem
+      | (x,Value.BoundOp (op,k)) :: rem -> fold ((x,Op (op,k))::acc) i rem
+      | (x,Value.BoundSig s) :: rem -> fold ((x,Sig s)::acc) i rem
+      | (x,Value.BoundDyn y) :: rem -> fold ((x,Dyn y)::acc) i rem
+    in
+    {toplevel = fold [] 0 bound; locals = []; depth = 0}
+
+  let add x bound = {bound with locals = x :: bound.locals; depth = bound.depth + 1}
+
+  let find ~loc x {toplevel;locals;depth} =
+    match Name.index_of_ident x locals with
+      | Some i -> Val i
+      | None ->
+        begin match Name.assoc_ident x toplevel with
+          | Some (Val k) -> Val (k+depth)
+          | Some (Const _ | Data _ | Op _ | Sig _ | Dyn _ as b) -> b
+          | None -> Error.syntax ~loc "Unknown name %t." (Name.print_ident x)
+        end
+
+  let get_dynamic ~loc x bound =
+    match find ~loc x bound with
+      | Dyn y -> y
+      | Val _ | Const _ | Op _ | Data _ | Sig _ ->
+        Error.syntax ~loc "The variable %t is not a dynamic variable." (Name.print_ident x)
+
+  let get_signature ~loc x bound =
+    match find ~loc x bound with
+      | Sig s -> s
+      | Val _ | Const _ | Op _ | Data _ | Dyn _ ->
+        Error.syntax ~loc "The variable %t is not a signature." (Name.print_ident x)
+
+  let get_operation ~loc x bound =
+    match find ~loc x bound with
+      | Op (op,k) -> op,k
+      | Val _ | Const _ | Data _ | Sig _ | Dyn _ ->
+        Error.syntax ~loc "The name %t is not a operation." (Name.print_ident x)
+
+end
 
 module IdentMap = Name.IdentMap
-
-let add_bound x bound = x :: bound
 
 let mk_lambda ~loc ys c =
   List.fold_left (fun c (y,u) -> Syntax.Lambda (y,u,c), loc) c ys
@@ -15,48 +66,42 @@ let mk_lambda ~loc ys c =
 let mk_prod ~loc ys t =
   List.fold_left (fun c (y,u) -> Syntax.Prod (y,u,c), loc) t ys
 
-
 (* n is the length of vars *)
-let rec tt_pattern (env : Value.env) bound vars n (p,loc) =
+let rec tt_pattern bound vars n (p,loc) =
   match p with
     | Input.Tt_Anonymous ->
       (Syntax.Tt_Anonymous, loc), vars, n
 
     | Input.Tt_As (p,x) ->
-      begin try
-        let i = List.assoc x vars in
-        let p, vars, n = tt_pattern env bound vars n p in
-        (Syntax.Tt_As (p,i), loc), vars, n
-      with | Not_found ->
-        let i = n in
-        let p, vars, n = tt_pattern env bound ((x,n)::vars) (n+1) p in
-        (Syntax.Tt_As (p,i), loc), vars, n
+      begin match Name.assoc_ident x vars with
+        | Some i ->
+          let p, vars, n = tt_pattern bound vars n p in
+          (Syntax.Tt_As (p,i), loc), vars, n
+        | None ->
+          let i = n in
+          let p, vars, n = tt_pattern bound ((x,n)::vars) (n+1) p in
+          (Syntax.Tt_As (p,i), loc), vars, n
       end
 
     | Input.Tt_Var x ->
-      begin try
-        let i = List.assoc x vars in
-        (Syntax.Tt_As ((Syntax.Tt_Anonymous, loc), i), loc), vars, n
-      with | Not_found ->
-        (Syntax.Tt_As ((Syntax.Tt_Anonymous, loc), n), loc), ((x,n)::vars), (n+1)
+      begin match Name.assoc_ident x vars with
+        | Some i ->
+          (Syntax.Tt_As ((Syntax.Tt_Anonymous, loc), i), loc), vars, n
+        | None ->
+          (Syntax.Tt_As ((Syntax.Tt_Anonymous, loc), n), loc), ((x,n)::vars), (n+1)
       end
 
     | Input.Tt_Type ->
       (Syntax.Tt_Type, loc), vars, n
 
     | Input.Tt_Name x ->
-      begin match Name.index_of_ident x bound with
-        | Some k -> (Syntax.Tt_Bound k, loc), vars, n
-        | None ->
-           begin
-             match Value.get_decl x env with
-             | Some (Value.DeclConstant _) -> (Syntax.Tt_Constant x, loc), vars, n
-             | Some (Value.DeclData _) -> Error.syntax ~loc "data in a term pattern"
-             | Some (Value.DeclOperation _) -> Error.syntax ~loc "operation in a term pattern"
-             | Some (Value.DeclSignature _) -> (Syntax.Tt_Signature x, loc), vars, n
-             | Some (Value.DeclDynamic y) -> (Syntax.Tt_Dynamic y, loc), vars, n
-             | None -> Error.syntax ~loc "unknown name %t" (Name.print_ident x)
-           end
+      begin match Bound.find ~loc x bound with
+        | Bound.Val k -> (Syntax.Tt_Bound k, loc), vars, n
+        | Bound.Const c -> (Syntax.Tt_Constant c, loc), vars, n
+        | Bound.Data _ -> Error.syntax ~loc "data constructor in a term pattern"
+        | Bound.Op _ -> Error.syntax ~loc "operation in a term pattern"
+        | Bound.Sig s -> (Syntax.Tt_Signature s, loc), vars, n
+        | Bound.Dyn y -> (Syntax.Tt_Dynamic y, loc), vars, n
       end
 
     | Input.Tt_Lambda (b,x,popt,p) ->
@@ -64,26 +109,27 @@ let rec tt_pattern (env : Value.env) bound vars n (p,loc) =
         | None ->
           None, vars, n
         | Some p ->
-          let p, vars, n = tt_pattern env bound vars n p in
+          let p, vars, n = tt_pattern bound vars n p in
           Some p, vars, n
         in
       let bopt, vars, n =
         if b
         then
-          try
+          begin match Name.assoc_ident x vars with
+            | Some i ->
             (* XXX it might be a good idea to warn if x is already a pattern variable, since that should never match. *)
-            let i = List.assoc x vars in
-            Some i, vars, n
-          with | Not_found ->
-            Some n, ((x,n)::vars), (n+1)
+              Some i, vars, n
+            | None ->
+              Some n, ((x,n)::vars), (n+1)
+          end
         else None, vars, n
       in
-      let p, vars, n = tt_pattern env (add_bound x bound) vars n p in
+      let p, vars, n = tt_pattern (Bound.add x bound) vars n p in
       (Syntax.Tt_Lambda (x,bopt,popt,p), loc), vars, n
 
     | Input.Tt_Apply (p1,p2) ->
-      let p1, vars, n = tt_pattern env bound vars n p1 in
-      let p2, vars, n = tt_pattern env bound vars n p2 in
+      let p1, vars, n = tt_pattern bound vars n p1 in
+      let p2, vars, n = tt_pattern bound vars n p2 in
       (Syntax.Tt_Apply (p1,p2), loc), vars, n
 
     | Input.Tt_Prod (b,x,popt,p) ->
@@ -91,29 +137,31 @@ let rec tt_pattern (env : Value.env) bound vars n (p,loc) =
         | None ->
           None, vars, n
         | Some p ->
-          let p, vars, n = tt_pattern env bound vars n p in
+          let p, vars, n = tt_pattern bound vars n p in
           Some p, vars, n
         in
       let bopt, vars, n =
         if b
         then
-          try
-            let i = List.assoc x vars in
-            Some i, vars, n
-          with | Not_found ->
-            Some n, ((x,n)::vars), (n+1)
+          begin match Name.assoc_ident x vars with
+            | Some i ->
+            (* XXX it might be a good idea to warn if x is already a pattern variable, since that should never match. *)
+              Some i, vars, n
+            | None ->
+              Some n, ((x,n)::vars), (n+1)
+          end
         else None, vars, n
       in
-      let p, vars, n = tt_pattern env (add_bound x bound) vars n p in
+      let p, vars, n = tt_pattern (Bound.add x bound) vars n p in
       (Syntax.Tt_Prod (x,bopt,popt,p), loc), vars, n
 
     | Input.Tt_Eq (p1,p2) ->
-      let p1, vars, n = tt_pattern env bound vars n p1 in
-      let p2, vars, n = tt_pattern env bound vars n p2 in
+      let p1, vars, n = tt_pattern bound vars n p1 in
+      let p2, vars, n = tt_pattern bound vars n p2 in
       (Syntax.Tt_Eq (p1,p2), loc), vars, n
 
     | Input.Tt_Refl p ->
-      let p, vars, n = tt_pattern env bound vars n p in
+      let p, vars, n = tt_pattern bound vars n p in
       (Syntax.Tt_Refl p, loc), vars, n
 
     | Input.Tt_Structure lps ->
@@ -122,110 +170,110 @@ let rec tt_pattern (env : Value.env) bound vars n (p,loc) =
           let ps = List.rev ps in
           (Syntax.Tt_Structure ps, loc), vars, n
         | (l,p)::rem ->
-          let p, vars, n = tt_pattern env bound vars n p in
+          let p, vars, n = tt_pattern bound vars n p in
           fold vars n ((l,p)::ps) rem
         in
       fold vars n [] lps
 
     | Input.Tt_Projection (p,l) ->
-      let p, vars, n = tt_pattern env bound vars n p in
+      let p, vars, n = tt_pattern bound vars n p in
       (Syntax.Tt_Projection (p,l), loc), vars, n
 
     | Input.Tt_GenSig p ->
-      let p,vars,n = pattern env bound vars n p in
+      let p,vars,n = pattern bound vars n p in
       (Syntax.Tt_GenSig p, loc), vars, n
 
     | Input.Tt_GenStruct (p1,p2) ->
-      let p1, vars, n = tt_pattern env bound vars n p1 in
-      let p2, vars, n = pattern env bound vars n p2 in
+      let p1, vars, n = tt_pattern bound vars n p1 in
+      let p2, vars, n = pattern bound vars n p2 in
       (Syntax.Tt_GenStruct (p1,p2), loc), vars, n
 
     | Input.Tt_GenProj (p1,p2) ->
-      let p1, vars, n = tt_pattern env bound vars n p1 in
-      let p2, vars, n = pattern env bound vars n p2 in
+      let p1, vars, n = tt_pattern bound vars n p1 in
+      let p2, vars, n = pattern bound vars n p2 in
       (Syntax.Tt_GenProj (p1,p2), loc), vars, n
 
     | Input.Tt_GenAtom p ->
-      let p, vars, n = tt_pattern env bound vars n p in
+      let p, vars, n = tt_pattern bound vars n p in
       (Syntax.Tt_GenAtom p, loc), vars, n
 
     | Input.Tt_GenConstant p ->
-      let p, vars, n = tt_pattern env bound vars n p in
+      let p, vars, n = tt_pattern bound vars n p in
       (Syntax.Tt_GenConstant p, loc), vars, n
 
-and pattern (env : Value.env) bound vars n (p,loc) =
+and pattern bound vars n (p,loc) =
   match p with
     | Input.Patt_Anonymous -> (Syntax.Patt_Anonymous, loc), vars, n
 
     | Input.Patt_As (p,x) ->
-      begin try
-        let i = List.assoc x vars in
-        let p, vars, n = pattern env bound vars n p in
-        (Syntax.Patt_As (p,i), loc), vars, n
-      with | Not_found ->
-        let i = n in
-        let p, vars, n = pattern env bound ((x,n)::vars) (n+1) p in
-        (Syntax.Patt_As (p,i), loc), vars, n
+      begin match Name.assoc_ident x vars with
+        | Some i ->
+          let p, vars, n = pattern bound vars n p in
+          (Syntax.Patt_As (p,i), loc), vars, n
+        | None ->
+          let i = n in
+          let p, vars, n = pattern bound ((x,i)::vars) (n+1) p in
+          (Syntax.Patt_As (p,i), loc), vars, n
       end
 
     | Input.Patt_Var x ->
-      begin try
-        let i = List.assoc x vars in
-        (Syntax.Patt_As ((Syntax.Patt_Anonymous, loc), i), loc), vars, n
-      with | Not_found ->
-        (Syntax.Patt_As ((Syntax.Patt_Anonymous, loc), n), loc), ((x,n)::vars), (n+1)
+      begin match Name.assoc_ident x vars with
+        | Some i ->
+          (Syntax.Patt_As ((Syntax.Patt_Anonymous, loc), i), loc), vars, n
+        | None ->
+          (Syntax.Patt_As ((Syntax.Patt_Anonymous, loc), n), loc), ((x,n)::vars), (n+1)
       end
 
     | Input.Patt_Name x ->
-      begin match Name.index_of_ident x bound with
-        | None ->
-          begin match Value.get_data x env with (* TODO get_decl *)
-            | Some k ->
-              if k = 0
-              then (Syntax.Patt_Data (x,[]), loc), vars, n
-              else Error.syntax ~loc "the data constructor %t expects %d arguments but is matched with 0"
-                  (Name.print_ident x) k
-            | None -> Error.syntax ~loc "unknown value name %t" (Name.print_ident x)
-          end
-        | Some k ->
+      begin match Bound.find ~loc x bound with
+        | Bound.Val k ->
             (Syntax.Patt_Bound k, loc), vars, n
+        | Bound.Data (c,k) ->
+          if k = 0
+          then (Syntax.Patt_Data (c,[]), loc), vars, n
+          else Error.syntax ~loc "the data constructor %t expects %d arguments but is matched with 0"
+              (Name.print_ident c) k
+        | Bound.Const _ | Bound.Op _ | Bound.Sig _ | Bound.Dyn _ ->
+          Error.syntax ~loc "cannot match this." (* TODO some can be done *)
       end
 
     | Input.Patt_Jdg (p1,p2) ->
-      let p1, vars, n = tt_pattern env bound vars n p1 in
-      let p2, vars, n = tt_pattern env bound vars n p2 in
+      let p1, vars, n = tt_pattern bound vars n p1 in
+      let p2, vars, n = tt_pattern bound vars n p2 in
       (Syntax.Patt_Jdg (p1,p2), loc), vars, n
 
     | Input.Patt_Data (t,ps) ->
-      begin match Value.get_data t env with
-        | Some k ->
+      begin match Bound.find ~loc t bound with
+        | Bound.Data (c,k) ->
           let l = List.length ps in
           if k = l
           then
             let rec fold vars n ps = function
               | [] ->
                 let ps = List.rev ps in
-                (Syntax.Patt_Data (t,ps), loc), vars, n
+                (Syntax.Patt_Data (c,ps), loc), vars, n
               | p::rem ->
-                let p, vars, n = pattern env bound vars n p in
+                let p, vars, n = pattern bound vars n p in
                 fold vars n (p::ps) rem
               in
             fold vars n [] ps
           else
-            Error.syntax ~loc "the data constructor %t expects %d arguments but is matched with %d" (Name.print_ident t) k l
-        | None -> Error.syntax ~loc "unknown data constructor %t" (Name.print_ident t)
+            Error.syntax ~loc "the data constructor %t expects %d arguments but is matched with %d"
+                         (Name.print_ident c) k l
+        | Bound.Val _ | Bound.Const _ | Bound.Op _ | Bound.Sig _ | Bound.Dyn _ ->
+          Error.syntax ~loc "only data constructors can be applied in general patterns"
       end
 
     | Input.Patt_Cons (p1, p2) ->
-      let p1, vars, n = pattern env bound vars n p1 in
-      let p2, vars, n = pattern env bound vars n p2 in
+      let p1, vars, n = pattern bound vars n p1 in
+      let p2, vars, n = pattern bound vars n p2 in
       (Syntax.Patt_Cons (p1,p2), loc), vars, n
 
     | Input.Patt_List ps ->
        let rec fold ~loc vars n = function
          | [] -> (Syntax.Patt_Nil, loc), vars, n
          | p :: ps ->
-            let p, vars, n = pattern env bound vars n p in
+            let p, vars, n = pattern bound vars n p in
             let ps, vars, n = fold ~loc:(snd p) vars n ps in
             (Syntax.Patt_Cons (p, ps), loc), vars, n
        in
@@ -237,84 +285,77 @@ and pattern (env : Value.env) bound vars n (p,loc) =
           let ps = List.rev ps in
           (Syntax.Patt_Tuple ps, loc), vars, n
         | p::rem ->
-          let p, vars, n = pattern env bound vars n p in
+          let p, vars, n = pattern bound vars n p in
           fold vars n (p::ps) rem
         in
       fold vars n [] ps
 
-let raw_signature ~loc x def =
-  Syntax.Signature (x, List.map (fun _ -> None) def), loc
-
-
-let rec comp ~yield (env : Value.env) bound (c',loc) =
+let rec comp ~yield bound (c',loc) =
   match c' with
     | Input.Handle (c, hcs) ->
-       let c = comp ~yield env bound c
-       and h = handler ~loc env bound hcs in
+       let c = comp ~yield bound c
+       and h = handler ~loc bound hcs in
        Syntax.With (h, c), loc
 
     | Input.With (c1, c2) ->
-       let c1 = comp ~yield env bound c1
-       and c2 = comp ~yield env bound c2 in
+       let c1 = comp ~yield bound c1
+       and c2 = comp ~yield bound c2 in
        Syntax.With (c1, c2), loc
 
     | Input.Let (lst, c) ->
-       let bound, lst = let_clauses ~loc ~yield env bound lst in
-       let c = comp ~yield env bound c in
+       let bound, lst = let_clauses ~loc ~yield bound lst in
+       let c = comp ~yield bound c in
        Syntax.Let (lst, c), loc
 
     | Input.LetRec (lst, c) ->
-       let bound, lst = letrec_clauses ~loc ~yield env bound lst in
-       let c = comp ~yield env bound c in
+       let bound, lst = letrec_clauses ~loc ~yield bound lst in
+       let c = comp ~yield bound c in
        Syntax.LetRec (lst, c), loc
 
     | Input.Now (x,c1,c2) ->
-      begin match Value.get_dynamic x env with
-        | Some y ->
-          let c1 = comp ~yield env bound c1
-          and c2 = comp ~yield env bound c2 in
-          Syntax.Now (y,c1,c2), loc
-        | None -> Error.syntax ~loc "%t is not a dynamic variable." (Name.print_ident x)
-      end
+      let y = Bound.get_dynamic ~loc x bound
+      and c1 = comp ~yield bound c1
+      and c2 = comp ~yield bound c2 in
+      Syntax.Now (y,c1,c2), loc
 
     | Input.Lookup c ->
-       let c = comp ~yield env bound c in
+       let c = comp ~yield bound c in
        Syntax.Lookup c, loc
 
     | Input.Ref c ->
-       let c = comp ~yield env bound c in
+       let c = comp ~yield bound c in
        Syntax.Ref c, loc
 
     | Input.Update (c1, c2) ->
-       let c1 = comp ~yield env bound c1
-       and c2 = comp ~yield env bound c2 in
+       let c1 = comp ~yield bound c1
+       and c2 = comp ~yield bound c2 in
        Syntax.Update (c1, c2), loc
 
     | Input.Sequence (c1, c2) ->
-       let c1 = comp ~yield env bound c1
-       and c2 = comp ~yield env bound c2 in
+       let c1 = comp ~yield bound c1
+       and c2 = comp ~yield bound c2 in
        Syntax.Sequence (c1, c2), loc
 
     | Input.Assume ((x, t), c) ->
-       let t = comp ~yield env bound t in
-       let bound = add_bound x bound in
-       let c = comp ~yield env bound c in
+       let t = comp ~yield bound t in
+       let bound = Bound.add x bound in
+       let c = comp ~yield bound c in
        Syntax.Assume ((x, t), c), loc
 
     | Input.Where (c1, c2, c3) ->
-       let c1 = comp ~yield env bound c1
-       and c2 = comp ~yield env bound c2
-       and c3 = comp ~yield env bound c3 in
+       let c1 = comp ~yield bound c1
+       and c2 = comp ~yield bound c2
+       and c3 = comp ~yield bound c3 in
        Syntax.Where (c1, c2, c3), loc
 
     | Input.Match (c, cases) ->
-       let c = comp ~yield env bound c
-       and cases = List.map (match_case ~yield env bound) cases in
+       let c = comp ~yield bound c
+       and cases = List.map (match_case ~yield bound) cases in
        Syntax.Match (c, cases), loc
 
     | Input.Ascribe (c, t) ->
-       let t = comp ~yield env bound t
-       and c = comp ~yield env bound c in
+       let t = comp ~yield bound t
+       and c = comp ~yield bound c in
        Syntax.Ascribe (c, t), loc
 
     | Input.External s ->
@@ -323,119 +364,94 @@ let rec comp ~yield (env : Value.env) bound (c',loc) =
     | Input.Lambda (xs, c) ->
       let rec fold bound ys = function
         | [] ->
-           let c = comp ~yield env bound c in
+           let c = comp ~yield bound c in
            mk_lambda ~loc ys c
         | (x, None) :: xs ->
-          let bound = add_bound x bound
+          let bound = Bound.add x bound
           and ys = (x, None) :: ys in
           fold bound ys xs
         | (x, Some t) :: xs ->
-          let ys = (let t = comp ~yield env bound t in (x, Some t) :: ys)
-          and bound = add_bound x bound in
+          let ys = (let t = comp ~yield bound t in (x, Some t) :: ys)
+          and bound = Bound.add x bound in
           fold bound ys xs
       in
       fold bound [] xs
 
     | Input.Spine (e, cs) ->
-      spine ~yield env bound e cs
+      spine ~yield bound e cs
 
     | Input.Prod (xs, c) ->
       let rec fold bound ys = function
         | [] ->
-           let c = comp ~yield env bound c in
+           let c = comp ~yield bound c in
            mk_prod ~loc ys c
         | (x,t) :: xs ->
-          let ys = (let t = comp ~yield env bound t in (x, t) :: ys)
-          and bound = add_bound x bound in
+          let ys = (let t = comp ~yield bound t in (x, t) :: ys) in
+          let bound = Bound.add x bound in
           fold bound ys xs
       in
       fold bound [] xs
 
     | Input.Eq (c1, c2) ->
-      let c1 = comp ~yield env bound c1
-      and c2 = comp ~yield env bound c2 in
+      let c1 = comp ~yield bound c1
+      and c2 = comp ~yield bound c2 in
       Syntax.Eq (c1, c2), loc
 
     | Input.Refl c ->
-      let c = comp ~yield env bound c in
+      let c = comp ~yield bound c in
       Syntax.Refl c, loc
 
     | Input.Signature (s,cs) ->
-      begin match Value.get_signature s env with
-        | Some s_def ->
-          let rec fold bound xcs def = function
-            | [] ->
-              let rec complete xcs = function
-                | [] -> Syntax.Signature (s,List.rev xcs), loc
-                | _::def -> complete (None::xcs) def
-              in
-              complete xcs def
-            | (l,mx,mc)::cs ->
-              let rec find xcs = function
-                | (l',_,_)::def ->
-                  if not (Name.eq_ident l l')
-                  then
-                    find (None::xcs) def
-                  else
-                    let x = match mx with | Some x -> x | None -> l in
-                    let mc = match mc with
-                      | Some c -> Some (comp ~yield env bound c)
-                      | None -> None
-                    in
-                    let bound = add_bound x bound in
-                    fold bound (Some (x,mc)::xcs) def cs
-                | [] -> Error.syntax ~loc "Signature constraint: field %t does not appear in signature %t."
-                                     (Name.print_ident l) (Name.print_ident s)
-              in
-              find xcs def
+      let s = Bound.get_signature ~loc s bound in
+      let rec fold bound xcs = function
+        | [] ->
+          Syntax.Signature (s,List.rev xcs), loc
+        | (l,mx,mc)::cs ->
+          let x = match mx with | Some x -> x | None -> l in
+          let mc = match mc with
+            | Some c -> Some (comp ~yield bound c)
+            | None -> None
           in
-          fold bound [] s_def cs
-        | None -> Error.syntax ~loc "unknown signature %t" (Name.print_ident s)
-      end
+          let bound = Bound.add x bound in
+          fold bound ((l,x,mc)::xcs) cs
+      in
+      fold bound [] cs
 
     | Input.Structure lycs ->
        let rec fold bound res = function
         | [] -> List.rev res
-        | (x,y,c) :: rem ->
-          let y = match y with | Some y -> y | None -> x in
-          let c = match c with | Some c -> Some (comp ~yield env bound c) | None -> None in
-          fold (add_bound y bound) ((x,y,c) :: res) rem
+        | (l,x,c) :: rem ->
+          let x = match x with | Some x -> x | None -> l in
+          let c = match c with | Some c -> Some (comp ~yield bound c) | None -> None in
+          fold (Bound.add x bound) ((l,x,c) :: res) rem
         in
       let lcs = fold bound [] lycs in
       Syntax.Structure lcs, loc
 
-    | Input.Projection (c,x) ->
-      let c = comp ~yield env bound c in
-      Syntax.Projection (c,x), loc
+    | Input.Projection (c,l) ->
+      let c = comp ~yield bound c in
+      Syntax.Projection (c,l), loc
 
     | Input.Var x ->
-         (* a bound variable always shadows a name *)
-       begin
-         match Name.index_of_ident x bound with
-         | Some k -> Syntax.Bound k, loc
-         | None ->
-            begin
-              match Value.get_decl x env with
-              | Some (Value.DeclConstant _) ->
-                 Syntax.Constant x, loc
+      begin match Bound.find ~loc x bound with
+        | Bound.Val k -> Syntax.Bound k, loc
+        | Bound.Const c ->
+          Syntax.Constant c, loc
 
-              | Some (Value.DeclData k) ->
-                 if k = 0 then Syntax.Data (x, []), loc
-                 else Error.syntax ~loc "this data constructor needs %d more arguments" k
+        | Bound.Data (c,k) ->
+          if k = 0 then Syntax.Data (c, []), loc
+          else Error.syntax ~loc "this data constructor needs %d more arguments" k
 
-              | Some (Value.DeclOperation k) ->
-                 if k = 0 then Syntax.Operation (x, []), loc
-                 else Error.syntax ~loc "this operation needs %d more arguments" k
+        | Bound.Op (op,k) ->
+          if k = 0 then Syntax.Operation (op, []), loc
+          else Error.syntax ~loc "this operation needs %d more arguments" k
 
-              | Some (Value.DeclSignature def) ->
-                raw_signature ~loc x def
+        | Bound.Sig s ->
+          Syntax.Signature (s,[]), loc
 
-              | Some (Value.DeclDynamic y) ->
-                Syntax.Dynamic y, loc
-
-              | None -> Error.syntax ~loc "unknown name %t" (Name.print_ident x)
-            end
-       end
+        | Bound.Dyn y ->
+          Syntax.Dynamic y, loc
+      end
 
   | Input.Type ->
     Syntax.Type, loc
@@ -443,7 +459,7 @@ let rec comp ~yield (env : Value.env) bound (c',loc) =
   | Input.Yield c ->
     if yield
     then
-      let c = comp ~yield env bound c in
+      let c = comp ~yield bound c in
       Syntax.Yield c, loc
     else
       Error.syntax ~loc "yield may only be used in a handler"
@@ -453,80 +469,80 @@ let rec comp ~yield (env : Value.env) bound (c',loc) =
 
   | Input.Function (xs, c) ->
      let rec fold bound = function
-       | [] -> comp ~yield env bound c
+       | [] -> comp ~yield bound c
        | x :: xs ->
-          let bound = add_bound x bound in
+          let bound = Bound.add x bound in
           let c = fold bound xs in
           Syntax.Function (x, c), loc
      in
-       fold bound xs
+     fold bound xs
 
   | Input.Handler hcs ->
-     handler ~loc env bound hcs
+     handler ~loc bound hcs
 
   | Input.List cs ->
      let rec fold ~loc = function
        | [] -> Syntax.Nil, loc
        | c :: cs ->
-          let c = comp ~yield env bound c in
+          let c = comp ~yield bound c in
           let cs = fold ~loc:(snd c) cs in
           Syntax.Cons (c, cs), loc
      in
      fold ~loc cs
 
   | Input.Cons (e1, e2) ->
-    let e1 = comp ~yield env bound e1 in
-    let e2 = comp ~yield env bound e2 in
+    let e1 = comp ~yield bound e1 in
+    let e2 = comp ~yield bound e2 in
     Syntax.Cons (e1,e2), loc
 
   | Input.Tuple cs ->
-    let lst = List.map (comp ~yield env bound) cs in
+    let lst = List.map (comp ~yield bound) cs in
     Syntax.Tuple lst, loc
 
   | Input.Congruence (e1,e2) ->
-    let e1 = comp ~yield env bound e1 in
-    let e2 = comp ~yield env bound e2 in
+    let e1 = comp ~yield bound e1 in
+    let e2 = comp ~yield bound e2 in
     Syntax.Congruence (e1,e2), loc
 
   | Input.Extensionality (e1,e2) ->
-    let e1 = comp ~yield env bound e1 in
-    let e2 = comp ~yield env bound e2 in
+    let e1 = comp ~yield bound e1 in
+    let e2 = comp ~yield bound e2 in
     Syntax.Extensionality (e1,e2), loc
 
   | Input.Reduction c ->
-     let c = comp ~yield env bound c in
+     let c = comp ~yield bound c in
      Syntax.Reduction c, loc
 
   | Input.String s ->
     Syntax.String s, loc
 
   | Input.GenSig (c1,c2) ->
-    let c1 = comp ~yield env bound c1
-    and c2 = comp ~yield env bound c2 in
+    let c1 = comp ~yield bound c1
+    and c2 = comp ~yield bound c2 in
     Syntax.GenSig (c1,c2), loc
 
   | Input.GenStruct (c1,c2) ->
-    let c1 = comp ~yield env bound c1
-    and c2 = comp ~yield env bound c2 in
+    let c1 = comp ~yield bound c1
+    and c2 = comp ~yield bound c2 in
     Syntax.GenStruct (c1,c2), loc
 
   | Input.GenProj (c1,c2) ->
-    let c1 = comp ~yield env bound c1
-    and c2 = comp ~yield env bound c2 in
+    let c1 = comp ~yield bound c1
+    and c2 = comp ~yield bound c2 in
     Syntax.GenProj (c1,c2), loc
 
   | Input.Context c ->
-    let c = comp ~yield env bound c in
+    let c = comp ~yield bound c in
     Syntax.Context c, loc
 
   | Input.Occurs (c1,c2) ->
-    let c1 = comp ~yield env bound c1
-    and c2 = comp ~yield env bound c2 in
+    let c1 = comp ~yield bound c1
+    and c2 = comp ~yield bound c2 in
     Syntax.Occurs (c1,c2), loc
 
   | Input.Ident x -> Syntax.Ident x, loc
 
-and let_clauses ~loc ~yield env bound lst =
+and let_clauses ~loc ~yield bound lst =
   let rec fold bound' lst' = function
     | [] ->
        let lst' = List.rev lst' in
@@ -536,16 +552,16 @@ and let_clauses ~loc ~yield env bound lst =
        then
          Error.syntax ~loc "%t is bound more than once" (Name.print_ident x)
        else
-         let c = let_clause ~yield env bound ys t_opt c in
-         let bound' = add_bound x bound' in
+         let c = let_clause ~yield bound ys t_opt c in
+         let bound' = Bound.add x bound' in
          let lst' = (x, c) :: lst' in
          fold bound' lst' xcs
   in
   fold bound [] lst
 
-and letrec_clauses ~loc ~yield env bound lst =
+and letrec_clauses ~loc ~yield bound lst =
   let bound =
-    List.fold_left (fun bound (f, _, _, _, _) -> add_bound f bound) bound lst
+    List.fold_left (fun bound (f, _, _, _, _) -> Bound.add f bound) bound lst
   in
   let rec fold lst' = function
     | [] ->
@@ -556,39 +572,39 @@ and letrec_clauses ~loc ~yield env bound lst =
        then
          Error.syntax ~loc "%t is bound more than once" (Name.print_ident f)
        else
-         let y, c = letrec_clause ~yield env bound y ys t_opt c in
+         let y, c = letrec_clause ~yield bound y ys t_opt c in
          let lst' = (f, y, c) :: lst' in
          fold lst' xcs
   in
   fold [] lst
 
-and let_clause ~yield env bound ys t_opt c =
+and let_clause ~yield bound ys t_opt c =
   let rec fold bound = function
     | [] ->
        begin
          match t_opt with
-         | None -> comp ~yield env bound c
+         | None -> comp ~yield bound c
          | Some t ->
-            let t = comp ~yield env bound t
-            and c = comp ~yield env bound c in
+            let t = comp ~yield bound t
+            and c = comp ~yield bound c in
             Syntax.Ascribe (c, t), (snd c) (* XXX improve location *)
        end
     | y :: ys ->
-       let bound = add_bound y bound in
+       let bound = Bound.add y bound in
        let c = fold bound ys in
        Syntax.Function (y, c), (snd c) (* XXX improve location *)
   in
   fold bound ys
 
-and letrec_clause ~yield env bound y ys t_opt c =
-  let bound = add_bound y bound in
-  let c = let_clause ~yield env bound ys t_opt c in
+and letrec_clause ~yield bound y ys t_opt c =
+  let bound = Bound.add y bound in
+  let c = let_clause ~yield bound ys t_opt c in
   y, c
 
 
-(* Desguar a spine. This function is a bit messy because we need to untangle
-   to env. But it's worth doing to make users happy. *)
-and spine ~yield env bound ((c',loc) as c) cs =
+(* Desugar a spine. This function is a bit messy because we need to untangle
+   to env. But it's worth doing to make users happy. TODO outdated comment *)
+and spine ~yield bound ((c',loc) as c) cs =
 
   (* Auxiliary function which splits a list into two parts with k
      elements in the first part. *)
@@ -603,42 +619,33 @@ and spine ~yield env bound ((c',loc) as c) cs =
 
   (* First we calculate the head of the spine, and the remaining arguments. *)
   let c, cs =
-    begin
-      match c' with
-      | Input.Var x when not (List.mem x bound) ->
-         begin
-           match Value.get_decl x env with
+    match c' with
+      | Input.Var x ->
+        begin match Bound.find ~loc x bound with
+          | Bound.Val i -> (Syntax.Bound i, loc), cs
+          | Bound.Const x ->
+            (Syntax.Constant x, loc), cs
+          | Bound.Data (x,k) ->
+            let cs', cs = split "data constructor" k cs in
+            data ~loc ~yield bound x cs', cs
+          | Bound.Op (op,k) ->
+            let cs', cs = split "operation" k cs in
+            operation ~loc ~yield bound op cs', cs
+          | Bound.Sig s ->
+            (Syntax.Signature (s,[]),loc), cs
+          | Bound.Dyn y ->
+            (Syntax.Dynamic y, loc), cs
+        end
 
-           | Some (Value.DeclConstant _) ->
-              (Syntax.Constant x, loc), cs
-
-           | Some (Value.DeclData k) ->
-              let cs', cs = split "data constructor" k cs in
-              data ~loc ~yield env bound x cs', cs
-
-           | Some (Value.DeclOperation k) ->
-              let cs', cs = split "operation" k cs in
-              operation ~loc ~yield env bound x cs', cs
-
-           | Some (Value.DeclSignature def) ->
-              raw_signature ~loc x def, cs
-
-           | Some (Value.DeclDynamic y) ->
-              (Syntax.Dynamic y, loc), cs
-
-           | None ->
-              Error.syntax ~loc "unknown identifier %t" (Name.print_ident x)
-         end
-
-      | _ -> comp ~yield env bound c, cs
-    end in
+      | _ -> comp ~yield bound c, cs
+  in
 
   List.fold_left (fun h c ->
-    let c = comp ~yield env bound c in
+    let c = comp ~yield bound c in
     Syntax.Apply (h,c), loc) c cs
 
 (* Desugar handler cases. *)
-and handler ~loc env bound hcs =
+and handler ~loc bound hcs =
   (* for every case | #op p => c we do #op binder => match binder with | p => c end *)
   let rec fold val_cases op_cases finally_cases = function
     | [] ->
@@ -647,27 +654,23 @@ and handler ~loc env bound hcs =
     | Input.CaseVal c :: hcs ->
       (* XXX if this handler is in a outer handler's operation case, should we use its yield?
          eg handle ... with | op => handler | val x => yield x end end *)
-      let case = match_case ~yield:false env bound c in
+      let case = match_case ~yield:false bound c in
       fold (case::val_cases) op_cases finally_cases hcs
 
     | Input.CaseOp (op, ((ps,_,_) as c)) :: hcs ->
-      begin match Value.get_operation op env with
-        | Some k ->
-          let n = List.length ps in
-          if n = k
-          then
-            let case = match_op_case ~yield:true env bound c in
-            let my_cases = try IdentMap.find op op_cases with | Not_found -> [] in
-            let my_cases = case::my_cases in
-            fold val_cases (IdentMap.add op my_cases op_cases) finally_cases hcs
-          else
-            Error.syntax ~loc "operation %t expects %d arguments but was matched with %d" (Name.print_ident op) k n
-        | None ->
-          Error.syntax ~loc "unknown operation %t" (Name.print_ident op)
-      end
+      let op,k = Bound.get_operation ~loc op bound in
+      let n = List.length ps in
+      if n = k
+      then
+        let case = match_op_case ~yield:true bound c in
+        let my_cases = try IdentMap.find op op_cases with | Not_found -> [] in
+        let my_cases = case::my_cases in
+        fold val_cases (IdentMap.add op my_cases op_cases) finally_cases hcs
+      else
+        Error.syntax ~loc "operation %t expects %d arguments but was matched with %d" (Name.print_ident op) k n
 
     | Input.CaseFinally c :: hcs ->
-      let case = match_case ~yield:false env bound c in
+      let case = match_case ~yield:false bound c in
       fold val_cases op_cases (case::finally_cases) hcs
 
   in
@@ -675,55 +678,56 @@ and handler ~loc env bound hcs =
   Syntax.Handler (Syntax.{handler_val; handler_ops; handler_finally}), loc
 
 (* Desugar a match case *)
-and match_case ~yield env bound (p, c) =
-  let p, vars, _ = pattern env bound [] 0 p in
+and match_case ~yield bound (p, c) =
+  let p, vars, _ = pattern bound [] 0 p in
   let rec fold xs bound = function
     | [] -> xs, bound
-    | (x,_)::rem -> fold (x::xs) (add_bound x bound) rem
+    | (x,_)::rem -> fold (x::xs) (Bound.add x bound) rem
     in
   let xs, bound = fold [] bound vars in
-  let c = comp ~yield env bound c in
+  let c = comp ~yield bound c in
   (xs, p, c)
 
-and match_op_case ~yield env bound (ps, pt, c) =
+and match_op_case ~yield bound (ps, pt, c) =
   let rec fold_patterns ps vars n = function
     | [] -> List.rev ps, vars, n
     | p::rem ->
-      let p, vars, n = pattern env bound vars n p in
+      let p, vars, n = pattern bound vars n p in
       fold_patterns (p::ps) vars n rem
   in
   let ps, vars, n = fold_patterns [] [] 0 ps in
   let pt, vars = match pt with
     | Some p ->
-      let p, vars, n = pattern env bound vars n p in
+      let p, vars, n = pattern bound vars n p in
       Some p, vars
     | None ->
       None, vars
   in
   let rec fold xs bound = function
     | [] -> xs, bound
-    | (x,_)::rem -> fold (x::xs) (add_bound x bound) rem
+    | (x,_)::rem -> fold (x::xs) (Bound.add x bound) rem
     in
   let xs, bound = fold [] bound vars in
-  let c = comp ~yield env bound c in
+  let c = comp ~yield bound c in
   (xs, ps, pt, c)
 
-and data ~loc ~yield env bound x cs =
-  let cs = List.map (comp ~yield env bound) cs in
+and data ~loc ~yield bound x cs =
+  let cs = List.map (comp ~yield bound) cs in
   Syntax.Data (x, cs), loc
 
-and operation ~loc ~yield env bound x cs =
-  let cs = List.map (comp ~yield env bound) cs in
+and operation ~loc ~yield bound x cs =
+  let cs = List.map (comp ~yield bound) cs in
   Syntax.Operation (x, cs), loc
 
-let toplevel (env : Value.env) bound (d', loc) =
+let toplevel bound (d', loc) =
+  let bound = Bound.compute_indices bound in
   let d' = match d' with
     | Input.DeclOperation (x, k) -> Syntax.DeclOperation (x, k)
 
     | Input.DeclData (x, k) -> Syntax.DeclData (x, k)
 
     | Input.DeclConstants (xs, u) ->
-       let u = comp ~yield:false env bound u in
+       let u = comp ~yield:false bound u in
        Syntax.DeclConstants (xs, u)
 
     | Input.DeclSignature (s, lst) ->
@@ -736,8 +740,8 @@ let toplevel (env : Value.env) bound (d', loc) =
             else if Name.is_anonymous x
             then Error.syntax ~loc "anonymous field"
             else
-              let c = comp ~yield:false env bound c in
-              fold (add_bound y bound) (x::labels) ((x,y,c)::res) rem
+              let c = comp ~yield:false bound c in
+              fold (Bound.add y bound) (x::labels) ((x,y,c)::res) rem
        in
        let lst = fold bound [] [] lst in
        Syntax.DeclSignature (s, lst)
@@ -746,49 +750,44 @@ let toplevel (env : Value.env) bound (d', loc) =
         let lst =
           List.map
             (fun (op, (xs, y, c)) ->
-              match Value.get_operation op env with
-                | Some k ->
-                  let n = List.length xs in
-                  if n = k
-                  then
-                    let bound = List.fold_left (fun bound x -> add_bound x bound) bound xs in
-                    let bound = match y with | Some y -> add_bound y bound | None -> bound in
-                    op, (xs, y, comp ~yield:false env bound c)
-                  else
-                    Error.syntax ~loc "operation %t expects %d arguments but was matched with %d"
-                                 (Name.print_ident op) k n
-                | None -> Error.syntax ~loc "unknown operation %t" (Name.print_ident op)
+              let op,k = Bound.get_operation ~loc op bound in
+              let n = List.length xs in
+              if n = k
+              then
+                let bound = List.fold_left (fun bound x -> Bound.add x bound) bound xs in
+                let bound = match y with | Some y -> Bound.add y bound | None -> bound in
+                op, (xs, y, comp ~yield:false bound c)
+              else
+                Error.syntax ~loc "operation %t expects %d arguments but was matched with %d"
+                             (Name.print_ident op) k n
             )
             lst
         in
         Syntax.TopHandle lst
 
     | Input.TopLet lst ->
-       let bound, lst = let_clauses ~loc ~yield:false env bound lst in
+       let bound, lst = let_clauses ~loc ~yield:false bound lst in
        Syntax.TopLet lst
 
     | Input.TopLetRec lst ->
-       let bound, lst = letrec_clauses ~loc ~yield:false env bound lst in
+       let bound, lst = letrec_clauses ~loc ~yield:false bound lst in
        Syntax.TopLetRec lst
 
     | Input.TopDynamic (x,c) ->
-      let c = comp ~yield:false env bound c in
+      let c = comp ~yield:false bound c in
       Syntax.TopDynamic (x,c)
 
     | Input.TopNow (x,c) ->
-      begin match Value.get_dynamic x env with
-        | Some y ->
-          let c = comp ~yield:false env bound c in
-          Syntax.TopNow (y,c)
-        | None -> Error.syntax ~loc "%t is not a dynamic variable." (Name.print_ident x)
-      end
+      let y = Bound.get_dynamic ~loc x bound in
+      let c = comp ~yield:false bound c in
+      Syntax.TopNow (y,c)
 
     | Input.TopDo c ->
-      let c = comp ~yield:false env bound c in
+      let c = comp ~yield:false bound c in
       Syntax.TopDo c
 
     | Input.TopFail c ->
-      let c = lazy (comp ~yield:false env bound c) in
+      let c = lazy (comp ~yield:false bound c) in
       Syntax.TopFail c
 
     | Input.Quit -> Syntax.Quit
@@ -803,3 +802,4 @@ let toplevel (env : Value.env) bound (d', loc) =
 
   in
   d', loc
+

--- a/src/parser/desugar.mli
+++ b/src/parser/desugar.mli
@@ -3,4 +3,4 @@
 (** [toplevel primitive bound c] desugars a toplevel command [c] with a
     list of primitives and their arities, and a list of bound variables
     that are converted to de Bruijn indiced. *)
-val toplevel : Value.env -> Name.ident list -> Input.toplevel -> Syntax.toplevel
+val toplevel : (Name.ident * Value.bound_info) list -> Input.toplevel -> Syntax.toplevel

--- a/src/syntax.mli
+++ b/src/syntax.mli
@@ -75,7 +75,7 @@ and comp' =
   | Eq of comp * comp
   | Refl of comp
   (** [s with li as xi = maybe ci] with every previous [xj] bound in [ci] (including the constrained ones). *)
-  | Signature of Name.signature * (Name.ident * comp option) option list
+  | Signature of Name.signature * (Name.label * Name.ident * comp option) list
   (** [{ li as xi = maybe ci } ] with previous [xj] bound in [ci].
       In checking mode, constrained fields may be omitted in which case they are not bound in the computations.
       In infer mode all fields must be present and explicit. *)

--- a/src/utils/name.ml
+++ b/src/utils/name.ml
@@ -11,8 +11,10 @@ type ident = Ident of string * fixity
 type atom = Atom of string * fixity * int
 
 type label = ident
-
 type signature = ident
+type constant = ident
+type data = ident
+type operation = ident
 
 let print_ident ?(parentheses=true) x ppf =
   match x with
@@ -139,6 +141,11 @@ let index_of_ident x ys =
     | y :: ys -> if eq_ident x y then Some k else fold (k + 1) ys
   in
   fold 0 ys
+
+let rec assoc_ident x = function
+  | [] -> None
+  | (y,v)::_ when (eq_ident x y) -> Some v
+  | _::l -> assoc_ident x l
 
 let print_debruijn xs k ppf =
   try

--- a/src/utils/name.mli
+++ b/src/utils/name.mli
@@ -10,11 +10,12 @@ type ident = private Ident of string * fixity
 
 type atom = private Atom of string * fixity * int
 
-(** The type of a structure or signature field. *)
+(** Aliases with different semantics *)
 type label = ident
-
-(** The type of a signature name. *)
 type signature = ident
+type constant = ident
+type data = ident
+type operation = ident
 
 (** Print a name. *)
 val print_ident : ?parentheses:bool -> ident -> Format.formatter -> unit
@@ -69,6 +70,9 @@ val index_of_atom : atom -> atom list -> int option
 
 (** [index_of_ident x xs] finds the index of [x] in list [xs] if it's there. *)
 val index_of_ident : ident -> ident list -> int option
+
+(** Like List.assoc, but using [eq_ident] and without exceptions. *)
+val assoc_ident : ident -> (ident * 'a) list -> 'a option
 
 val print_debruijn : ident list -> int -> Format.formatter -> unit
 

--- a/tests/everything.m31.ref
+++ b/tests/everything.m31.ref
@@ -121,45 +121,41 @@ Check <expr> .                               check the type of <expr>
 
 The syntax is vaguely Coq-like. The strict equality is written with a double ==.
 
-data Some 1
-data None 0
-data Unconstrained 1
-data Constrained 1
-operation equal 2
-operation as_prod 1
-operation as_eq 1
-operation as_signature 1
-signature unit 
-data ( !! ) 1
-operation failure 1
-operation whnf 1
-dynamic betas
-dynamic hints
-dynamic etas
-dynamic reducing
-data eager 0
-data lazy 0
-operation unary_op 1
-operation nonary_op 0
-data dummy 0
-data black 0
-data rgb_color 3
-constant A Type
-constant a A
-constant b A
-constant ( + ) A → A → A
-constant ( * ) A → A → A
-constant ( ^ ) A → A → A
-constant ( - ) A → A → A
+constant eq a ≡ b
+constant exfalso Π (T : Type), T
 constant ( <= ) A → A → A
+constant ( - ) A → A → A
+constant ( ^ ) A → A → A
+constant ( * ) A → A → A
+constant ( + ) A → A → A
+constant b A
+constant a A
+constant A Type
+data rgb_color 3
+data black 0
+data dummy 0
+data lazy 0
+data eager 0
+data ( !! ) 1
+data Constrained 1
+data Unconstrained 1
+data None 0
+data Some 1
+operation hippy 0
+operation emit 1
+operation set 1
+operation get 0
+operation nonary_op 0
+operation unary_op 1
+operation whnf 1
+operation failure 1
+operation as_signature 1
+operation as_eq 1
+operation as_prod 1
+operation equal 2
+signature container T : Type, cont : T
+signature wrapped unwrap : A
 signature isContr T : Type, center as a0 : T,
     contr_path as _ : Π (x : T), a0 ≡ x
-signature wrapped unwrap : A
-operation get 0
-operation set 1
-constant exfalso Π (T : Type), T
-signature container T : Type, cont : T
-operation emit 1
-constant eq a ≡ b
-operation hippy 0
+signature unit 
 

--- a/tests/not-found.m31.ref
+++ b/tests/not-found.m31.ref
@@ -5,4 +5,4 @@ Constant sig_ind_beta is declared.
 projT1' is defined.
 projT2' is defined.
 File "./not-found.m31", line 42, characters 26-36: Syntax error
-  unknown name projT1_beta
+  Unknown name projT1_beta.


### PR DESCRIPTION
When we get a name, instead of looking between decls and bound to find out what it refers to, we only need to look at the lexical context.

Re-enabling top level shadowing would now give the expected result in the following example (although not done in this PR):
```
let x = Type
constant x : Type
do x
```

With internal names of declared things decoupled from what their binder, we could change `Name.operation` to `Name.atom`, then allow locally declared operations which cannot be caught outside the scope of that name.
Or if it turns out that comparing idents is costly when matching, we could change `Name.constant` and `Name.data` to `Name.atom` (comparison is `int` comparison, but better printing).