### PR TITLE
Rename types, declare operations

### DIFF
--- a/_includes/macros.html
+++ b/_includes/macros.html
@@ -1,12 +1,11 @@
 $\newcommand{\G}{\Gamma}$
 $\newcommand{\D}{\Delta}$
-$\newcommand{\T}{T}$
-$\newcommand{\U}{U}$
+$\newcommand{\tyA}{A}$
+$\newcommand{\tyB}{B}$
 $\newcommand{\x}{x}$
 $\newcommand{\y}{y}$
 $\newcommand{\z}{z}$
 $\newcommand{\e}{e}$
-$\newcommand{\rulename}[1]{\text{\textsc{#1}}}$
 $\newcommand{\bnf}{\ \mathrel{ {\colon}{\colon}{=}}\ }$
 $\newcommand{\bnfor}{\ \mid\ \ }$
 $\newcommand{\ctxempty}{\bullet}$

--- a/meta-language.md
+++ b/meta-language.md
@@ -7,7 +7,7 @@ use_math: true
 
 Table of contents:
 
-* [About the Andromeda meta-language](#about-the-andromeda-meta-language)
+* [About the Andromeda meta-language](#about-the-a1ndromeda-meta-language)
 * [ML-types](#ml-types)
    * [ML-type definitions](#ml-type-definitions)
    * [Inductive ML-datatypes](#inductive-ml-datatypes)
@@ -58,8 +58,8 @@ of Robin Milner's
 [Logic for computable functions](http://i.stanford.edu/pub/cstr/reports/cs/tr/72/288/CS-TR-72-288.pdf)
 (LCF). We call it the **Andromeda meta-language (AML)**.
 
-Andromeda computes typing judgments of the form $\isterm{\G}{\e}{\T}$ ("Under
-assumptions $\G$ term $\e$ has type $\T$"), but only the ones that are *derivable* in
+Andromeda computes typing judgments of the form $\isterm{\G}{\e}{\tyA}$ ("Under
+assumptions $\G$ term $\e$ has type $\tyA$"), but only the ones that are *derivable* in
 [type theory with equality reflection](type-theory.html). This is known as *soundness* of
 AML. *Completeness* of AML states that every derivable judgment is computed by some
 program. Neither property has actually been proved yet, we are working on it.
@@ -140,6 +140,7 @@ defintions. E.g., the ML-type of binary trees can be defined as
 
 The following types are predefined by Andromeda:
 
+* `mlunit` is the unit type whose only value is the empty tuple `()`
 * `mlstring` is the type of [strings](#strings)
 * `option α` is the type of [optional values](#optional-values)
 * `list α` is the type of [lists](#lists)
@@ -239,7 +240,7 @@ computes `c₁`, discards the result, and computes `c₂`. It is equivalent to
 
     let _ = c₁ in c₂
 
-except for warning when `c₁` evaluates to something other than the empty tuple `()`.
+except for warning when `c₁` has type other than `mlunit`.
 
 ##### Recursive functions
 
@@ -335,8 +336,8 @@ The general patterns are:
    | `?x` | match any value and bind it to `x` |
    | `p as ?x` | match according to pattern `p` and also bind the value to `x` |
    | `x` | match a value if it equals the value of `x` |
-   | `⊢ j` | match a judgment $\isterm{\G}{\e}{\T}$ according to the *judgment pattern `j`*, see below |
-   | `⊢ j₁ : j₂` | match a judgment $\isterm{\G}{\e}{\T}$ with `j₁` and $\isterm{\G}{\T}{Type}$ with `j₂` |
+   | `⊢ j` | match a judgment $\isterm{\G}{\e}{\tyA}$ according to the *judgment pattern `j`*, see below |
+   | `⊢ j₁ : j₂` | match a judgment $\isterm{\G}{\e}{\tyA}$ with `j₁` and $\isterm{\G}{\tyA}{\Type}$ with `j₂` |
    | `Tag p₁ ... pᵢ` | match a data tag |
    | `[]` | match the empty list |
    | `p₁ :: p₂` | match the head and the tail of a non-empty list |
@@ -363,7 +364,7 @@ In the above `match` statement the pattern refers to `a` whose values is `"foo"`
 
 ###### Judgment patterns
 
-A judgment pattern matches a judgment $\isterm{\G}{\e}{\T}$ as follows:
+A judgment pattern matches a judgment $\isterm{\G}{\e}{\tyA}$ as follows:
 
    |---|---|
    | `_` | match any term |
@@ -383,8 +384,8 @@ A judgment pattern matches a judgment $\isterm{\G}{\e}{\T}$ as follows:
 
 ###### Matching under binders
 
-When matching a judgment $\isterm{\G}{∏ (x : A) B}{Type}$ with a pattern `∏ (y : j₁), j₂`,
-a fresh variable $y₁$ is produced so that we may match $\isterm{\G, y₁ : A}{B}{Type}$ with `j₂`.
+When matching a judgment $\isterm{\G}{∏ (x : A) B}{\Type}$ with a pattern `∏ (y : j₁), j₂`,
+a fresh variable $y₁$ is produced so that we may match $\isterm{\G, y₁ : A}{B}{\Type}$ with `j₂`.
 
 Patterns which match under a binder have two forms:
 * one in which the binder variable is a pattern variable, such as `∏ (?y : j₁), j₂`.
@@ -662,25 +663,25 @@ Set the verbosity level. The levels are:
 ### Judgment computations
 
 There is no way in Andromeda to create a bare type-theoretic term $\e$, only a complete
-typing judgment $\isterm{\G}{\e}{\T}$. Even those computations that *look* like terms
+typing judgment $\isterm{\G}{\e}{\tyA}$. Even those computations that *look* like terms
 actually compute judgments. For instance, if `c₁` computes to
 
-$$\isterm{\G}{\e_1}{\Prod{\x}{\T} \U}$$
+$$\isterm{\G}{\e_1}{\Prod{\x}{\tyA} \tyB}$$
 
 and `c₂` computes to
 
-$$\isterm{\D}{\e_2}{\T},$$
+$$\isterm{\D}{\e_2}{\tyA},$$
 
 then the "application" `c₁ c₂` computes to
 
-$$\isterm{\G \bowtie \D}{\app{\e_1}{\x}{\T}{\U}{\e_2}}{\subst{\U}{\x}{\e_2}}$$
+$$\isterm{\G \bowtie \D}{\app{\e_1}{\x}{\tyA}{\tyB}{\e_2}}{\subst{\tyB}{\x}{\e_2}}$$
 
 where $\G \bowtie \D$ is the *join* of contexts $\G$ and $\D$, satisfying the property
 that $\G \bowtie \D$ contains both $\G$ and $\D$ (the two contexts $\G$ and $\D$ may be
 incompatible, in which case Andromeda reports an error).
 
-Even though Andromeda always computes an entire judgment $\isterm{\G}{\e}{\T}$ it is
-useful to think of it as just a term $\e$ with a known type $\T$ and assumptions $\G$
+Even though Andromeda always computes an entire judgment $\isterm{\G}{\e}{\tyA}$ it is
+useful to think of it as just a term $\e$ with a known type $\tyA$ and assumptions $\G$
 which Andromeda is kindly keeping track of.
 
 ##### Inferring and checking mode
@@ -689,17 +690,17 @@ A judgment is computed in one of two modes, the **inferring** or the **checking*
 
 In the inferring mode the judgment that is being computed is unrestrained.
 
-In checking mode there is a given type $\T$ (actually a judgment $\istype{\G}{\T}$) and
-the judgment that is being computed must have the form $\isterm{\D}{\e}{\T}$. In other
+In checking mode there is a given type $\tyA$ (actually a judgment $\istype{\G}{\tyA}$) and
+the judgment that is being computed must have the form $\isterm{\D}{\e}{\tyA}$. In other
 words, the type is prescribed in advanced. For example, an application
 
     c₁ c₂
 
 proceeds as follows:
 
-1. Compute `c₁` in inferring mode to obtain a judgment $\isterm{\G}{\e}{\T}$.
-2. Verify that $\T$ is equal to $\Prod{x}{\T_1}{\T_2}$, using `as_prod` if necessary (see [equality checking](#equality-checking)).
-3. Compute `c₂` in checking mode at type $\T_1$.
+1. Compute `c₁` in inferring mode to obtain a judgment $\isterm{\G}{\e}{\tyA}$.
+2. Verify that $\tyA$ is equal to $\Prod{x}{\tyA_1}{\tyA_2}$, using `as_prod` if necessary (see [equality checking](#equality-checking)).
+3. Compute `c₂` in checking mode at type $\tyA_1$.
 
 
 #### The universe
@@ -734,11 +735,11 @@ A primitive type `T` is declared with
 
 #### Assumptions
 
-If computation `c₁` computes to judgment $\istype{\G}{\T}$ then
+If computation `c₁` computes to judgment $\istype{\G}{\tyA}$ then
 
     assume x : c₁ in c₂
 
-binds `x` to $\isterm{\ctxextend{\G}{\x'}{\T}}{\x'}{\T}$,
+binds `x` to $\isterm{\ctxextend{\G}{\x'}{\tyA}}{\x'}{\tyA}$,
 then it evaluates `c₂`. The judgment is valid by
 [rule `ctx-var`](type-theory.html#term-var) and
 [rule `ctx-extend`](type-theory.html#ctx-extend). Example:
@@ -895,9 +896,9 @@ Type ascription
 
     c₁ : c₂
 
-first computes `c₂`, which must evaluate to a type $\istype{\G}{\T}$. It then computes
-`c₁` in checking mode at type $\T$ thereby guaranteeing that the result will be a judgment
-of the form $\isterm{\D}{\e}{\T}$.
+first computes `c₂`, which must evaluate to a type $\istype{\G}{\tyA}$. It then computes
+`c₁` in checking mode at type $\tyA$ thereby guaranteeing that the result will be a judgment
+of the form $\isterm{\D}{\e}{\tyA}$.
 
 #### Context and occurs check
 
@@ -905,7 +906,7 @@ The computation
 
     context c
 
-computes `c` to a judgment $\isterm{\G}{\e}{\T}$ and gives the list of all assumptions in
+computes `c` to a judgment $\isterm{\G}{\e}{\tyA}$ and gives the list of all assumptions in
 $\Gamma$. Example:
 
     # constant A : Type
@@ -921,7 +922,7 @@ The computation
 
     occurs x c
 
-computes `x` to a judgment $\isterm{\D}{\x}{A}$ and `c` to a judgment $\isterm{\G}{\e}{\T}$ such that $x$ is a variable.
+computes `x` to a judgment $\isterm{\D}{\x}{A}$ and `c` to a judgment $\isterm{\G}{\e}{\tyA}$ such that $x$ is a variable.
 It evaluates to `None` if $x$ does not occur in $\G$, and to
 `Some U` if $x$ occurs in $\G$ as an assumption of type `U`.
 

--- a/meta-language.md
+++ b/meta-language.md
@@ -403,12 +403,16 @@ several examples below.
 
 A new operation is declared by
 
-    operation op i
+    operation op : t₁ → t₂ → ... → tᵢ → u
 
-where `op` is the operation name and the numeral `i` is its arity, i.e., the number of
-arguments it takes. An operation is then invoked with
+where `op` is the operation name, `t₁`, ..., `tᵢ` are the types of the operation
+arguments, and `u` is its return type.
+
+An operation is then invoked with
 
     op c₁ .. cᵢ
+
+where `cⱼ` must have type `tⱼ`.
 
 One way to think of an operation is as a generalized resumable exception: when an
 operation is invoked it "propagates" outward to the innermost handler that handles it. The

--- a/type-theory.md
+++ b/type-theory.md
@@ -25,22 +25,22 @@ simplified with respect to the implementation in the following ways:
 
    $$
    \infer
-   {\istype{\G}{\T} \qquad
-    \isterm{\G}{\e_1}{\T} \qquad
-    \isterm{\G}{\e_2}{\T}
+   {\istype{\G}{\tyA} \qquad
+    \isterm{\G}{\e_1}{\tyA} \qquad
+    \isterm{\G}{\e_2}{\tyA}
    }
-   {\istype{\G}{\JuEqual{\T}{\e_1}{\e_2}}}
+   {\istype{\G}{\JuEqual{\tyA}{\e_1}{\e_2}}}
    $$
 
    but is implemented as
 
    $$
    \infer
-   {\istype{\G}{\T} \qquad
-    \isterm{\D}{\e_1}{\T} \qquad
-    \isterm{\Xi}{\e_2}{\T}
+   {\istype{\G}{\tyA} \qquad
+    \isterm{\D}{\e_1}{\tyA} \qquad
+    \isterm{\Xi}{\e_2}{\tyA}
    }
-   {\istype{(\G \bowtie \D \bowtie \Xi)}{\JuEqual{\T}{\e_1}{\e_2}}}
+   {\istype{(\G \bowtie \D \bowtie \Xi)}{\JuEqual{\tyA}{\e_1}{\e_2}}}
    $$
 
    where the *join* $\G \bowtie \D$ is computed as the union of (directed graphs
@@ -55,29 +55,29 @@ For instance, a $\lambda$-abstraction is tagged with both the doman and the codo
 
 ### Syntax
 
-Terms $\e$ and types $\T$, $\U$:
+Terms $\e$ and types $\tyA$, $\tyB$:
 
 |---|---|
 | $\Type$ | universe |
-| $\Prod{x}{\T} \U$ | product |
-| $\JuEqual{\T}{\e_1}{\e_2}$ | equality type |
+| $\Prod{x}{\tyA} \tyB$ | product |
+| $\JuEqual{\tyA}{\e_1}{\e_2}$ | equality type |
 | $\x$ | variable |
-| $\lam{\x}{\T_1}{\T_2} \e$ | $\lambda$-abstraction |
-| $\app{\e_1}{\x}{\T_1}{\T_2}{\e_2}$ | application |
-| $\juRefl{\T} \e$ | reflexivity |
+| $\lam{\x}{\tyA}{\tyB} \e$ | $\lambda$-abstraction |
+| $\app{\e_1}{\x}{\tyA}{\tyB}{\e_2}$ | application |
+| $\juRefl{\tyA} \e$ | reflexivity |
 
 Contexts $\G$:
 
 |---|---|
 | $\ctxempty$ | empty context |
-| $\ctxextend{\G}{\x}{\T}$ | context $\G$ extended with $\x : \T$ |
+| $\ctxextend{\G}{\x}{\tyA}$ | context $\G$ extended with $\x : \tyA$ |
 
 ### Judgments
 
 |---|---|
 | $\isctx{\G}$          | $\G$ is a well formed context |
-| $\isterm{\G}{\e}{\T}$ | $\e$ is a well formed term of type $\T$ in context $\G$ |
-| $\eqterm{\G}{\e_1}{\e_2}{\T}$ | $e_1$ and $e_2$ are equal terms of type $\T$ in context |
+| $\isterm{\G}{\e}{\tyA}$ | $\e$ is a well formed term of type $\tyA$ in context $\G$ |
+| $\eqterm{\G}{\e_1}{\e_2}{\tyA}$ | $e_1$ and $e_2$ are equal terms of type $\tyA$ in context |
 | $\eqctx{\G}{\D}$      | $\G$ and $\D$ are equal contexts |
 
 ### Judgment: $\isctx{\G}$
@@ -95,10 +95,10 @@ $$
 $$
   \infer
   {\isctx{\G} \qquad
-   \istype{\G}{\T} \qquad
+   \istype{\G}{\tyA} \qquad
    x \not\in \mathsf{dom}(\G)
   }
-  {\isctx{\ctxextend{\G}{\x}{\T}}}
+  {\isctx{\ctxextend{\G}{\x}{\tyA}}}
 $$
 
 Here $\mathsf{dom}(\G)$ is the set of all variables that are declared in $\G$, i.e.:
@@ -106,7 +106,7 @@ Here $\mathsf{dom}(\G)$ is the set of all variables that are declared in $\G$, i
 $$
 \mathsf{dom}(\ctxempty) = \emptyset
 \qquad\text{and}\qquad
-\mathsf{dom}(\ctxextend{\G}{\x}{\T}) = \mathsf{dom}(\G) \cup \{x\}.
+\mathsf{dom}(\ctxextend{\G}{\x}{\tyA}) = \mathsf{dom}(\G) \cup \{x\}.
 $$
 
 ### Judgment: $\eqctx{\G}{\D}$
@@ -127,10 +127,10 @@ $$
    &\eqctx{\G}{\D} \qquad
    x \not\in \mathsf{dom}(\G) \cup \mathsf{dom}(\D) \\
    &
-   \istype{\G}{\T} \qquad
-   \istype{\D}{\U}
+   \istype{\G}{\tyA} \qquad
+   \istype{\D}{\tyB}
    \end{aligned}}
-  {\eqctx{\ctxextend{\G}{\x}{\T}}{\ctxextend{\D}{\x}{\U}}}
+  {\eqctx{\ctxextend{\G}{\x}{\tyA}}{\ctxextend{\D}{\x}{\tyB}}}
 $$
 
 ###### `ctx-term-conv`
@@ -138,8 +138,8 @@ $$
 $$
   \infer
   {\eqctx{\G}{\D} \qquad
-   \isterm{\G}{\e}{\T}}
-  {\isterm{\D}{\e}{\T}}
+   \isterm{\G}{\e}{\tyA}}
+  {\isterm{\D}{\e}{\tyA}}
 $$
 
 ###### `ctx-eq-conv`
@@ -147,11 +147,11 @@ $$
 $$
   \infer
   {\eqctx{\G}{\D} \qquad
-   \eqterm{\G}{\e_1}{\e_2}{\T}}
-  {\eqterm{\D}{\e_1}{\e_2}{\T}}
+   \eqterm{\G}{\e_1}{\e_2}{\tyA}}
+  {\eqterm{\D}{\e_1}{\e_2}{\tyA}}
 $$
 
-### Judgment: $\isterm{\G}{\e}{\T}$
+### Judgment: $\isterm{\G}{\e}{\tyA}$
 
 #### General rules
 
@@ -159,10 +159,10 @@ $$
 
 $$
   \infer
-  {\isterm{\G}{\e}{\T} \qquad
-   \eqtype{\G}{\T}{\U}
+  {\isterm{\G}{\e}{\tyA} \qquad
+   \eqtype{\G}{\tyA}{\tyB}
   }
-  {\isterm{\G}{\e}{\U}}
+  {\isterm{\G}{\e}{\tyB}}
 $$
 
 ###### `term-var`
@@ -170,9 +170,9 @@ $$
 $$
   \infer
   {\isctx{\G} \qquad
-   (\x{:}\T) \in \G
+   (\x{:}\tyA) \in \G
   }
-  {\isterm{\G}{\x}{\T}}
+  {\isterm{\G}{\x}{\tyA}}
 $$
 
 #### Universe
@@ -191,26 +191,26 @@ $$
 ###### `ty-prod`
 
 $$\infer
-  {\istype{\G}{\T} \qquad
-   \istype{\ctxextend{\G}{\x}{\T}}{\U}
+  {\istype{\G}{\tyA} \qquad
+   \istype{\ctxextend{\G}{\x}{\tyA}}{\tyB}
   }
-  {\istype{\G}{\Prod{\x}{\T}{\U}}}
+  {\istype{\G}{\Prod{\x}{\tyA}{\tyB}}}
 $$
 
 ###### `term-abs`
 
 $$\infer
-  {\isterm{\ctxextend{\G}{\x}{\T}}{\e}{\U}}
-  {\isterm{\G}{(\lam{\x}{\T}{\U}{\e})}{\Prod{\x}{\T}{\U}}}
+  {\isterm{\ctxextend{\G}{\x}{\tyA}}{\e}{\tyB}}
+  {\isterm{\G}{(\lam{\x}{\tyA}{\tyB}{\e})}{\Prod{\x}{\tyA}{\tyB}}}
 $$
 
 ###### `term-app`
 
 $$\infer
-  {\isterm{\G}{\e_1}{\Prod{x}{\T} \U} \qquad
-   \isterm{\G}{\e_2}{\T}
+  {\isterm{\G}{\e_1}{\Prod{x}{\tyA} \tyB} \qquad
+   \isterm{\G}{\e_2}{\tyA}
   }
-  {\isterm{\G}{\app{\e_1}{\x}{\T}{\U}{\e_2}}{\subst{\U}{\x}{\e_2}}}
+  {\isterm{\G}{\app{\e_1}{\x}{\tyA}{\tyB}{\e_2}}{\subst{\tyB}{\x}{\e_2}}}
 $$
 
 #### Equality type
@@ -219,18 +219,18 @@ $$
 
 $$
   \infer
-  {\istype{\G}{\T} \qquad
-   \isterm{\G}{\e_1}{\T} \qquad
-   \isterm{\G}{\e_2}{\T}
+  {\istype{\G}{\tyA} \qquad
+   \isterm{\G}{\e_1}{\tyA} \qquad
+   \isterm{\G}{\e_2}{\tyA}
   }
-  {\istype{\G}{\JuEqual{\T}{\e_1}{\e_2}}}
+  {\istype{\G}{\JuEqual{\tyA}{\e_1}{\e_2}}}
 $$
 
 ###### `term-refl`
 
 $$\infer
-  {\isterm{\G}{\e}{\T}}
-  {\isterm{\G}{\juRefl{\T} \e}{\JuEqual{\T}{\e}{\e}}}
+  {\isterm{\G}{\e}{\tyA}}
+  {\isterm{\G}{\juRefl{\tyA} \e}{\JuEqual{\tyA}{\e}{\e}}}
 $$
 
 ### Equality
@@ -240,31 +240,31 @@ $$
 ###### `eq-refl`
 
 $$  \infer
-  {\isterm{\G}{\e}{\T}}
-  {\eqterm{\G}{\e}{\e}{\T}}
+  {\isterm{\G}{\e}{\tyA}}
+  {\eqterm{\G}{\e}{\e}{\tyA}}
 $$
 
 ###### `eq-sym`
 
 $$\infer
-  {\eqterm{\G}{\e_2}{\e_1}{\T}}
-  {\eqterm{\G}{\e_1}{\e_2}{\T}}
+  {\eqterm{\G}{\e_2}{\e_1}{\tyA}}
+  {\eqterm{\G}{\e_1}{\e_2}{\tyA}}
 $$
 
 ###### `eq-trans`
 
 $$\infer
-  {\eqterm{\G}{\e_1}{\e_2}{\T}\qquad
-   \eqterm{\G}{\e_2}{\e_3}{\T}}
-  {\eqterm{\G}{\e_1}{\e_3}{\T}}
+  {\eqterm{\G}{\e_1}{\e_2}{\tyA}\qquad
+   \eqterm{\G}{\e_2}{\e_3}{\tyA}}
+  {\eqterm{\G}{\e_1}{\e_3}{\tyA}}
 $$
 
 ###### `eq-conv`
 
 $$\infer
-  {\eqterm{\G}{\e_1}{\e_2}{\T}\qquad
-    \eqtype{\G}{\T}{\U}}
-  {\eqterm{\G}{\e_1}{\e_2}{\U}}
+  {\eqterm{\G}{\e_1}{\e_2}{\tyA}\qquad
+    \eqtype{\G}{\tyA}{\tyB}}
+  {\eqterm{\G}{\e_1}{\e_2}{\tyB}}
 $$
 
 Remark: in the presence of `eq-reflection` (see below) the rules `eq-conv`,
@@ -276,11 +276,11 @@ Remark: in the presence of `eq-reflection` (see below) the rules `eq-conv`,
 
 $$
 \infer
-  {\isterm{\ctxextend{\G}{\x}{\T_1}}{\e_1}{\T_2}\qquad
-   \isterm{\G}{\e_2}{\T_1}}
-  {\eqterm{\G}{\bigl(\app{(\lam{\x}{\T_1}{\T_2}{\e_1})}{\x}{\T_1}{\T_2}{\e_2}\bigr)}
+  {\isterm{\ctxextend{\G}{\x}{\tyA}}{\e_1}{\tyB}\qquad
+   \isterm{\G}{\e_2}{\tyA}}
+  {\eqterm{\G}{\bigl(\app{(\lam{\x}{\tyA}{\tyB}{\e_1})}{\x}{\tyA}{\tyB}{\e_2}\bigr)}
               {\subst{\e_1}{\x}{\e_2}}
-              {\subst{\T_2}{\x}{\e_2}}}
+              {\subst{\tyB}{\x}{\e_2}}}
 $$
 
 #### Reflection and extensionality
@@ -289,30 +289,30 @@ $$
 
 $$
   \infer
-  {\isterm{\G}{\e}{\JuEqual{\T}{\e_1}{\e_2}}}
-  {\eqterm{\G}{\e_1}{\e_2}{\T}}
+  {\isterm{\G}{\e}{\JuEqual{\tyA}{\e_1}{\e_2}}}
+  {\eqterm{\G}{\e_1}{\e_2}{\tyA}}
 $$
 
 ###### `eq-ext`
 
 $$\infer
-  {\isterm{\G}{\e_3}{\JuEqual{\T}{\e_1}{\e_2}} \qquad
-    \isterm{\G}{\e_4}{\JuEqual{\T}{\e_1}{\e_2}}
+  {\isterm{\G}{\e_3}{\JuEqual{\tyA}{\e_1}{\e_2}} \qquad
+    \isterm{\G}{\e_4}{\JuEqual{\tyA}{\e_1}{\e_2}}
   }
-  {\eqterm{\G}{\e_3}{e_4}{\JuEqual{\T}{\e_1}{\e_2}}}
+  {\eqterm{\G}{\e_3}{e_4}{\JuEqual{\tyA}{\e_1}{\e_2}}}
 $$
 
 ###### `prod-ext`
 
 $$\infer
   {\begin{aligned}[t]
-   &\isterm{\G}{\e_1}{\Prod{\x}{\T}{\U}}\qquad
-    \isterm{\G}{\e_2}{\Prod{\x}{\T}{\U}}\\
-   &\eqterm{\ctxextend{\G}{\x}{\T}}{(\app{\e_1}{\x}{\T}{\U}{\x})}
-          {(\app{\e_2}{\x}{\T}{\U}{\x})}{\U}
+   &\isterm{\G}{\e_1}{\Prod{\x}{\tyA}{\tyB}}\qquad
+    \isterm{\G}{\e_2}{\Prod{\x}{\tyA}{\tyB}}\\
+   &\eqterm{\ctxextend{\G}{\x}{\tyA}}{(\app{\e_1}{\x}{\tyA}{\tyB}{\x})}
+          {(\app{\e_2}{\x}{\tyA}{\tyB}{\x})}{\tyB}
   \end{aligned}
   }
-  {\eqterm{\G}{\e_1}{\e_2}{\Prod{\x}{\T}{\U}}}
+  {\eqterm{\G}{\e_1}{\e_2}{\Prod{\x}{\tyA}{\tyB}}}
 $$
 
 #### Congruences
@@ -322,21 +322,21 @@ $$
 ###### `cong-prod`
 
 $$\infer
-  {\eqtype{\G}{\T_1}{\U_1}\qquad
-   \eqtype{\ctxextend{\G}{\x}{\T_1}}{\T_2}{\U_2}}
-  {\eqtype{\G}{\Prod{\x}{\T_1}{\T_2}}{\Prod{\x}{\U_1}{\U_2}}}
+  {\eqtype{\G}{\tyA_1}{\tyB_1}\qquad
+   \eqtype{\ctxextend{\G}{\x}{\tyA_1}}{\tyA_2}{\tyB_2}}
+  {\eqtype{\G}{\Prod{\x}{\tyA_1}{\tyA_2}}{\Prod{\x}{\tyB_1}{\tyB_2}}}
 $$
 
 ###### `cong-eq`
 
 $$
   \infer
-  {\eqtype{\G}{\T}{\U}\qquad
-   \eqterm{\G}{\e_1}{\e'_1}{\T}\qquad
-   \eqterm{\G}{\e_2}{\e'_2}{\T}
+  {\eqtype{\G}{\tyA}{\tyB}\qquad
+   \eqterm{\G}{\e_1}{\e'_1}{\tyA}\qquad
+   \eqterm{\G}{\e_2}{\e'_2}{\tyA}
   }
-  {\eqtype{\G}{\JuEqual{\T}{\e_1}{\e_2}}
-              {\JuEqual{\U}{\e'_1}{\e'_2}}}
+  {\eqtype{\G}{\JuEqual{\tyA}{\e_1}{\e_2}}
+              {\JuEqual{\tyB}{\e'_1}{\e'_2}}}
 $$
 
 ##### Products
@@ -345,12 +345,12 @@ $$
 
 $$
   \infer
-  {\eqtype{\G}{\T_1}{\U_1}\qquad
-    \eqtype{\ctxextend{\G}{\x}{\T_1}}{\T_2}{\U_2}\qquad
-    \eqterm{\ctxextend{\G}{\x}{\T_1}}{\e_1}{\e_2}{\T_2}}
-  {\eqterm{\G}{(\lam{\x}{\T_1}{\T_2}{\e_1})}
-              {(\lam{\x}{\U_1}{\U_2}{\e_2})}
-              {\Prod{\x}{\T_1}{\T_2}}}
+  {\eqtype{\G}{\tyA_1}{\tyB_1}\qquad
+    \eqtype{\ctxextend{\G}{\x}{\tyA_1}}{\tyA_2}{\tyB_2}\qquad
+    \eqterm{\ctxextend{\G}{\x}{\tyA_1}}{\e_1}{\e_2}{\tyA_2}}
+  {\eqterm{\G}{(\lam{\x}{\tyA_1}{\tyA_2}{\e_1})}
+              {(\lam{\x}{\tyB_1}{\tyB_2}{\e_2})}
+              {\Prod{\x}{\tyA_1}{\tyA_2}}}
 $$
 
 ###### `cong-app`
@@ -358,12 +358,12 @@ $$
 $$
   \infer
   {\begin{aligned}[t]
-   &\eqtype{\G}{\T_1}{\U_1}\qquad
-    \eqtype{\ctxextend{\G}{\x}{\T_1}}{\T_2}{\U_2}\\
-   &\eqterm{\G}{\e_1}{\e'_1}{\Prod{\x}{\T_1}{\T_2}}\qquad
-    \eqterm{\G}{\e_2}{\e'_2}{\T_1}
+   &\eqtype{\G}{\tyA_1}{\tyB_1}\qquad
+    \eqtype{\ctxextend{\G}{\x}{\tyA_1}}{\tyA_2}{\tyB_2}\\
+   &\eqterm{\G}{\e_1}{\e'_1}{\Prod{\x}{\tyA_1}{\tyA_2}}\qquad
+    \eqterm{\G}{\e_2}{\e'_2}{\tyA_1}
    \end{aligned}}
-{\eqterm{\G}{(\app{\e_1}{\x}{\T_1}{\T_2}{\e_2})}{(\app{\e'_1}{\x}{\U_1}{\U_2}{\e'_2})}{\subst{\T_2}{\x}{\e_2}}}
+{\eqterm{\G}{(\app{\e_1}{\x}{\tyA_1}{\tyA_2}{\e_2})}{(\app{\e'_1}{\x}{\tyB_1}{\tyB_2}{\e'_2})}{\subst{\tyA_2}{\x}{\e_2}}}
 $$
 
 ##### Equality types
@@ -372,9 +372,9 @@ $$
 
 $$
 \infer
-{\eqterm{\G}{\e_1}{\e_2}{\T}\qquad
- \eqtype{\G}{\T}{\U}}
-{\eqterm{\G}{\juRefl{\T} \e_1}{\juRefl{\U} \e_2}{\JuEqual{\T}{\e_1}{\e_1}}}
+{\eqterm{\G}{\e_1}{\e_2}{\tyA}\qquad
+ \eqtype{\G}{\tyA}{\tyB}}
+{\eqterm{\G}{\juRefl{\tyA} \e_1}{\juRefl{\tyB} \e_2}{\JuEqual{\tyA}{\e_1}{\e_1}}}
 $$
 
 TODO: Substitution.


### PR DESCRIPTION
Renaming types `U` and `T` to `A` and `B` because @EgbertRijke thinks `U` stands for a universe.