### PR TITLE
Syntax for TT ascription in `let' (RFC)

### DIFF
--- a/examples/bool.m31
+++ b/examples/bool.m31
@@ -31,7 +31,7 @@ do Type
    Better hint management would help here. *)
 (* do external "config" "verbosity" 3 *)
 
-let bool_disjoint : true ≡ false → empty =
+let bool_disjoint :: true ≡ false → empty =
     λ (p : true == false),
      let P = λ (b : bool), ind_bool (λ (_ : bool), Type) unit empty b in
      let p =
@@ -44,14 +44,14 @@ let bool_disjoint : true ≡ false → empty =
        now betas = add_betas [ind_bool_true] in
          p : unit == empty in
      now betas = add_betas [p] in
-       let u = {} in u : empty
+       let u = tt in u : empty
 
 
 (* let's be less careful. *)
-now betas = add_beta ind_bool_true betas
-now betas = add_beta ind_bool_false betas
+now betas = add_beta ind_bool_true
+now betas = add_beta ind_bool_false
 
-let bool_disjoint' : true == false → empty = λ p,
+let bool_disjoint' :: true == false → empty = λ p,
      let P = λ (b : bool), ind_bool (λ (_ : bool), Type) unit empty b in
      let p =
          (* we need to remove the global hints, otherwise
@@ -62,8 +62,7 @@ let bool_disjoint' : true == false → empty = λ p,
 
      let p = p : unit == empty in
      now betas = add_betas [p] in
-     let u = {} in u : empty
-     (* {} : empty *)
+     let u = tt in u : empty
 
 do bool_disjoint'
 

--- a/examples/equality.m31
+++ b/examples/equality.m31
@@ -1,21 +1,21 @@
 (** Properties of equality. *)
 
-let symmetric : Π (A : Type) (a b : A), a ≡ b -> b ≡ a =
+let symmetric :: Π (A : Type) (a b : A), a ≡ b -> b ≡ a =
   λ A a b p,
-        now betas = add_beta p betas in
+        now betas = add_beta p in
         refl b
 
 do symmetric
 
-let transitive : Π (A : Type) (a b c : A), a ≡ b -> b ≡ c -> a ≡ c =
+let transitive :: Π (A : Type) (a b c : A), a ≡ b -> b ≡ c -> a ≡ c =
   λ A a b c p q,
-     now betas = add_beta p betas in
+     now betas = add_beta p in
      q
 
 
 do transitive
 
-let J : Π
+let J :: Π
        (A : Type)
        (B : Π (a b : A), a ≡ b -> Type)
        (d : Π (x : A), B x x (refl x))
@@ -24,7 +24,7 @@ let J : Π
      B a b p
   =
   λ A B r a b p,
-    now betas = add_beta p betas in
+    now betas = add_beta p in
     r b
 
 do J

--- a/examples/peano.m31
+++ b/examples/peano.m31
@@ -103,14 +103,14 @@ let plus_S' =
       y)
   : ∀ (x y : N), plus (S x) y ≡ S (plus x y)
 
-let plus_commute : ∀ (x y : N), plus x y ≡ plus y x =
+let plus_commute :: ∀ (x y : N), plus x y ≡ plus y x =
   (λ (x y : N),
     now betas = add_betas [plus_Z,plus_S,plus_Z',plus_S'] in
     ind_N
       (λ (z : N), plus z y ≡ plus y z)
       (refl y)
       (λ (z : N) (IH : plus z y ≡ plus y z),
-          now betas = add_beta IH betas in
+          now betas = add_beta IH in
            refl (S (plus z y)) : plus (S z) y ≡ plus y (S z) )
       x)
 
@@ -119,7 +119,7 @@ do plus_commute
 
 (* Using commutativity we can now verify that if a : P (x + y) then a : P (y + x). *)
 do
-  now hints = add_hint plus_commute hints in
+  now hints = add_hint plus_commute in
    (λ (P : N → Type) (x y : N) (a : P (plus x y)), a : P (plus y x))
 
 (** (times n m) computes m*n as n-fold sum of m. *)

--- a/examples/unit.m31
+++ b/examples/unit.m31
@@ -1,7 +1,10 @@
-constant unit_rect: Π (P : unit -> Type) (x : P {}) (u : unit), P u
-constant unit_iota: Π (P : unit -> Type) (x : P {}), unit_rect P x {} == x
+constant unit : Type
+constant tt : unit
 
-let unit_contractible = (λ x, refl x : x == {}) : ∀ (x : unit), x == {}
+constant unit_rect : Π (P : unit -> Type) (x : P tt) (u : unit), P u
+constant unit_iota : Π (P : unit -> Type) (x : P tt), unit_rect P x tt == x
+constant unit_eta  : ∏ (x y : unit), x ≡ y
+now etas = add_eta unit_eta
 
-(* Inhabit {} *)
-
+let unit_contractible :: ∀ (x : unit), x == tt =
+    λ x, refl x

--- a/src/parser/input.mli
+++ b/src/parser/input.mli
@@ -47,8 +47,10 @@ and pattern' =
   | Patt_List of pattern list
   | Patt_Tuple of pattern list
 
+type type_ascription = ML_type_ascription of ml_schema | TT_type_ascription of ty
+
 (** Sugared terms *)
-type term = term' * Location.t
+and term = term' * Location.t
 and term' =
   (* expressions *)
   | Var of Name.ident
@@ -98,9 +100,9 @@ and comp = term
 (** Sugared expressions *)
 and expr = term
 
-and let_clause = Name.ident * Name.ident list * ml_schema option * comp
+and let_clause = Name.ident * Name.ident list * type_ascription option * comp
 
-and letrec_clause = Name.ident * Name.ident * Name.ident list * ml_schema option * comp
+and letrec_clause = Name.ident * Name.ident * Name.ident list * type_ascription option * comp
 
 (** Handle cases *)
 and handle_case =

--- a/src/parser/lexer.ml
+++ b/src/parser/lexer.ml
@@ -67,15 +67,18 @@ let numeral = [%sedlex.regexp? Plus digit]
 
 let project = [%sedlex.regexp? '.', (name | numeral)]
 
-let symbolchar = [%sedlex.regexp?  ('!' | '$' | '%' | '&' | '*' | '+' | '-' | '.' | '/' | ':' | '<' | '=' | '>' | '?' | '@' | '^' | '|' | '~')]
+let symbolchar = [%sedlex.regexp?  ( '!' | '$' | '%' | '&' | '*' | '+' | '-'
+                                   | '.' | '/' | ':' | '<' | '=' | '>' | '?'
+                                   | '@' | '^' | '|' | '~' )]
 
 let prefixop = [%sedlex.regexp? ('~' | '?' | '!'), Star symbolchar ]
-let infixop0 = [%sedlex.regexp? ('=' | '<' | '>' | '|' | '&' | '$'), Star symbolchar]
-let infixop1 = [%sedlex.regexp? ('@' | '^'), Star symbolchar ]
-let infixop2 = [%sedlex.regexp? ('+' | '-'), Star symbolchar ]
-let infixop3 = [%sedlex.regexp? ('*' | '/' | '%'), Star symbolchar ]
-let infixop4 = [%sedlex.regexp? "**", Star symbolchar ]
+let infixop0 = [%sedlex.regexp? ('=' | '<' | '>' | '|' | '&' | '$' | 8728),
+                              Star ( symbolchar | name )]
+let infixop1 = [%sedlex.regexp? ('@' | '^'), Star ( symbolchar | name ) ]
 let dcolon   = [%sedlex.regexp? "::"]
+let infixop2 = [%sedlex.regexp? ('+' | '-'), Star ( symbolchar | name ) ]
+let infixop3 = [%sedlex.regexp? ('*' | '/' | '%'), Star ( symbolchar | name ) ]
+let infixop4 = [%sedlex.regexp? "**", Star ( symbolchar | name ) ]
 
 let start_longcomment = [%sedlex.regexp? "(*"]
 let end_longcomment= [%sedlex.regexp? "*)"]

--- a/src/parser/lexer.ml
+++ b/src/parser/lexer.ml
@@ -72,10 +72,10 @@ let symbolchar = [%sedlex.regexp?  ('!' | '$' | '%' | '&' | '*' | '+' | '-' | '.
 let prefixop = [%sedlex.regexp? ('~' | '?' | '!'), Star symbolchar ]
 let infixop0 = [%sedlex.regexp? ('=' | '<' | '>' | '|' | '&' | '$'), Star symbolchar]
 let infixop1 = [%sedlex.regexp? ('@' | '^'), Star symbolchar ]
-let infixcons = [%sedlex.regexp? "::"]
 let infixop2 = [%sedlex.regexp? ('+' | '-'), Star symbolchar ]
 let infixop3 = [%sedlex.regexp? ('*' | '/' | '%'), Star symbolchar ]
 let infixop4 = [%sedlex.regexp? "**", Star symbolchar ]
+let dcolon   = [%sedlex.regexp? "::"]
 
 let start_longcomment = [%sedlex.regexp? "(*"]
 let end_longcomment= [%sedlex.regexp? "*)"]
@@ -135,8 +135,7 @@ and token_aux ({ Ulexbuf.stream;_ } as lexbuf) =
                                                 Name.make ~fixity:(Name.Infix Level.Infix0) s, loc_of lexbuf)
   | infixop1                 -> f (); INFIXOP1 (let s = Ulexbuf.lexeme lexbuf in
                                                 Name.make ~fixity:(Name.Infix Level.Infix1) s, loc_of lexbuf)
-  | infixcons                -> f (); INFIXCONS(let s = Ulexbuf.lexeme lexbuf in
-                                                Name.make ~fixity:(Name.Infix Level.InfixCons) s, loc_of lexbuf)
+  | dcolon                   -> f (); DCOLON (Ulexbuf.lexeme lexbuf, loc_of lexbuf)
   | infixop2                 -> f (); INFIXOP2 (let s = Ulexbuf.lexeme lexbuf in
                                                 Name.make ~fixity:(Name.Infix Level.Infix2) s, loc_of lexbuf)
   (* Comes before infixop3 because ** matches the infixop3 pattern too *)

--- a/src/runtime/predefined.ml
+++ b/src/runtime/predefined.ml
@@ -42,7 +42,8 @@ let predefined_bound = let open Input in
   let loc = Location.unknown in
   let decl_hyps = TopDynamic (Name.Predefined.hypotheses, (List [], loc)), loc in
   let force_hyps_type = TopDo (Let ([Name.anonymous, [],
-    Some (ML_Forall ([], (ML_TyApply (Name.Predefined.list, [ML_Judgment, loc]) , loc)), loc),
+    Some (Input.ML_type_ascription
+            (ML_Forall ([], (ML_TyApply (Name.Predefined.list, [ML_Judgment, loc]) , loc)), loc)),
     (Var Name.Predefined.hypotheses, loc)], (Tuple [], loc)), loc), loc in
   [decl_hyps; force_hyps_type]
 

--- a/src/typing/typecheck.mli
+++ b/src/typing/typecheck.mli
@@ -1,4 +1,6 @@
 
-(** [toplevel env c] checks that toplevel command [c] is well typed and updates the environment accordingly. *)
-val toplevel : Tyenv.t -> Syntax.ml_schema option Syntax.toplevel -> Tyenv.t * Mlty.ty_schema Syntax.toplevel
+(** [toplevel env c] checks that toplevel command [c] is well typed and updates
+    the environment accordingly. *)
+val toplevel : Tyenv.t -> Syntax.ml_schema option Syntax.toplevel
+  -> Tyenv.t * Mlty.ty_schema Syntax.toplevel
 


### PR DESCRIPTION
Meta-level typing introduced the requirement of ML-type ascriptions on
let-bindings to indicate when type-variables should be generalised.

This commit adds a double-colon syntax to allow to instead ascribe the
object-level type of the variable bound by a `let', restoring the
behaviour of type ascriptions on`let's before ML typing.

```
let x :: E = C
```

gets desugared into

```
let x = (C : E)
```

This syntax overloads the `::` operator which is used elsewhere as infix version of List.cons. Suggestions for alternative syntax are welcome.
