### PR TITLE
Multiple constants on a line requires commas

### DIFF
--- a/src/parser/parser.mly
+++ b/src/parser/parser.mly
@@ -123,7 +123,7 @@ plain_topcomp:
   | HANDLE lst=top_handler_cases END                  { TopHandle lst }
   | DO c=term                                         { TopDo c }
   | FAIL c=term                                       { TopFail c }
-  | CONSTANT xs=nonempty_list(var_name) COLON u=term  { DeclConstants (xs, u) }
+  | CONSTANT xs=separated_nonempty_list(COMMA, var_name) COLON u=term  { DeclConstants (xs, u) }
   | MLTYPE lst=mlty_defs                              { DefMLType lst }
   | MLTYPE REC lst=mlty_defs                          { DefMLTypeRec lst }
   | OPERATION op=var_name COLON opsig=op_mlsig        { DeclOperation (op, opsig) }

--- a/tests/bad-congr.m31
+++ b/tests/bad-congr.m31
@@ -1,7 +1,7 @@
 
 fail congr_prod Type Type Type
 
-constant A B : Type
+constant A, B : Type
 
 fail congr_prod (assume x : A -> B in x) A (refl B)
 

--- a/tests/coerce.m31
+++ b/tests/coerce.m31
@@ -1,4 +1,4 @@
-constant A B C : Type
+constant A, B, C : Type
 constant a : A
 constant f : A -> B
 constant g : B -> C

--- a/tests/dynamic.m31
+++ b/tests/dynamic.m31
@@ -1,6 +1,6 @@
 
 constant A : Type
-constant a b : A
+constant a, b : A
 
 dynamic x = a
 

--- a/tests/error-context-subst.m31
+++ b/tests/error-context-subst.m31
@@ -1,6 +1,6 @@
 (* Substitute with different values in separate subterms, then join. *)
 
-constant A B C : Type
+constant A, B, C : Type
 constant pair : A -> B -> C
 
 let T = assume T : Type in T

--- a/tests/eta-pair.m31
+++ b/tests/eta-pair.m31
@@ -26,7 +26,7 @@ constant pair_eta :
 
 constant C : Type
 constant D : Type
-constant p q : prod C D
+constant p, q : prod C D
 
 
 (* Beta rules. *)

--- a/tests/everything.m31
+++ b/tests/everything.m31
@@ -17,9 +17,9 @@ operation nonary_op : color
 (** Declare constants *)
 (* constant `names` : `type` *)
 constant A : (* the type of types *) Type
-constant a b : A
+constant a, b : A
 (* Ocaml-style infixes are valid `name`s and `label`s *)
-constant ( + ) ( * ) ( ^ ) ( - ) ( <= ) :
+constant ( + ), ( * ), ( ^ ), ( - ), ( <= ) :
   (* non-dependent product type *) A -> A -> A
 
 (* Infixes and prefixes are printed as such. *)

--- a/tests/generic.m31
+++ b/tests/generic.m31
@@ -1,5 +1,5 @@
 
-constant A B : Type
+constant A, B : Type
 constant eq : A == B
 now betas = add_beta eq
 

--- a/tests/handle-pattern-default.m31
+++ b/tests/handle-pattern-default.m31
@@ -2,7 +2,7 @@
 operation O : judgement -> mlstring
 
 constant A : Type
-constant a b : A
+constant a, b : A
 
 (* when an operation doesn't match, we need to bubble it upwards, then pass the result to the continuation *)
 do 

--- a/tests/implicit.m31
+++ b/tests/implicit.m31
@@ -1,6 +1,6 @@
 constant A : Type
 constant a : A
-constant f g h : A -> A
+constant f, g, h : A -> A
 constant g_def : g == (lambda x : A, f (f x))
 constant h_def : h == g
 

--- a/tests/infixes.m31
+++ b/tests/infixes.m31
@@ -2,9 +2,9 @@
 (** TT infixes *)
 constant A : Type
 
-constant a b c d : A
+constant a, b, c, d : A
 
-constant ( + ) ( - ) ( ^ ) ( / ) : A -> A -> A
+constant ( + ), ( - ), ( ^ ), ( / ) : A -> A -> A
 
 let s = (-) ((+) a b) ((^) c ((^) d d))
 

--- a/tests/many-constants-declaration.m31
+++ b/tests/many-constants-declaration.m31
@@ -1,5 +1,5 @@
 (* Test whether declaration of several constants works. *)
-constant A B : Type
-constant f g : A -> Type
+constant A, B : Type
+constant f, g : A -> Type
 constant a : A
-constant x y z : f a -> Type
+constant x, y, z : f a -> Type

--- a/tests/natural.m31
+++ b/tests/natural.m31
@@ -1,4 +1,4 @@
-constant A B : Type
+constant A, B : Type
 constant a : A
 constant eq : A == B
 

--- a/tests/unhandled-op.m31
+++ b/tests/unhandled-op.m31
@@ -2,7 +2,7 @@
 mltype x = x end
 
 constant A : Type
-constant a b : A
+constant a, b : A
 constant (+) : A -> A -> A
 
 operation Not_found : empty


### PR DESCRIPTION
Declaring multiple (non-parameterized) constants on the same line now
requires the names to be comma-separated. This feature only seems to
be used in tests.