### PR TITLE
Fix continuations and dynamic environment

### DIFF
--- a/src/nucleus/assumption.ml
+++ b/src/nucleus/assumption.ml
@@ -75,5 +75,3 @@ let as_atom_set ~loc {free;bound;} =
   then free
   else Error.impossible ~loc "reducing assumptions to free assumptions not allowed when there are bound assumptions"
 
-let bound x = x.bound
-

--- a/src/nucleus/assumption.mli
+++ b/src/nucleus/assumption.mli
@@ -30,4 +30,3 @@ val bind : int -> t -> t
     Otherwise it raises an Error.impossible. *)
 val as_atom_set : loc:Location.t -> t -> Name.AtomSet.t
 
-val bound : t -> BoundSet.t

--- a/src/nucleus/eval.ml
+++ b/src/nucleus/eval.ml
@@ -320,8 +320,8 @@ let rec infer (c',loc) =
     infer_projection ~loc c p
 
   | Syntax.Yield c ->
-    Value.lookup_continuation ~loc >>= fun k ->
-    infer c >>= Value.apply_closure k
+    infer c >>= fun v ->
+    Value.continue ~loc v
 
   | Syntax.Hypotheses ->
      Value.lookup_abstracting >>= fun lst ->
@@ -823,8 +823,7 @@ and match_op_cases ~loc op cases vs checking =
   let rec fold = function
     | [] ->
       Value.operation op ?checking vs >>= fun v ->
-      Value.lookup_continuation ~loc >>= fun k ->
-      Value.apply_closure k v
+      Value.continue ~loc v
     | (xs, ps, pt, c) :: cases ->
       Matching.match_op_pattern ps pt vs checking >>= begin function
         | Some vs ->

--- a/src/nucleus/eval.ml
+++ b/src/nucleus/eval.ml
@@ -98,9 +98,8 @@ let rec infer (c',loc) =
             Some f
           end
         and handler_ops = Name.IdentMap.mapi (fun op cases ->
-            let f {Value.args=vs;checking;cont} =
-              Value.set_continuation cont
-              (match_op_cases ~loc op cases vs checking)
+            let f {Value.args=vs;checking} =
+              match_op_cases ~loc op cases vs checking
             in
             f)
           handler_ops

--- a/src/nucleus/value.ml
+++ b/src/nucleus/value.ml
@@ -53,7 +53,7 @@ and lexical = {
   context : (Name.ident * bound_info) list;
   bound : value list;
 
-  continuation : continuation option;
+  continuation : value continuation option;
 
   (* The following are only modified at the top level *)
   handle : (Name.ident * (value list * Jdg.ty option,value) closure) list;
@@ -78,7 +78,7 @@ and ('a, 'b) closure = Clos of ('a -> 'b comp)
 
 and 'a result =
   | Return of 'a
-  | Operation of Name.ident * value list * Jdg.ty option * dynamic * (value,'a) closure
+  | Operation of Name.ident * value list * Jdg.ty option * dynamic * 'a continuation
 
 and 'a comp = env -> 'a result * state
 
@@ -86,11 +86,11 @@ and operation_args = { args : value list; checking : Jdg.ty option }
 
 and handler = {
   handler_val: (value,value) closure option;
-  handler_ops: (continuation -> (operation_args, value) closure) Name.IdentMap.t;
+  handler_ops: (value continuation -> (operation_args, value) closure) Name.IdentMap.t;
   handler_finally: (value,value) closure option;
 }
 
-and continuation = (value,value) closure
+and 'a continuation = Continuation of (value -> state -> 'a result * state)
 
 (** A toplevel computation carries around the current
     environment. *)
@@ -141,6 +141,9 @@ let mk_closure_ref g r = Clos (fun v env -> g v {env with lexical = (!r).lexical
 
 let apply_closure (Clos f) v env = f v env
 
+let mk_cont f env = Continuation (fun v state -> f v {env with state})
+let apply_cont (Continuation f) v {state;_} = f v state
+
 (** References *)
 let mk_ref v env =
   let x,state = Store.fresh v env.state in
@@ -161,7 +164,7 @@ let rec bind (r:'a comp) (f:'a -> 'b comp) : 'b comp = fun env ->
   | Return v, state -> f v {env with state}
   | Operation (op, vs, jt, d, k), state ->
      let env = {env with state} in
-     let k = mk_closure0 (fun x -> bind (apply_closure k x) f) env in
+     let k = mk_cont (fun x -> bind (apply_cont k x) f) env in
      Operation (op, vs, jt, d, k), env.state
 
 let (>>=) = bind
@@ -279,7 +282,7 @@ let as_constrain ~loc = function
 (** Operations *)
 
 let operation op ?checking vs env =
-  Operation (op, vs, checking, env.dynamic, mk_closure0 return env), env.state
+  Operation (op, vs, checking, env.dynamic, mk_cont return env), env.state
 
 let operation_equal v1 v2 =
   operation name_equal [v1;v2]
@@ -476,7 +479,7 @@ let lookup_handle op {lexical={handle=lst;_};_} =
 
 let continue ~loc v ({lexical={continuation;_};_} as env) =
   match continuation with
-    | Some cont -> apply_closure cont v env
+    | Some cont -> apply_cont cont v env
     | None -> Error.impossible ~loc "No continuation"
 
 let push_file f env =
@@ -680,7 +683,7 @@ let rec handle_comp {handler_val; handler_ops; handler_finally} (r : value comp)
   | Operation (op, vs, jt, dynamic, cont), state ->
      let env = {env with dynamic; state} in
      let h = {handler_val; handler_ops; handler_finally=None} in
-     let cont = mk_closure0 (fun v env -> handle_comp h (apply_closure cont v) env) env in
+     let cont = mk_cont (fun v env -> handle_comp h (apply_cont cont v) env) env in
      begin
        try
          let f = (Name.IdentMap.find op handler_ops) cont in
@@ -704,7 +707,7 @@ let top_handle ~loc r env0 =
         | None -> Error.runtime ~loc "unhandled operation %t" (print_operation env op vs)
         | Some f ->
           let r = apply_closure f (vs,checking) >>=
-            apply_closure k
+            apply_cont k
           in
           handle (r env) env
        end

--- a/src/nucleus/value.ml
+++ b/src/nucleus/value.ml
@@ -53,7 +53,7 @@ and lexical = {
   context : (Name.ident * bound_info) list;
   bound : value list;
 
-  continuation : (value,value) closure option;
+  continuation : continuation option;
 
   (* The following are only modified at the top level *)
   handle : (Name.ident * (value list * Jdg.ty option,value) closure) list;

--- a/src/nucleus/value.ml
+++ b/src/nucleus/value.ml
@@ -474,9 +474,9 @@ let lookup_handle op {lexical={handle=lst;_};_} =
     Some (List.assoc op lst)
   with Not_found -> None
 
-let lookup_continuation ~loc ({lexical={continuation;_};_} as env) =
+let continue ~loc v ({lexical={continuation;_};_} as env) =
   match continuation with
-    | Some cont -> Return cont, env.state
+    | Some cont -> apply_closure cont v env
     | None -> Error.impossible ~loc "No continuation"
 
 let push_file f env =

--- a/src/nucleus/value.mli
+++ b/src/nucleus/value.mli
@@ -38,13 +38,9 @@ type value = private
   | String of string (** NB: strings are opaque to the user, ie not lists *)
   | Ident of Name.ident
 
-and operation_args = { args : value list; checking : Jdg.ty option; cont : (value,value) closure }
+and operation_args = { args : value list; checking : Jdg.ty option}
 
-and handler = {
-  handler_val: (value,value) closure option;
-  handler_ops: (operation_args, value) closure Name.IdentMap.t;
-  handler_finally: (value,value) closure option;
-}
+and handler
 
 (** computations provide a dynamically scoped environment and operations *)
 type 'a comp
@@ -227,9 +223,6 @@ val add_dynamic : loc:Location.t -> Name.ident -> value -> unit toplevel
 
 (** Add a top-level handler case to the environment. *)
 val add_handle : Name.ident -> (value list * Jdg.ty option,value) closure -> unit toplevel
-
-(** Set the continuation for a handler computation. *)
-val set_continuation : (value,value) closure -> 'a comp -> 'a comp
 
 (** Lookup the current continuation. *)
 val lookup_continuation : loc:Location.t -> ((value,value) closure) comp

--- a/src/nucleus/value.mli
+++ b/src/nucleus/value.mli
@@ -225,7 +225,7 @@ val add_dynamic : loc:Location.t -> Name.ident -> value -> unit toplevel
 val add_handle : Name.ident -> (value list * Jdg.ty option,value) closure -> unit toplevel
 
 (** Lookup the current continuation. *)
-val lookup_continuation : loc:Location.t -> ((value,value) closure) comp
+val continue : loc:Location.t -> value -> value comp
 
 (** Add a file to the list of files included. *)
 val push_file : string -> unit toplevel

--- a/tests/beta-dynamic.m31.ref
+++ b/tests/beta-dynamic.m31.ref
@@ -6,5 +6,4 @@ f is defined.
 eq₁₀ : a ≡ b 
 ⊢ eq₁₀ : a ≡ b
 Operation gimme_beta is declared.
-eq₁₁ : a ≡ b 
-⊢ eq₁₁ : a ≡ b
+⊢ refl a : a ≡ a


### PR DESCRIPTION
Applying a continuation resets the dynamic environment of its call site.
Try examples/esystems.m31 before and after to see why this is important.