### PR TITLE
Fix empty matches

### DIFF
--- a/src/runtime/predefined.ml
+++ b/src/runtime/predefined.ml
@@ -19,8 +19,6 @@ let predefined_aml_types = let open Input in
     (Name.Predefined.nil, []);
     (Name.Predefined.cons, [ty_alpha; (ML_TyApply (Name.Predefined.list, [ty_alpha]), loc)])
     ])], loc
-  and decl_empty = DefMLType [Name.Predefined.empty, ([],
-  ML_Sum [])], loc
   and decl_coercible = DefMLType [Name.Predefined.coercible_ty, ([],
     ML_Sum [
     (Name.Predefined.notcoercible, []);
@@ -28,7 +26,7 @@ let predefined_aml_types = let open Input in
     (Name.Predefined.coercible_constructor, [ML_Judgment, loc])
     ])], loc
   in
-  [decl_option; decl_list; decl_empty; decl_coercible]
+  [decl_option; decl_list; decl_coercible]
 
 let predefined_ops = let open Input in
   let loc = Location.unknown in

--- a/src/typing/typecheck.ml
+++ b/src/typing/typecheck.ml
@@ -413,8 +413,6 @@ and handler ~loc {Syntax.handler_val=handler_val;handler_ops;handler_finally} =
 and match_cases ~loc t cases =
   match cases with
     | [] ->
-      Tyenv.predefined_type Name.Predefined.empty [] >>= fun empty ->
-      Tyenv.add_equation ~loc t empty >>= fun () ->
       Tyenv.return ([], Mlty.fresh_type ())
     | (xs, p, c) :: others ->
       match_case xs p t (comp c) >>= fun (c, out) ->

--- a/src/utils/name.ml
+++ b/src/utils/name.ml
@@ -55,8 +55,6 @@ module Predefined = struct
 
   let as_eq = make "as_eq"
 
-  let empty = make "empty"
-
   let coercible_ty = make "coercible"
  
   let coercible_constructor = make "Coercible"

--- a/src/utils/name.mli
+++ b/src/utils/name.mli
@@ -45,9 +45,6 @@ module Predefined : sig
   (** The name of the [as_eq] operation *)
   val as_eq : operation
 
-  (** The name of the empty type *)
-  val empty : ty
-
   (** The name of the [coercible] type *)
   val coercible_ty : ty
 

--- a/std/base.m31
+++ b/std/base.m31
@@ -25,3 +25,5 @@ mltype eagerness =
   | lazy
   end
 
+mltype empty = end
+


### PR DESCRIPTION
We don't do exhaustiveness checking so it's actually OK to have empty matches on arbitrary types.