### PR TITLE
Print subscripts config

### DIFF
--- a/src/andromeda.ml
+++ b/src/andromeda.ml
@@ -30,6 +30,10 @@ let options = Arg.align [
      Arg.Set Config.print_dependencies,
      " Print dependencies between free variables and inside terms");
 
+    ("--no-subscripts",
+     Arg.Set Config.print_dependencies,
+     " Do not print the freshness-index subscripts of atoms");
+
     ("--max-boxes",
      Arg.Set_int Config.max_boxes,
      " Set the maximum depth of pretty printing");

--- a/src/config.ml
+++ b/src/config.ml
@@ -23,4 +23,5 @@ let print_dependencies = ref false
 
 let max_boxes = ref 42
 
-let print_subscripts = ref false
+let print_subscripts = ref true
+

--- a/src/config.ml
+++ b/src/config.ml
@@ -23,4 +23,4 @@ let print_dependencies = ref false
 
 let max_boxes = ref 42
 
-let print_subscripts = ref true
+let print_subscripts = ref false

--- a/src/config.ml
+++ b/src/config.ml
@@ -23,3 +23,4 @@ let print_dependencies = ref false
 
 let max_boxes = ref 42
 
+let print_subscripts = ref true

--- a/src/config.ml
+++ b/src/config.ml
@@ -23,5 +23,5 @@ let print_dependencies = ref false
 
 let max_boxes = ref 42
 
-let print_subscripts = ref true
+let print_subscripts = ref false
 

--- a/src/config.mli
+++ b/src/config.mli
@@ -38,3 +38,5 @@ val print_dependencies : bool ref
 (** *)
 val max_boxes : int ref
 
+(** Should atoms be printed with freshness subscripts? *)
+val print_subscripts : bool ref

--- a/src/nucleus/assumption.ml
+++ b/src/nucleus/assumption.ml
@@ -12,9 +12,9 @@ let empty = {free = AtomSet.empty; bound = BoundSet.empty; }
 let is_empty {free;bound} =
   AtomSet.is_empty free && BoundSet.is_empty bound
 
-let print xs {free;bound} ppf =
+let print xs atoms {free;bound} ppf =
   Format.fprintf ppf "%t@ ;@ %t"
-              (Print.sequence Name.print_atom "," (AtomSet.elements free))
+              (Print.sequence (Name.print_atom ~penv:atoms) "," (AtomSet.elements free))
               (Print.sequence (Name.print_debruijn xs) "," (BoundSet.elements bound))
 
 let singleton x =

--- a/src/nucleus/assumption.mli
+++ b/src/nucleus/assumption.mli
@@ -7,7 +7,7 @@ val empty : t
 
 val is_empty : t -> bool
 
-val print : Name.ident list -> t -> Format.formatter -> unit
+val print : Name.ident list -> Name.env -> t -> Format.formatter -> unit
 
 val singleton : Name.atom -> t
 

--- a/src/nucleus/context.mli
+++ b/src/nucleus/context.mli
@@ -7,6 +7,10 @@ val empty : t
 (** Is the context empty? *)
 val is_empty : t -> bool
 
+(** Add atoms to the printing environment, avoiding name collisions. *)
+val penv_atoms : penv:Tt.print_env -> t -> Tt.print_env
+
+(** Print the context. Atoms are printed according to the environment. *)
 val print : penv:Tt.print_env -> t -> Format.formatter -> unit
 
 val lookup_ty : Name.atom -> t -> Tt.ty option

--- a/src/nucleus/external.ml
+++ b/src/nucleus/external.ml
@@ -69,6 +69,13 @@ let externals =
             Config.print_dependencies := false;
             Value.return_unit
 
+          | "subscripts" ->
+            Config.print_subscripts := true;
+            Value.return_unit
+          | "no-subscripts" ->
+            Config.print_subscripts := false;
+            Value.return_unit
+
           | _ -> Error.runtime ~loc "unknown config %s" s
         ));
 

--- a/src/nucleus/jdg.ml
+++ b/src/nucleus/jdg.ml
@@ -18,6 +18,7 @@ let strengthen (Term (ctx,e,t)) =
   Term (ctx,e,t)
 
 let print_term ~penv ?max_level (Term (ctx, e,t)) ppf =
+  let penv = Context.penv_atoms ~penv ctx in
   Print.print ?max_level ~at_level:Level.jdg ppf
               "%t%s @[<hv>@[<hov>%t@]@;<1 -2>: @[<hov>%t@]@]"
               (Context.print ~penv ctx)

--- a/src/nucleus/tt.ml
+++ b/src/nucleus/tt.ml
@@ -432,6 +432,7 @@ and alpha_equal_term_ty (e, t) (e', t') = alpha_equal e e' && alpha_equal_ty t t
 (****** Printing routines *****)
 type print_env =
   { forbidden : Name.ident list ;
+    atoms : (Name.atom * Name.ident) list ;
     sigs : Name.signature -> Name.label list }
 
 type name_printing =
@@ -472,7 +473,7 @@ let rec print_term ?max_level ~penv {term=e;assumptions;_} ppf =
   then
     Format.fprintf ppf "(%t)^{{%t}}"
                 (print_term' ~penv ~max_level:Level.highest e)
-                (Assumption.print penv.forbidden assumptions)
+                (Assumption.print penv.forbidden penv.atoms assumptions)
   else
     print_term' ~penv ?max_level e ppf
 
@@ -483,7 +484,7 @@ and print_term' ~penv ?max_level e ppf =
         Format.fprintf ppf "Type"
 
       | Atom x ->
-        Name.print_atom x ppf
+        Name.print_atom ~penv:(penv.atoms) x ppf
 
       | Constant x ->
          Name.print_ident x ppf

--- a/src/nucleus/tt.ml
+++ b/src/nucleus/tt.ml
@@ -547,7 +547,7 @@ and print_app ?max_level ~penv e1 e2 ppf =
   match e1_prefix with
   | Some (As_atom op) ->
      Print.print ppf ?max_level ~at_level:Level.prefix "%t@ %t"
-                 (Name.print_atom ~parentheses:false op)
+                 (Name.print_atom ~parentheses:false ~penv:penv.atoms op)
                  (print_term ~max_level:Level.prefix_arg ~penv e2)
 
   | Some (As_ident op) ->
@@ -590,7 +590,7 @@ and print_app ?max_level ~penv e1 e2 ppf =
                       (print_term ~max_level:lvl_left ~penv e1)
                       (match op with
                        | As_ident op -> Name.print_ident ~parentheses:false op
-                       | As_atom op -> Name.print_atom ~parentheses:false op)
+                       | As_atom op -> Name.print_atom ~parentheses:false ~penv:penv.atoms op)
                       (print_term ~max_level:lvl_right ~penv e2)
        | None ->
           (* ordinary application *)

--- a/src/nucleus/tt.mli
+++ b/src/nucleus/tt.mli
@@ -174,6 +174,7 @@ val alpha_equal_sig : signature -> signature -> bool
 
 type print_env =
   { forbidden : Name.ident list ;
+    atoms : (Name.atom * Name.ident) list ;
     sigs : Name.signature -> Name.label list }
 
 val print_ty : ?max_level:Level.t -> penv:print_env -> ty -> Format.formatter -> unit

--- a/src/nucleus/value.ml
+++ b/src/nucleus/value.ml
@@ -490,6 +490,7 @@ let included f env =
 (** Generate a printing environment from runtime environment *)
 let get_penv env =
   { Tt.forbidden = List.map fst env.lexical.context ;
+    Tt.atoms = [] ;
     Tt.sigs = (fun s ->
                match get_signature s env with
                  | None -> Error.impossible ~loc:Location.unknown "get_penv: unknown signature %t" (Name.print_ident s)

--- a/src/utils/name.ml
+++ b/src/utils/name.ml
@@ -33,6 +33,7 @@ let print_label = print_ident ~parentheses:true
 let subdigit = [|"₀"; "₁"; "₂"; "₃"; "₄"; "₅"; "₆"; "₇"; "₈"; "₉"|]
 
 let subscript k =
+  if not !Config.print_subscripts then "" else
   if !Config.ascii then "_" ^ string_of_int k
   else if k = 0 then subdigit.(0)
   else

--- a/src/utils/name.ml
+++ b/src/utils/name.ml
@@ -162,10 +162,10 @@ let print_atom_subs ?(parentheses=true) x ppf =
 let print_atom ?parentheses ?(penv=[]) x ppf =
   if !Config.print_subscripts
   then
+    print_atom_subs ?parentheses x ppf
+  else
     try
       print_ident ?parentheses (snd (List.find (fun (y,_) -> eq_atom x y) penv)) ppf
     with
       | Not_found -> print_atom_subs ?parentheses x ppf
-  else
-    print_atom_subs ?parentheses x ppf
 

--- a/src/utils/name.ml
+++ b/src/utils/name.ml
@@ -10,6 +10,8 @@ type ident = Ident of string * fixity
 
 type atom = Atom of string * fixity * int
 
+type env = (atom * ident) list
+
 type label = ident
 type signature = ident
 type constant = ident
@@ -27,38 +29,6 @@ let print_ident ?(parentheses=true) x ppf =
        Format.fprintf ppf "%s" s
 
 let print_label = print_ident ~parentheses:true
-
-(** Subscripts *)
-
-let subdigit = [|"₀"; "₁"; "₂"; "₃"; "₄"; "₅"; "₆"; "₇"; "₈"; "₉"|]
-
-let subscript k =
-  if not !Config.print_subscripts then "" else
-  if !Config.ascii then "_" ^ string_of_int k
-  else if k = 0 then subdigit.(0)
-  else
-    let rec fold s = function
-      | 0 -> s
-      | k ->
-         let s = subdigit.(k mod 10) ^ s in
-         fold s (k / 10)
-    in
-    fold "" k
-
-let print_atom ?(parentheses=true) x ppf =
-  match x with
-  | Atom (s, Word, k) ->
-     Format.fprintf ppf "%s%s" s (subscript k)
-
-  | Atom (_, Anonymous, k) ->
-     Format.fprintf ppf "_%s" (subscript k)
-
-  | Atom (s, (Prefix|Infix _), k) ->
-     if parentheses then
-       Format.fprintf ppf "( %s%s )" s (subscript k)
-     else
-       Format.fprintf ppf "%s%s" s (subscript k)
-
 
 let print_op = print_ident ~parentheses:true
 
@@ -157,4 +127,45 @@ let print_debruijn xs k ppf =
   with
   | Failure "nth" ->
       Format.fprintf ppf "DEBRUIJN[%d]" k
+
+
+(** Subscripts *)
+
+let subdigit = [|"₀"; "₁"; "₂"; "₃"; "₄"; "₅"; "₆"; "₇"; "₈"; "₉"|]
+
+let subscript k =
+  if !Config.ascii then "_" ^ string_of_int k
+  else if k = 0 then subdigit.(0)
+  else
+    let rec fold s = function
+      | 0 -> s
+      | k ->
+         let s = subdigit.(k mod 10) ^ s in
+         fold s (k / 10)
+    in
+    fold "" k
+
+let print_atom_subs ?(parentheses=true) x ppf =
+  match x with
+  | Atom (s, Word, k) ->
+     Format.fprintf ppf "%s%s" s (subscript k)
+
+  | Atom (_, Anonymous, k) ->
+     Format.fprintf ppf "_%s" (subscript k)
+
+  | Atom (s, (Prefix|Infix _), k) ->
+     if parentheses then
+       Format.fprintf ppf "( %s%s )" s (subscript k)
+     else
+       Format.fprintf ppf "%s%s" s (subscript k)
+
+let print_atom ?parentheses ?(penv=[]) x ppf =
+  if !Config.print_subscripts
+  then
+    try
+      print_ident ?parentheses (snd (List.find (fun (y,_) -> eq_atom x y) penv)) ppf
+    with
+      | Not_found -> print_atom_subs ?parentheses x ppf
+  else
+    print_atom_subs ?parentheses x ppf
 

--- a/src/utils/name.mli
+++ b/src/utils/name.mli
@@ -10,6 +10,9 @@ type ident = private Ident of string * fixity
 
 type atom = private Atom of string * fixity * int
 
+(** A name environment tells us how to print atoms found in it. *)
+type env = (atom * ident) list
+
 (** Aliases with different semantics *)
 type label = ident
 type signature = ident
@@ -21,7 +24,7 @@ type operation = ident
 val print_ident : ?parentheses:bool -> ident -> Format.formatter -> unit
 
 (** Print an atom *)
-val print_atom : ?parentheses:bool -> atom -> Format.formatter -> unit
+val print_atom : ?parentheses:bool -> ?penv:env -> atom -> Format.formatter -> unit
 
 (** Print a field label *)
 val print_label : label -> Format.formatter -> unit

--- a/tests/beta-dynamic.m31.ref
+++ b/tests/beta-dynamic.m31.ref
@@ -3,8 +3,8 @@ Constant a is declared.
 Constant b is declared.
 f is defined.
 ⊢ refl a : a ≡ a
-eq₁₀ : a ≡ b 
-⊢ eq₁₀ : a ≡ b
+eq : a ≡ b 
+⊢ eq : a ≡ b
 Operation gimme_beta is declared.
-eq₁₁ : a ≡ b 
-⊢ eq₁₁ : a ≡ b
+eq : a ≡ b 
+⊢ eq : a ≡ b

--- a/tests/checking-op.m31.ref
+++ b/tests/checking-op.m31.ref
@@ -1,13 +1,13 @@
 Operation inhab is declared.
 h is defined.
 Constant A is declared.
-x_inhab₁₀ : A 
-⊢ x_inhab₁₀ : A
+x_inhab : A 
+⊢ x_inhab : A
 h' is defined.
-y_inhab₁₁ : A 
-⊢ y_inhab₁₁ : A
-z_inhab₁₂ : A 
-⊢ z_inhab₁₂ : A
+y_inhab : A 
+⊢ y_inhab : A
+z_inhab : A 
+⊢ z_inhab : A
 The command failed with error:
 File "./checking-op.m31", lines 21-23, characters 5-7: Runtime error
   no match found for None

--- a/tests/context-dependencies.m31.ref
+++ b/tests/context-dependencies.m31.ref
@@ -2,8 +2,8 @@ Constant A is declared.
 Constant B is declared.
 Constant P is declared.
 Constant Q is declared.
-b₁₃ : B 
-e₁₄ : B ≡ A 
-x₁₅ : P b₁₃ 
-f₁₇ : Q b₁₃ x₁₅ → A 
-⊢ f₁₇ : Q b₁₃ x₁₅ → A
+b : B 
+e : B ≡ A 
+x : P b 
+f : Q b x → A 
+⊢ f : Q b x → A

--- a/tests/context-subst.m31.ref
+++ b/tests/context-subst.m31.ref
@@ -2,11 +2,11 @@ Constant A is declared.
 x is defined.
 P is defined.
 y is defined.
-x₁₀ : A 
-y₁₃ : (λ (_ : A), A) x₁₀ 
-⊢ y₁₃ : (λ (_ : A), A) x₁₀
+x0 : A 
+y0 : (λ (_ : A), A) x0 
+⊢ y0 : (λ (_ : A), A) x0
 Constant f is declared.
-x₁₀ : A 
-P₁₂ : A → Type 
-y₁₃ : P₁₂ (f x₁₀) 
-⊢ y₁₃ : P₁₂ (f x₁₀)
+x0 : A 
+P0 : A → Type 
+y0 : P0 (f x0) 
+⊢ y0 : P0 (f x0)

--- a/tests/error-handle-change-type.m31.ref
+++ b/tests/error-handle-change-type.m31.ref
@@ -2,5 +2,5 @@ Constant A is declared.
 Constant B is declared.
 Constant a is declared.
 Operation mafia is declared.
-e₁₀ : B ≡ A 
+e : B ≡ A 
 ⊢ a : B

--- a/tests/everything.m31.ref
+++ b/tests/everything.m31.ref
@@ -15,8 +15,8 @@ Constant ( <= ) is declared.
   : A → A → A → A → A
 Signature isContr is declared.
 x0 is defined.
-x₂₂ : {isContr with T = Type ≡ Type} 
-⊢ x₂₂ : {isContr with T = Type ≡ Type}
+x : {isContr with T = Type ≡ Type} 
+⊢ x : {isContr with T = Type ≡ Type}
 The command failed with error:
 File "./everything.m31", line 81, characters 6-9: Typing error
   this expression should be a product, found Type
@@ -53,8 +53,8 @@ register is defined.
 ()
 ⊢ b : A
 ⊢ A : Type
-x₃₂ : A 
-⊢ x₃₂ : A
+x : A 
+⊢ x : A
 "this will happen"
 ()
 alpha_equal is defined.
@@ -66,29 +66,28 @@ Signature container is declared.
 ⊢ {cont = exfalso A} : {container with T = A}
 ⊢ {cont = a} : {container with T = A}
 ⊢ {unwrap = a}.unwrap : A
-x₄₄ : wrapped 
-⊢ x₄₄.unwrap : A
+x : wrapped 
+⊢ x.unwrap : A
 ⊢ a : A
 ⊢ a : A
-((⊢ wrapped : Type, [(unwrap, unwrap₄₆ : A 
-                                ⊢ unwrap₄₆ : A)]), [Constrained
-(⊢ a : A)])
+((⊢ wrapped : Type, [(unwrap, unwrap : A 
+                                ⊢ unwrap : A)]), [Constrained (⊢ 
+a : A)])
 (⊢ {container with T = A} : Type, [⊢ a : A])
-(x₄₉ : wrapped 
- ⊢ x₄₉ : wrapped, unwrap)
+(x : wrapped 
+ ⊢ x : wrapped, unwrap)
 Tvar is defined.
 yvar is defined.
 dependent is defined.
 Some (⊢ Type : Type)
 None
-[T₅₀ : Type 
- ⊢ T₅₀ : Type,
-T₅₀ : Type 
-x₅₂ : T₅₀ 
-⊢ x₅₂ : T₅₀]
+[T : Type 
+ ⊢ T : Type, T : Type 
+               x : T 
+               ⊢ x : T]
 Operation emit is declared.
-[x₅₃ : A 
- ⊢ x₅₃ : A]
+[x : A 
+ ⊢ x : A]
 Constant eq is declared.
 ⊢ refl a : a ≡ a
 ⊢ refl a : a ≡ b

--- a/tests/generic.m31.ref
+++ b/tests/generic.m31.ref
@@ -6,16 +6,15 @@ Constant urist is declared.
 ankle is defined.
 ⊢ {person = dwarf, pet = urist} : cat
 (⊢ cat : Type, [⊢ dwarf : Type, ⊢ urist : dwarf])
-((⊢ cat : Type, [(person, person₂₄ : Type 
-                            ⊢ person₂₄ : Type), (pet,
-person₂₄ : Type 
-pet₂₅ : person₂₄ 
-⊢ pet₂₅ : person₂₄)]), [Unconstrained
-(person₂₆ : Type 
- ⊢ person₂₆ : Type), Unconstrained
-(person₂₆ : Type 
- pet₂₇ : person₂₆ 
- ⊢ pet₂₇ : person₂₆)])
+((⊢ cat : Type, [(person, person : Type 
+                            ⊢ person : Type), (pet,
+person : Type 
+pet : person 
+⊢ pet : person)]), [Unconstrained (person : Type 
+                                     ⊢ person : Type), Unconstrained
+(person : Type 
+ pet : person 
+ ⊢ pet : person)])
 (⊢ {person = dwarf, pet = urist} : cat, pet)
 ()
 ⊢ {person = dwarf, pet = urist} : cat
@@ -23,7 +22,7 @@ The command failed with error:
 File "./generic.m31", line 33, characters 6-30: Typing error
   bad field pet: types dwarf and Type do not match
 Constant A is declared.
-eq₄₀ : A ≡ cat 
+eq : A ≡ cat 
 ⊢ {person = dwarf, pet = urist} : A
 ⊢ {person = dwarf, pet = urist}.pet : {person = dwarf, pet = urist}.person
 first_proj is defined.
@@ -40,8 +39,8 @@ File "./generic.m31", line 68, characters 6-24: Typing error
   Cannot project field gold from signature cat: no such field
 Constant B is declared.
 Constant eq is declared.
-x₅₇ : A 
-⊢ x₅₇ : A
+x : A 
+⊢ x : A
 The command failed with error:
 File "./generic.m31", lines 78-80, characters 6-5: Runtime error
   no match found for ⊢ {person = dwarf, pet = urist} : cat

--- a/tests/handle-assume.m31.ref
+++ b/tests/handle-assume.m31.ref
@@ -2,11 +2,10 @@ Constant A is declared.
 Constant B is declared.
 Constant Q is declared.
 Operation inhabit is declared.
-hyp₁₈ : A → Type 
-⊢ λ (a : A), Q A hyp₁₈ a : Π (a : A), hyp₁₈ a → Type
+hyp : A → Type 
+⊢ λ (a : A), Q A hyp a : Π (a : A), hyp a → Type
 File "./handle-assume.m31", line 18, characters 5-38: Runtime error
-  Cannot abstract a₁₉ because hyp₂₀ depends on it.
-Context:
-  a₁₉ : A 
-  hyp₂₀ : B a₁₉ 
-  
+  Cannot abstract a0 because hyp depends on it.
+Context: a0 : A 
+                                                         hyp : B a0 
+                                                         

--- a/tests/handle-conjure.m31.ref
+++ b/tests/handle-conjure.m31.ref
@@ -5,8 +5,8 @@ Constant B is declared.
 Constant Q is declared.
 Operation implicit is declared.
 File "./handle-conjure.m31", line 21, characters 5-39: Runtime error
-  Cannot abstract a₁₆ because magic₁₇ depends on it.
+  Cannot abstract a0 because magic depends on it.
 Context:
-  a₁₆ : A 
-  magic₁₇ : B a₁₆ 
+  a0 : A 
+  magic : B a0 
   

--- a/tests/infixes.m31.ref
+++ b/tests/infixes.m31.ref
@@ -12,12 +12,12 @@ s is defined.
 (⊢ a : A, ⊢ b : A, ⊢ c ^ d ^ d : A)
 ⊢ λ (( ++ ) : A → A → A) (x : A) (y : A), x ++ (y ++ x)
   : (A → A → A) → A → A → A
-( ++₁₉ ) : A → A → A 
-⊢ λ (x : A) (y : A), x ++₁₉ (y ++₁₉ x) : A → A → A
+( ++ ) : A → A → A 
+⊢ λ (x : A) (y : A), x ++ (y ++ x) : A → A → A
 ⊢ λ (( ??? ) : A → A) (x : A) (_ : A), ??? ??? x
   : (A → A) → A → A → A
-( ???₂₇ ) : A → A 
-⊢ λ (x : A) (_ : A), ???₂₇ ???₂₇ x : A → A → A
+( ??? ) : A → A 
+⊢ λ (x : A) (_ : A), ??? ??? x : A → A → A
 Data constructor ( @ ) is declared.
 x is defined.
 ⊢ a : A

--- a/tests/meta-match.m31.ref
+++ b/tests/meta-match.m31.ref
@@ -4,10 +4,10 @@ Constant b is declared.
 Constant c is declared.
 ⊢ a : A
 Data constructor lam is declared.
-lam (x₁₂ : A 
-     ⊢ x₁₂ : A) (⊢ A : Type) (⊢ a : A)
-((x'₁₁ : A 
-  ⊢ x'₁₁ : A, ⊢ A : Type), ⊢ A : Type)
+lam (x : A 
+     ⊢ x : A) (⊢ A : Type) (⊢ a : A) ((x' : A 
+                                             ⊢ x' : A, ⊢ A : Type),
+⊢ A : Type)
 Constant list is declared.
 Constant Nil is declared.
 Constant Cons is declared.

--- a/tests/top-hypotheses.m31.ref
+++ b/tests/top-hypotheses.m31.ref
@@ -1,5 +1,5 @@
 Operation happy is declared.
 Constant A is declared.
-happy₁₃ : (A → Type) → A 
-⊢ λ (B : A → Type), B (happy₁₃ B) : (A → Type) → Type
+happy0 : (A → Type) → A 
+⊢ λ (B : A → Type), B (happy0 B) : (A → Type) → Type
 []

--- a/tests/user-match-rigid.m31.ref
+++ b/tests/user-match-rigid.m31.ref
@@ -2,8 +2,8 @@ Constant A is declared.
 Constant a is declared.
 x is defined.
 quants is defined.
-Some ([(x₁₀ : A 
-        ⊢ x₁₀ : A, Some (⊢ a : A))], [])
+Some ([(x0 : A 
+        ⊢ x0 : A, Some (⊢ a : A))], [])
 None
 Signature pair is declared.
 None


### PR DESCRIPTION
Can (and does by default) print atoms with fresh names instead of subscripts when we can avoid collisions.
Some weird indenting eg in `handle-assume.m31.ref`, I don't know why.