### PR TITLE
Interface comments and reorganization

### DIFF
--- a/src/runtime/equal.ml
+++ b/src/runtime/equal.ml
@@ -145,7 +145,7 @@ let as_eq ~loc t =
   match as_eq_alpha t with
     | Some (e1, e2) -> Opt.return (Jdg.reflexivity_ty t, e1, e2)
     | None ->
-      Predefined.operation_as_eq ~loc (Jdg.term_of_ty t) >!=
+      Predefined.operation_as_eq ~loc t >!=
       begin function
         | None ->
           Opt.fail
@@ -183,7 +183,7 @@ let as_prod ~loc t =
   match as_prod_alpha t with
     | Some (a, b) -> Opt.return (Jdg.reflexivity_ty t, a, b)
     | None ->
-      Predefined.operation_as_prod ~loc (Jdg.term_of_ty t) >!=
+      Predefined.operation_as_prod ~loc t >!=
       begin function
         | None ->
           Opt.fail

--- a/src/runtime/predefined.ml
+++ b/src/runtime/predefined.ml
@@ -4,6 +4,10 @@ type coercible =
   | Convertible of Jdg.eq_ty
   | Coercible of Jdg.term
 
+(************************)
+(* Built-in Definitions *)
+(************************)
+
 let name_alpha = Name.make (Name.greek 0)
 
 let predefined_aml_types = let open Input in
@@ -52,18 +56,26 @@ let predefined_bound_names =
 let definitions = List.concat [predefined_aml_types; predefined_ops; predefined_bound]
 
 
-let list_nil = Runtime.mk_tag Name.Predefined.nil []
+(************************)
+(* AML list <-> ML list *)
+(************************)
 
+let list_nil        = Runtime.mk_tag Name.Predefined.nil []
 let list_cons v lst = Runtime.mk_tag Name.Predefined.cons [v; lst]
 
 let rec mk_list = function
-  | [] -> list_nil
+  | []      -> list_nil
   | x :: xs -> list_cons x (mk_list xs)
 
 let as_list ~loc v =
   match Runtime.as_list_opt v with
   | Some lst -> lst
   | None -> Runtime.(error ~loc (ListExpected v))
+
+
+(****************************)
+(* AML option <-> ML option *)
+(****************************)
 
 let from_option = function
   | Some v -> Runtime.mk_tag Name.Predefined.some [v]
@@ -75,6 +87,12 @@ let as_option ~loc = function
   | (Runtime.Term _ | Runtime.Closure _ | Runtime.Handler _ | Runtime.Tag _ | Runtime.Tuple _ |
      Runtime.Ref _ | Runtime.String _) as v ->
      Runtime.(error ~loc (OptionExpected v))
+
+
+
+(**********************************)
+(* AML coercible <-> ML coercible *)
+(**********************************)
 
 let as_coercible ~loc = function
   | Runtime.Tag (t, []) when Name.eq_ident t Name.Predefined.notcoercible ->
@@ -90,12 +108,20 @@ let as_coercible ~loc = function
      Runtime.Ref _ | Runtime.String _) as v ->
      Runtime.(error ~loc (CoercibleExpected v))
 
-let (>>=) = Runtime.bind
 
+(***************************************)
+(* Computations that invoke operations *)
+(***************************************)
+
+(* Maps AML-value-to-(term)-judgment across an option.
+   Fails if given Some value that is not a judgment.
+ *)
 let as_term_option ~loc v =
   match as_option ~loc v with
     | Some v -> Some (Runtime.as_term ~loc v)
     | None -> None
+
+let (>>=) = Runtime.bind
 
 let operation_equal ~loc j1 j2 =
   let v1 = Runtime.mk_term j1
@@ -115,24 +141,35 @@ let operation_coerce_fun ~loc j =
   Runtime.return (as_coercible ~loc v)
 
 let operation_as_prod ~loc j =
-  let v = Runtime.mk_term j in
+  let v = Runtime.mk_term (Jdg.term_of_ty j) in
   Runtime.operation Name.Predefined.as_prod [v] >>= fun v ->
   Runtime.return (as_term_option ~loc v)
 
 let operation_as_eq ~loc j =
-  let v = Runtime.mk_term j in
+  let v = Runtime.mk_term (Jdg.term_of_ty j) in
   Runtime.operation Name.Predefined.as_eq [v] >>= fun v ->
   Runtime.return (as_term_option ~loc v)
 
+(*********)
+(* Other *)
+(*********)
+
+(* Possibly this should be in Runtime?
+   It seems to be here only because predefined_bound_names
+   isn't in the interface.
+*)
+
 let add_abstracting j m =
   let loc = Location.unknown in
+  (* In practice k will be 0 because hypothesis is the first dynamic variable *)
   let k = match Name.level_of_ident Name.Predefined.hypotheses predefined_bound_names with
     | Some k -> k
     | None -> assert false
   in
-  let v = Runtime.mk_term j in
-  Runtime.index_of_level k >>= fun k ->
-  Runtime.lookup_bound ~loc k >>= fun hyps ->
-  let hyps = list_cons v hyps in
-  Runtime.now ~loc k hyps m
+  let v = Runtime.mk_term j in                  (* The given variable as an AML value *)
+  Runtime.index_of_level k >>= fun k ->         (* Switch k from counting from the
+                                                   beginning to counting from the end *)
+  Runtime.lookup_bound ~loc k >>= fun hyps ->   (* Get the AML list of [hypotheses] *)
+  let hyps = list_cons v hyps in                (* Add v to the front of that AML list *)
+  Runtime.now ~loc k hyps m                     (* Run computation m in this dynamic scope *)
 

--- a/src/runtime/predefined.mli
+++ b/src/runtime/predefined.mli
@@ -1,27 +1,80 @@
 (** Predefined types and operations. *)
 
+(** The ML equivalent of the AML coercible type
+ *)
 type coercible =
   | NotCoercible
   | Convertible of Jdg.eq_ty
   | Coercible of Jdg.term
 
+(** {6 Built-in Definitions} *)
+
+(** The list of built-in type, operation, and dynamic variable definitions
+    corresponding to the names in Name.Predeclared, e.g.,
+       - ['a list] and its constructors [[]] and [::]
+       - ['a option] and its constructors [Some] and [None]
+       - [coercible] and its constructors (as above)
+       - operations [equal], [as_prod], [as_eq], [coerce], [coerce_fun]
+       - the dynamic variable [hypotheses]
+ *)
 val definitions : Input.toplevel list
 
+(** {6 Runtime computations to invoke operations} *)
+
+(** A computation that, when run, invokes the [equal] operation on the given
+    terms (wrapped as AML values), and then returns the resulting term if any
+    (unwrapped from an AML value to a type theoretical judgment
+ *)
 val operation_equal : loc:Location.t -> Jdg.term -> Jdg.term -> Jdg.term option Runtime.comp
 
+(** A computation that, when run, invokes the [coerce] operation
+    on the given type theory term and desired type, and decodes
+    the resulting AML value as a value of the correponding ML type [coercible].
+ *)
 val operation_coerce : loc:Location.t -> Jdg.term -> Jdg.ty -> coercible Runtime.comp
 
+(** A computation that, when run, invokes the [coerce_fun] operation on the
+    given term and decodes the resulting AML value into the ML type [coercible].
+ *)
 val operation_coerce_fun : loc:Location.t -> Jdg.term -> coercible Runtime.comp
 
-val operation_as_prod : loc:Location.t -> Jdg.term -> Jdg.term option Runtime.comp
-val operation_as_eq : loc:Location.t -> Jdg.term -> Jdg.term option Runtime.comp
+(** A computation that, when run, invokes the [as_prod] operration on the
+    given type; unwraps the resulting evidence (if any) that the given
+    type is equal to a Pi type.
+ *)
+val operation_as_prod : loc:Location.t -> Jdg.ty -> Jdg.term option Runtime.comp
 
+(** A computation that, when run, invokes the [as_eq] operration on the
+    given type; unwraps the resulting evidence (if any) that the given
+    type is equal to an == type.
+ *)
+val operation_as_eq : loc:Location.t -> Jdg.ty -> Jdg.term option Runtime.comp
+
+(** {6 translation between AML and ML values} *)
+
+(** Decodes an AML list value as an ML list of AML values.
+    Fails if the given value is not an AML [list].
+ *)
 val as_list : loc:Location.t -> Runtime.value -> Runtime.value list
+
+(** Encodes a list of AML values as an AML list value
+ *)
 val mk_list : Runtime.value list -> Runtime.value
 
-(** Wrappers for making tags *)
+(** Encodes an ML option as an AML option
+ *)
 val from_option : Runtime.value option -> Runtime.value
+
+(** Decodes an AML option as an ML option.
+    Fails if the given value is not an AML [option]
+ *)
 val as_option : loc:Location.t -> Runtime.value -> Runtime.value option
 
+(** {6 Other} *)
+
+(** Takes a variable (a judgment describing a variable/atom within a context),
+    temporarily adds it to the the front of the list contained in the
+    dynamic variable [hypotheses] to run the given computation.
+ *)
 val add_abstracting : Jdg.term -> 'a Runtime.comp -> 'a Runtime.comp
 

--- a/src/runtime/runtime.ml
+++ b/src/runtime/runtime.ml
@@ -175,7 +175,6 @@ let catch m env =
 (** Returns *)
 let top_return x env = x, env
 
-let top_mk_closure f env = Closure (mk_closure0 f env), env
 let top_return_closure f env = mk_closure0 f env, env
 
 let return x env = Return x, env.state

--- a/src/runtime/runtime.mli
+++ b/src/runtime/runtime.mli
@@ -1,34 +1,63 @@
 (** Runtime values and computations *)
 
-(** The type of an AML reference. *)
-type ref
+(** {6 Values} *)
 
-(** Runtime environment *)
-type env
-
-type ('a,'b) closure
-
-(** The values are "finished" or "computed". They are inert pieces of data. *)
+(** values are "finished" or "computed". They are inert pieces of data. *)
 type value = private
-  | Term of Jdg.term
-  | Closure of (value,value) closure
-  | Handler of handler
-  | Tag of Name.ident * value list
-  | Tuple of value list
-  | Ref of ref
-  | String of string (** NB: strings are opaque to the user, ie not lists *)
+  | Term of Jdg.term                 (** A *typing* judgment built by the nucleus *)
+  | Closure of (value,value) closure (** An AML function *)
+  | Handler of handler               (** Handler value *)
+  | Tag of Name.ident * value list   (** Application of a data constructor *)
+  | Tuple of value list              (** Tuple of values *)
+  | Ref of ref                       (** Ref cell *)
+  | String of string                 (** String constant (opaque, not a list) *)
 
 and operation_args = { args : value list; checking : Jdg.ty option}
 
+(** A handler contains AML code for handling zero or more operations,
+    plus the default case *)
 and handler
 
-(** computations provide a dynamically scoped environment and operations *)
-type 'a comp
+(** Maps an ['a] to a ['b comp]. In practice ['b] is usually [value] *)
+and ('a,'b) closure
 
-(** state environment, no operations *)
-type 'a toplevel
+(** An AML reference cell. *)
+and ref
 
-(** the runtime errors *)
+(** a descriptive name of a value, e.g. the name of [Handler _] is ["a handler"] *)
+val name_of : value -> string
+
+(** {b Value construction} *)
+
+val mk_term    : Jdg.term   -> value                (** Builds a [Term] value *)
+val mk_handler : handler    -> value                (** Builds a [Handler] value *)
+val mk_tag     : Name.ident -> value list -> value  (** Builds a [Tag] value *)
+val mk_tuple   : value list -> value                (** Builds a [Tuple] value *)
+val mk_string  : string     -> value                (** Builds a [String] value *)
+
+(** {b Value extraction} *)
+
+val as_term : loc:Location.t -> value -> Jdg.term   (** Fails with [TermExpected] *)
+val as_closure : loc:Location.t -> value -> (value,value) closure (** Fails with [ClosureExpected] *)
+val as_handler : loc:Location.t -> value -> handler (** Fails with [HandlerExpected] *)
+val as_ref : loc:Location.t -> value -> ref         (** Fails with [RefExpected] *)
+val as_string : loc:Location.t -> value -> string   (** Fails with [StringExpected] *)
+
+(** {b Other operations} *)
+
+(** Check whether two values are equal. *)
+val equal_value: value -> value -> bool
+
+(** Check whether the given value represents an AML list *)
+val as_list_opt : value -> value list option
+
+(** Pretty-print a value. *)
+val print_value : ?max_level:Level.t -> penv:TT.print_env -> value -> Format.formatter -> unit
+
+
+(** {6 Error Handling} *)
+
+(** The runtime errors *)
 type error =
   | ExpectedAtom of Jdg.term
   | UnknownExternal of string
@@ -63,90 +92,71 @@ type error =
 (** The exception that is raised on runtime error *)
 exception Error of error Location.located
 
-(** Report a runtime error (fails irrevocably) *)
+(** Pretty-print a runtime error *)
+val print_error : penv:TT.print_env -> error -> Format.formatter -> unit
+
+(** Report a runtime error (raises an Error exception) *)
 val error : loc:Location.t -> error -> 'a
 
-(** a descriptive name of a value, e.g. the name of [Handler _] is ["a handler"] *)
-val name_of : value -> string
 
-(** Make values *)
-val mk_term : Jdg.term -> value
-val mk_handler : handler -> value
-val mk_tag : Name.ident -> value list -> value
-val mk_tuple : value list -> value
-val mk_string : string -> value
+(** {6 Computation} *)
 
-val apply_closure : ('a,'b) closure -> 'a -> 'b comp
+(** computations provide a dynamically scoped environment and operations *)
+type 'a comp
 
-(** References *)
-val mk_ref : value -> value comp
 
-val lookup_ref : ref -> value comp
+(** {b Monadic structure} *)
 
-val update_ref : ref -> value -> unit comp
-
-(** Monadic primitives *)
 val bind: 'a comp -> ('a -> 'b comp)  -> 'b comp
-
-val top_bind : 'a toplevel -> ('a -> 'b toplevel) -> 'b toplevel
-
-type 'a caught =
-  | CaughtJdg of Jdg.error Location.located
-  | CaughtRuntime of error Location.located
-  | Value of 'a
-
-(** Catch exceptions. The state is not changed if an exception is caught. *)
-val catch : 'a toplevel Lazy.t -> 'a caught toplevel
-
-val top_return : 'a -> 'a toplevel
 val return : 'a -> 'a comp
 
-(* XXX why do we need all of these? *)
-val top_return_closure : ('a -> 'b comp) -> ('a,'b) closure toplevel
-val top_mk_closure : (value -> value comp) -> value toplevel
-val return_closure : (value -> value comp) -> value comp
 
-val return_term : Jdg.term -> value comp
+(** {b Monadic shorthand} *)
+
 val return_unit : value comp
 
+val return_term : Jdg.term -> value comp
+val return_closure : (value -> value comp) -> value comp
 val return_handler :
    (value -> value comp) option ->
    (operation_args -> value comp) Name.IdentMap.t ->
    (value -> value comp) option ->
    value comp
 
-val top_fold : ('a -> 'b -> 'a toplevel) -> 'a -> 'b list -> 'a toplevel
+(** {b Monadic interface} *)
 
-(** Pretty-print a value. *)
-val as_list_opt : value -> value list option
+(** A computation that applies the given closure to the given argument
+    and produces the result. *)
+val apply_closure : ('a,'b) closure -> 'a -> 'b comp
 
-val print_value : ?max_level:Level.t -> penv:TT.print_env -> value -> Format.formatter -> unit
+(** A computation that creates and returns a new reference cell. *)
+val mk_ref : value -> value comp
 
-val print_error : penv:TT.print_env -> error -> Format.formatter -> unit
+(** A computation that dereferences the given reference cell. *)
+val lookup_ref : ref -> value comp
 
-(** Coerce values *)
-val as_term : loc:Location.t -> value -> Jdg.term
-val as_closure : loc:Location.t -> value -> (value,value) closure
-val as_handler : loc:Location.t -> value -> handler
-val as_ref : loc:Location.t -> value -> ref
-val as_string : loc:Location.t -> value -> string
+(** A computation that updates the given reference cell with the given value. *)
+val update_ref : ref -> value -> unit comp
 
-(** Operations *)
+(** A computation that invokes the specified operation. *)
 val operation : Name.operation -> ?checking:Jdg.ty -> value list -> value comp
 
-(** Extract the current environment (for matching) *)
-val get_env : env comp
+(** Wrap the given computation with a handler. *)
+val handle_comp : handler -> value comp -> value comp
 
-(** Typing Signature *)
-val get_typing_signature : env -> Jdg.Signature.t
+(** Wrap the given computation with a dynamic variable binding. *)
+val now : loc:Location.t -> int -> value -> 'a comp -> 'a comp
 
+(** Lookup the current continuation. Only usable while handling an operation. *)
+val continue : loc:Location.t -> value -> value comp
+
+(** Get the printing environment from the monad *)
+val lookup_penv : TT.print_env comp
+
+(** Gets the current constants *)
 val lookup_typing_signature : Jdg.Signature.t comp
 
-(** Lookup a free variable by its de Bruijn index *)
-val lookup_bound : loc:Location.t -> int -> value comp
-
-(** For matching *)
-val get_bound : loc:Location.t -> int -> env -> value
+(** Bound and free variable stuff *)
 
 (** Add a bound variable to the environment. *)
 val add_bound : value -> 'a comp -> 'a comp
@@ -157,19 +167,32 @@ val add_bound_rec :
 (** [index_of_level n] gives the De Bruijn index of the variable whose De Bruijn level is [n]. *)
 val index_of_level : Syntax.level -> Syntax.bound comp
 
-(** Modify the value bound by a dynamic variable *)
-val now : loc:Location.t -> int -> value -> 'a comp -> 'a comp
-
-val top_now : loc:Location.t -> int -> value -> unit toplevel
-
-(** Add a bound variable (for matching). *)
-val push_bound : value -> env -> env
-
 (** [add_free ~loc x (ctx,t) f] generates a fresh atom [y] from identifier [x],
     then it extends [ctx] to [ctx' = ctx, y : t]
     and runs [f (ctx' |- y : t)] in the environment with [x] bound to [ctx' |- y : t].
     NB: This is an effectful computation, as it increases a global counter. *)
 val add_free: loc:Location.t -> Name.ident -> Jdg.ty -> (Jdg.atom -> 'a comp) -> 'a comp
+
+(** Lookup a free variable by its de Bruijn index *)
+val lookup_bound : loc:Location.t -> int -> value comp
+
+(** {6 Toplevel} *)
+
+(** state environment, no operations *)
+type 'a toplevel
+
+(** {b Monadic structure } *)
+
+val top_bind : 'a toplevel -> ('a -> 'b toplevel) -> 'b toplevel
+val top_return : 'a -> 'a toplevel
+
+(** {b Monadic shorthand} *)
+
+val top_return_closure : ('a -> 'b comp) -> ('a,'b) closure toplevel
+
+val top_fold : ('a -> 'b -> 'a toplevel) -> 'a -> 'b list -> 'a toplevel
+
+(** {b Monadic interface} *)
 
 (** Add a constant of a given type to the environment. *)
 val add_constant : loc:Location.t -> Name.ident -> Jdg.closed_ty -> unit toplevel
@@ -186,20 +209,27 @@ val add_dynamic : loc:Location.t -> Name.ident -> value -> unit toplevel
 (** Add a top-level handler case to the environment. *)
 val add_handle : Name.ident -> (value list * Jdg.ty option,value) closure -> unit toplevel
 
-(** Lookup the current continuation. *)
-val continue : loc:Location.t -> value -> value comp
+(** Modify the value bound by a dynamic variable *)
+val top_now : loc:Location.t -> int -> value -> unit toplevel
 
-(** Get the printing environment from the monad *)
-val lookup_penv : TT.print_env comp
+(** Handle a computation at the toplevel. *)
+val top_handle : loc:Location.t -> 'a comp -> 'a toplevel
 
 (** Get the printing environment from the toplevel monad *)
 val top_lookup_penv : TT.print_env toplevel
 
-(** Interface to execute suspended computations. *)
-type topenv
+type 'a caught =
+  | CaughtJdg of Jdg.error Location.located
+  | CaughtRuntime of error Location.located
+  | Value of 'a
 
-(** Get the printing environment from the toplevel environment. *)
-val get_penv : topenv -> TT.print_env
+(** Catch Error exceptions. The state is not changed if an exception occurs. *)
+val catch : 'a toplevel Lazy.t -> 'a caught toplevel
+
+(** {6 Running a toplevel computation} *)
+
+(** toplevel environment *)
+type topenv
 
 (** The empty toplevel environment. *)
 val empty : topenv
@@ -207,14 +237,23 @@ val empty : topenv
 (** Execute a toplevel command in the given environment. *)
 val exec : 'a toplevel -> topenv -> 'a * topenv
 
-(** Handling *)
-val handle_comp : handler -> value comp -> value comp
+(** {6 Poorly-Documented Functions used by Matching } *)
 
-(** Handle a computation at the toplevel. *)
-val top_handle : loc:Location.t -> 'a comp -> 'a toplevel
+(** Runtime environment *)
+type env
 
-(** Check whether two values are equal. *)
-val equal_value: value -> value -> bool
+(** Extract the current environment (for matching) *)
+val get_env : env comp
+
+val get_typing_signature : env -> Jdg.Signature.t
+
+(** For matching *)
+val get_bound : loc:Location.t -> int -> env -> value
+
+(** Add a bound variable (for matching). *)
+val push_bound : value -> env -> env
+
+(** {6 Conversion to JSON} *)
 
 module Json :
 sig


### PR DESCRIPTION
Ocamldoc-friendly comments (especially in Runtime.mli and Predefined.mli).
Reorganization of code and declarations to put some related things together.
One or two minor interface cleanups.