### PR TITLE
Simplify JSON output, close #357

### DIFF
--- a/src/andromeda.ml
+++ b/src/andromeda.ml
@@ -58,6 +58,10 @@ let options = Arg.align [
       Arg.Unit (fun () -> Config.appty_guess := Config.GuessJdg),
       " Assume that unsolved applications are judgement applications.");
 
+    ("--json-location",
+     Arg.Set Config.json_location,
+     " Print locations in JSON output");
+
     ("-v",
      Arg.Unit (fun () ->
          Format.printf "Andromeda %s (%s)@." Build.version Sys.os_type ;

--- a/src/config.ml
+++ b/src/config.ml
@@ -19,6 +19,8 @@ let max_boxes = ref 42
 
 let global_atom_printer = ref true
 
+let json_location = ref false
+
 let columns = ref (Format.get_margin ())
 
 type appty_guess =

--- a/src/config.mli
+++ b/src/config.mli
@@ -35,6 +35,9 @@ val columns : int ref
 (** Should atoms be printed with freshness subscripts? *)
 val global_atom_printer : bool ref
 
+(** Should JSON format print locations? *)
+val json_location : bool ref
+
 (** What should we do if we get an unsolved application constraint? *)
 type appty_guess =
   | NoGuess

--- a/src/nucleus/assumption.ml
+++ b/src/nucleus/assumption.ml
@@ -78,8 +78,15 @@ module Json =
 struct
 
   let assumptions {free; bound} =
-    let bound = List.map (fun k -> Json.Int k) (BoundSet.elements bound) in
-    Json.record "assumptions" ["free", Name.Json.atomset free;
-                               "bound", Json.List bound]
+    let free =
+      if AtomSet.is_empty free
+      then []
+      else [("free", Name.Json.atomset free)]
+    and bound =
+      if BoundSet.is_empty bound
+      then []
+      else [("bound", Json.List (List.map (fun k -> Json.Int k) (BoundSet.elements bound)))]
+    in
+      Json.record (free @ bound)
 
 end

--- a/src/nucleus/jdg.ml
+++ b/src/nucleus/jdg.ml
@@ -846,21 +846,18 @@ struct
       AtomMap.fold
         (fun x {ty; needed_by} dict ->
          (Name.Json.atom x,
-          Json.record "entry" ["ty", TT.Json.ty ty;
-                               "needed_by", Name.Json.atomset needed_by]) :: dict)
+          Json.tuple [TT.Json.ty ty; Name.Json.atomset needed_by]) :: dict)
         ctx
         []
     in
-    Json.of_ty "ctx" ["data", Json.Dict dict]
+    Json.Dict dict
 
   let term (Term (ctx, e, ty)) =
-    (* XXX We pretend that terms are records, which they should be anyhow. *)
-    Json.of_ty "Jdg.term" ["context", context ctx;
-                           "term", TT.Json.term e;
-                           "type", TT.Json.ty ty]
+    Json.record [("context", context ctx);
+                 ("term", TT.Json.term e);
+                 ("ty", TT.Json.ty ty)]
 
   let ty (Ty (ctx, ty)) =
-    (* XXX We pretend that types are records, which they should be anyhow. *)
-    Json.of_ty "Jdg.term" ["context", context ctx;
-                           "type", TT.Json.ty ty]
+    Json.record [("context", context ctx);
+                 ("ty", TT.Json.ty ty)]
 end

--- a/src/runtime/external.ml
+++ b/src/runtime/external.ml
@@ -43,7 +43,11 @@ let externals =
       ((fun loc ->
       Runtime.return_closure (fun v ->
           let j = Runtime.Json.value v in
+          (* Temporarily set printing depth to infinity *)
+          let b = Format.get_max_boxes () in
+          Format.set_max_boxes 0 ;
           Format.printf "%t@." (Json.print j) ;
+          Format.set_max_boxes b ;
           Runtime.return_unit
         )),
       json_ty));
@@ -73,6 +77,14 @@ let externals =
           | "no-ascii" ->
             Config.ascii := false;
             Runtime.return_unit
+
+          | "json-location" ->
+             Config.json_location := true;
+             Runtime.return_unit
+
+          | "no-json-location" ->
+             Config.json_location := false;
+             Runtime.return_unit
 
           | _ -> Runtime.(error ~loc (UnknownConfig s))
         )),

--- a/src/runtime/runtime.ml
+++ b/src/runtime/runtime.ml
@@ -690,20 +690,20 @@ module Json =
 struct
 
   let rec value v =
-    let json = Json.tag "Runtime.value" in
     match v with
 
-      | Term e -> json "Term" [Jdg.Json.term e]
+    | Term e -> Json.tag "Term" [Jdg.Json.term e]
 
-      | Closure _ -> json "Closure" [Json.String "<closure>"]
+    | Closure _ -> Json.tag "<fun>" []
 
-      | Handler _ -> json "Handler" [Json.String "<handler>"]
+    | Handler _ -> Json.tag "<handler>" []
 
-      | Tag (c, lst) -> json "Tag" [Name.Json.ident c; Json.List (List.map value lst)]
+    | Tag (c, lst) -> Json.tag "Tag" [Name.Json.ident c; Json.List (List.map value lst)]
 
-      | Tuple lst -> json "Tuple" [Json.List (List.map value lst)]
+    | Tuple lst -> Json.tag "Tuple" [Json.List (List.map value lst)]
 
-      | Ref r -> json "Ref" [Json.String "<ref>"]
+    | Ref r -> Json.tag "<ref>" []
 
-      | String s -> json "String" [Json.String s]
+    | String s -> Json.tag "String" [Json.String s]
+
 end

--- a/src/utils/json.ml
+++ b/src/utils/json.ml
@@ -11,15 +11,13 @@ type t =
   | List of t list
   | Dict of (t * t) list
 
-let of_ty ty lst =
-  let lst = List.map (fun (key, value) -> (String key, value)) lst in
-  Dict ((String "_ty", String ty) :: lst)
-
 let tuple lst = List lst
 
-let record = of_ty
+let record lst =
+  let lst = List.map (fun (key, value) -> (String key, value)) lst in
+  Dict lst
 
-let tag ty tag data = of_ty ty ["tag", String tag; "data", List data]
+let tag tag data = tuple ((String tag) :: data)
 
 let rec print data ppf =
   match data with
@@ -37,4 +35,3 @@ and print_entry (label, data) ppf =
   Format.fprintf ppf "@[<hv>%t :@ %t@]"
                  (print label)
                  (print data)
-

--- a/src/utils/json.mli
+++ b/src/utils/json.mli
@@ -1,29 +1,19 @@
 (** The type representing JSON values (simplified) *)
 
-(** We enforce the following conventions on exporting
-    datatypes to JSON:
+(** We enforce the following conventions on exporting datatypes to JSON:
 
     - types which already exist in JSON are exported as such (ints, strings, lists, ...)
+
     - a value [{lbl1=v1; ... lblN=vN}] of record type [t] is exported as a dictionary
+      [{"lbl1" : v1, .."lblN" : vN}]
 
-        [{ "_ty" : "t",
-          "lbl1" : v1,
-          ..
-          "lblN" : vN }]
+    - a value [Tag (v1, ..., vN)] of sum type [t] is exported as [ ["Tag", v1, ..., vN] ]
 
-    - a value [Tag v] of sum type [t] is exported as
+    - a located value [{thing=v; loc=l}] is exported as [v], unless the [--json-location]
+      option is used, in which case we use [ [v, loc] ].
 
-        [{ "_ty" : "t",
-          "tag" : "Tag",
-          "data" : v }]
-
-    - if the tag does not have any [v] associated with it then the [data] key is omitted.
-
-    - if the sum has single tag then the tag is ommited
-
-    There is of course an opportunity here for some generic programming,
-    OCaml ppx magic etc., but let's resist the urge to get fancy for at
-    least a little while.
+    The exported JSON format does not hold typing information, but as long as
+    we know what type to expect, the OCaml value can be reconstructed.
  *)
 
 type t =
@@ -32,19 +22,16 @@ type t =
   | List of t list
   | Dict of (t * t) list
 
-(** [of_ty ty d] gives the JSON dictionary [d] with the additional entry ["_ty" : String ty]. *)
-val of_ty : string -> (string * t) list -> t
-
 (** [tuple lst] gives the JSON representation of a tuple with the given components. *)
 val tuple : t list -> t
 
-(** [record ty d] gives the JSON representation of a record of type [ty] with fields and
-    values [d]. *)
-val record : string -> (string * t) list -> t
+(** [record lst] gives the JSON representation of a record of type [ty] with fields and
+    values described by the associative list [lst]. *)
+val record : (string * t) list -> t
 
-(** [tag ty "Tag" v] gives the JSON representation of a value of sum type [ty] with the
+(** [tag "Tag" v] gives the JSON representation of a value of sum type [ty] with the
    given ["Tag"] and [data]. *)
-val tag : string -> string -> t list -> t
-                        
-(** Nicely print an s-expression *)
+val tag : string -> t list -> t
+
+(** Nicely print an JSON expression *)
 val print : t -> Format.formatter -> unit

--- a/src/utils/location.ml
+++ b/src/utils/location.ml
@@ -49,15 +49,16 @@ let locate x loc = { thing = x; loc }
 module Json =
 struct
   let location = function
-    | Unknown -> Json.tag "location" "Unknown" []
+    | Unknown -> Json.tag "Unknown" []
     | Known {filename; start_line; start_col; end_line; end_col} ->
-       Json.tag "location" "Known" [Json.String filename;
-                                    Json.Int start_line;
-                                    Json.Int start_col;
-                                    Json.Int end_line;
-                                    Json.Int end_col ]
+       Json.tuple [Json.String filename;
+                   Json.Int start_line;
+                   Json.Int start_col;
+                   Json.Int end_line;
+                   Json.Int end_col ]
 
   let located to_json {thing; loc} =
-    Json.record "located" ["thing", to_json thing;
-                           "loc", location loc]
+    if !Config.json_location
+    then Json.tuple [to_json thing; location loc]
+    else to_json thing
 end

--- a/src/utils/name.ml
+++ b/src/utils/name.ml
@@ -221,11 +221,11 @@ let print_atom ?parentheses ~printer x ppf =
 
 module Json =
 struct
-  let ident (Ident (s, _)) =
-    Json.of_ty "ident" ["data", Json.String s]
+  let ident = function
+    | Ident (s, Anonymous k) -> Json.tuple [Json.String s; Json.Int k]
+    | Ident (s, (Word|Prefix|Infix _)) -> Json.String s
 
-  let atom (Atom (s, _, k)) =
-    Json.of_ty "atom" ["data", Json.tuple [Json.String s; Json.Int k]]
+  let atom (Atom (s, _, k)) = Json.tuple [Json.String s; Json.Int k]
 
   let atomset s = Json.List (List.map atom (AtomSet.elements s))
 

--- a/tests/json.m31
+++ b/tests/json.m31
@@ -1,5 +1,8 @@
 let printj = external "print_json"
 
+(* without locations *)
+do external "config" "no-json-location"
+
 do printj Type
 
 constant A : Type
@@ -16,3 +19,17 @@ do printj h
 do assume g : A → A in
    assume b : A in
    printj (g b)
+
+(* with locations *)
+do external "config" "json-location"
+
+do printj Type
+
+do printj A
+
+do printj h
+
+do assume g : A → A in
+   assume b : A in
+   printj (g b)
+

--- a/tests/json.m31.ref
+++ b/tests/json.m31.ref
@@ -1,586 +1,149 @@
 val printj : ∀ α, α → mlunit
 
-{"_ty" : "Runtime.value",
- "tag" : "Term",
- "data" :
- [{"_ty" : "Jdg.term",
-   "context" : {"_ty" : "ctx", "data" : {}},
-   "term" :
-   {"_ty" : "term",
-    "term" : {"_ty" : "term'", "tag" : "Type", "data" : []},
-    "assumptions" : {"_ty" : "assumptions", "free" : [], "bound" : []},
-    "loc" :
-    {"_ty" : "location",
-     "tag" : "Known",
-     "data" : ["./json.m31", 3, 10, 3, 14]}},
-   "type" :
-   {"_ty" : "ty",
-    "tag" : "Ty",
-    "data" :
-    [{"_ty" : "term",
-      "term" : {"_ty" : "term'", "tag" : "Type", "data" : []},
-      "assumptions" : {"_ty" : "assumptions", "free" : [], "bound" : []},
-      "loc" :
-      {"_ty" : "location",
-       "tag" : "Known",
-       "data" : ["./json.m31", 3, 10, 3, 14]}}]}}]}
+()
+
+["Term", {"context" : {}, "term" : [["Type"], {}], "ty" : [["Type"], {}]}]
 ()
 
 Constant A is declared.
 
 Constant B is declared.
 
-{"_ty" : "Runtime.value",
- "tag" : "Term",
- "data" :
- [{"_ty" : "Jdg.term",
-   "context" : {"_ty" : "ctx", "data" : {}},
-   "term" :
-   {"_ty" : "term",
-    "term" :
-    {"_ty" : "term'",
-     "tag" : "Constant",
-     "data" : [{"_ty" : "ident", "data" : "A"}]},
-    "assumptions" : {"_ty" : "assumptions", "free" : [], "bound" : []},
-    "loc" :
-    {"_ty" : "location",
-     "tag" : "Known",
-     "data" : ["./json.m31", 8, 10, 8, 11]}},
-   "type" :
-   {"_ty" : "ty",
-    "tag" : "Ty",
-    "data" :
-    [{"_ty" : "term",
-      "term" : {"_ty" : "term'", "tag" : "Type", "data" : []},
-      "assumptions" : {"_ty" : "assumptions", "free" : [], "bound" : []},
-      "loc" :
-      {"_ty" : "location",
-       "tag" : "Known",
-       "data" : ["./json.m31", 5, 13, 5, 17]}}]}}]}
+["Term",
+ {"context" : {}, "term" : [["Constant", "A"], {}], "ty" : [["Type"], {}]}]
 ()
 
 Constant a is declared.
 
 val h : judgment
 
-{"_ty" : "Runtime.value",
- "tag" : "Term",
- "data" :
- [{"_ty" : "Jdg.term",
-   "context" : {"_ty" : "ctx", "data" : {}},
-   "term" :
-   {"_ty" : "term",
-    "term" :
-    {"_ty" : "term'",
-     "tag" : "Lambda",
-     "data" :
-     [[{"_ty" : "ident", "data" : "f"},
-       {"_ty" : "ty",
-        "tag" : "Ty",
-        "data" :
-        [{"_ty" : "term",
-          "term" :
-          {"_ty" : "term'",
-           "tag" : "Prod",
-           "data" :
-           [[{"_ty" : "ident", "data" : "x"},
-             {"_ty" : "ty",
-              "tag" : "Ty",
-              "data" :
-              [{"_ty" : "term",
-                "term" :
-                {"_ty" : "term'",
-                 "tag" : "Constant",
-                 "data" : [{"_ty" : "ident", "data" : "A"}]},
-                "assumptions" :
-                {"_ty" : "assumptions", "free" : [], "bound" : []},
-                "loc" :
-                {"_ty" : "location",
-                 "tag" : "Known",
-                 "data" : ["./json.m31", 12, 22, 12, 23]}}]},
-             {"_ty" : "ty",
-              "tag" : "Ty",
-              "data" :
-              [{"_ty" : "term",
-                "term" :
-                {"_ty" : "term'",
-                 "tag" : "Apply",
-                 "data" :
-                 [{"_ty" : "term",
-                   "term" :
-                   {"_ty" : "term'",
-                    "tag" : "Constant",
-                    "data" : [{"_ty" : "ident", "data" : "B"}]},
-                   "assumptions" :
-                   {"_ty" : "assumptions", "free" : [], "bound" : []},
-                   "loc" :
-                   {"_ty" : "location",
-                    "tag" : "Known",
-                    "data" : ["./json.m31", 12, 26, 12, 27]}},
-                  [{"_ty" : "ident", "data" : "anon"},
-                   {"_ty" : "ty",
-                    "tag" : "Ty",
-                    "data" :
-                    [{"_ty" : "term",
-                      "term" :
-                      {"_ty" : "term'",
-                       "tag" : "Constant",
-                       "data" : [{"_ty" : "ident", "data" : "A"}]},
-                      "assumptions" :
-                      {"_ty" : "assumptions", "free" : [], "bound" : []},
-                      "loc" :
-                      {"_ty" : "location",
-                       "tag" : "Known",
-                       "data" : ["./json.m31", 6, 13, 6, 14]}}]},
-                   {"_ty" : "ty",
-                    "tag" : "Ty",
-                    "data" :
-                    [{"_ty" : "term",
-                      "term" : {"_ty" : "term'", "tag" : "Type", "data" : []},
-                      "assumptions" :
-                      {"_ty" : "assumptions", "free" : [], "bound" : []},
-                      "loc" :
-                      {"_ty" : "location",
-                       "tag" : "Known",
-                       "data" : ["./json.m31", 6, 17, 6, 21]}}]}]]},
-                "assumptions" :
-                {"_ty" : "assumptions", "free" : [], "bound" : [0]},
-                "loc" :
-                {"_ty" : "location",
-                 "tag" : "Known",
-                 "data" : ["./json.m31", 12, 26, 12, 27]}}]}]]},
-          "assumptions" : {"_ty" : "assumptions", "free" : [], "bound" : []},
-          "loc" :
-          {"_ty" : "location",
-           "tag" : "Known",
-           "data" : ["./json.m31", 12, 14, 12, 30]}}]},
-       [{"_ty" : "term",
-         "term" :
-         {"_ty" : "term'",
-          "tag" : "Apply",
-          "data" :
-          [{"_ty" : "term",
-            "term" : {"_ty" : "term'", "tag" : "Bound", "data" : [0]},
-            "assumptions" :
-            {"_ty" : "assumptions", "free" : [], "bound" : [0]},
-            "loc" :
-            {"_ty" : "location",
-             "tag" : "Known",
-             "data" : ["./json.m31", 12, 14, 12, 30]}},
-           [{"_ty" : "ident", "data" : "x"},
-            {"_ty" : "ty",
-             "tag" : "Ty",
-             "data" :
-             [{"_ty" : "term",
-               "term" :
-               {"_ty" : "term'",
-                "tag" : "Constant",
-                "data" : [{"_ty" : "ident", "data" : "A"}]},
-               "assumptions" :
-               {"_ty" : "assumptions", "free" : [], "bound" : []},
-               "loc" :
-               {"_ty" : "location",
-                "tag" : "Known",
-                "data" : ["./json.m31", 12, 22, 12, 23]}}]},
-            {"_ty" : "ty",
-             "tag" : "Ty",
-             "data" :
-             [{"_ty" : "term",
-               "term" :
-               {"_ty" : "term'",
-                "tag" : "Apply",
-                "data" :
-                [{"_ty" : "term",
-                  "term" :
-                  {"_ty" : "term'",
-                   "tag" : "Constant",
-                   "data" : [{"_ty" : "ident", "data" : "B"}]},
-                  "assumptions" :
-                  {"_ty" : "assumptions", "free" : [], "bound" : []},
-                  "loc" :
-                  {"_ty" : "location",
-                   "tag" : "Known",
-                   "data" : ["./json.m31", 12, 26, 12, 27]}},
-                 [{"_ty" : "ident", "data" : "anon"},
-                  {"_ty" : "ty",
-                   "tag" : "Ty",
-                   "data" :
-                   [{"_ty" : "term",
-                     "term" :
-                     {"_ty" : "term'",
-                      "tag" : "Constant",
-                      "data" : [{"_ty" : "ident", "data" : "A"}]},
-                     "assumptions" :
-                     {"_ty" : "assumptions", "free" : [], "bound" : []},
-                     "loc" :
-                     {"_ty" : "location",
-                      "tag" : "Known",
-                      "data" : ["./json.m31", 6, 13, 6, 14]}}]},
-                  {"_ty" : "ty",
-                   "tag" : "Ty",
-                   "data" :
-                   [{"_ty" : "term",
-                     "term" : {"_ty" : "term'", "tag" : "Type", "data" : []},
-                     "assumptions" :
-                     {"_ty" : "assumptions", "free" : [], "bound" : []},
-                     "loc" :
-                     {"_ty" : "location",
-                      "tag" : "Known",
-                      "data" : ["./json.m31", 6, 17, 6, 21]}}]}]]},
-               "assumptions" :
-               {"_ty" : "assumptions", "free" : [], "bound" : [0]},
-               "loc" :
-               {"_ty" : "location",
-                "tag" : "Known",
-                "data" : ["./json.m31", 12, 26, 12, 27]}}]}]]},
-         "assumptions" : {"_ty" : "assumptions", "free" : [], "bound" : [0]},
-         "loc" :
-         {"_ty" : "location",
-          "tag" : "Known",
-          "data" : ["./json.m31", 12, 32, 12, 33]}},
-        {"_ty" : "ty",
-         "tag" : "Ty",
-         "data" :
-         [{"_ty" : "term",
-           "term" :
-           {"_ty" : "term'",
-            "tag" : "Apply",
-            "data" :
-            [{"_ty" : "term",
-              "term" :
-              {"_ty" : "term'",
-               "tag" : "Constant",
-               "data" : [{"_ty" : "ident", "data" : "B"}]},
-              "assumptions" :
-              {"_ty" : "assumptions", "free" : [], "bound" : []},
-              "loc" :
-              {"_ty" : "location",
-               "tag" : "Known",
-               "data" : ["./json.m31", 12, 26, 12, 27]}},
-             [{"_ty" : "ident", "data" : "anon"},
-              {"_ty" : "ty",
-               "tag" : "Ty",
-               "data" :
-               [{"_ty" : "term",
-                 "term" :
-                 {"_ty" : "term'",
-                  "tag" : "Constant",
-                  "data" : [{"_ty" : "ident", "data" : "A"}]},
-                 "assumptions" :
-                 {"_ty" : "assumptions", "free" : [], "bound" : []},
-                 "loc" :
-                 {"_ty" : "location",
-                  "tag" : "Known",
-                  "data" : ["./json.m31", 6, 13, 6, 14]}}]},
-              {"_ty" : "ty",
-               "tag" : "Ty",
-               "data" :
-               [{"_ty" : "term",
-                 "term" : {"_ty" : "term'", "tag" : "Type", "data" : []},
-                 "assumptions" :
-                 {"_ty" : "assumptions", "free" : [], "bound" : []},
-                 "loc" :
-                 {"_ty" : "location",
-                  "tag" : "Known",
-                  "data" : ["./json.m31", 6, 17, 6, 21]}}]}]]},
-           "assumptions" : {"_ty" : "assumptions", "free" : [], "bound" : []},
-           "loc" :
-           {"_ty" : "location",
-            "tag" : "Known",
-            "data" : ["./json.m31", 12, 26, 12, 27]}}]}]]]},
-    "assumptions" : {"_ty" : "assumptions", "free" : [], "bound" : []},
-    "loc" :
-    {"_ty" : "location",
-     "tag" : "Known",
-     "data" : ["./json.m31", 12, 8, 12, 35]}},
-   "type" :
-   {"_ty" : "ty",
-    "tag" : "Ty",
-    "data" :
-    [{"_ty" : "term",
-      "term" :
-      {"_ty" : "term'",
-       "tag" : "Prod",
-       "data" :
-       [[{"_ty" : "ident", "data" : "f"},
-         {"_ty" : "ty",
-          "tag" : "Ty",
-          "data" :
-          [{"_ty" : "term",
-            "term" :
-            {"_ty" : "term'",
-             "tag" : "Prod",
-             "data" :
-             [[{"_ty" : "ident", "data" : "x"},
-               {"_ty" : "ty",
-                "tag" : "Ty",
-                "data" :
-                [{"_ty" : "term",
-                  "term" :
-                  {"_ty" : "term'",
-                   "tag" : "Constant",
-                   "data" : [{"_ty" : "ident", "data" : "A"}]},
-                  "assumptions" :
-                  {"_ty" : "assumptions", "free" : [], "bound" : []},
-                  "loc" :
-                  {"_ty" : "location",
-                   "tag" : "Known",
-                   "data" : ["./json.m31", 12, 22, 12, 23]}}]},
-               {"_ty" : "ty",
-                "tag" : "Ty",
-                "data" :
-                [{"_ty" : "term",
-                  "term" :
-                  {"_ty" : "term'",
-                   "tag" : "Apply",
-                   "data" :
-                   [{"_ty" : "term",
-                     "term" :
-                     {"_ty" : "term'",
-                      "tag" : "Constant",
-                      "data" : [{"_ty" : "ident", "data" : "B"}]},
-                     "assumptions" :
-                     {"_ty" : "assumptions", "free" : [], "bound" : []},
-                     "loc" :
-                     {"_ty" : "location",
-                      "tag" : "Known",
-                      "data" : ["./json.m31", 12, 26, 12, 27]}},
-                    [{"_ty" : "ident", "data" : "anon"},
-                     {"_ty" : "ty",
-                      "tag" : "Ty",
-                      "data" :
-                      [{"_ty" : "term",
-                        "term" :
-                        {"_ty" : "term'",
-                         "tag" : "Constant",
-                         "data" : [{...}]},
-                        "assumptions" :
-                        {"_ty" : "assumptions", "free" : [], "bound" : []},
-                        "loc" :
-                        {"_ty" : "location",
-                         "tag" : "Known",
-                         "data" : ["./json.m31", 6, 13, 6, 14]}}]},
-                     {"_ty" : "ty",
-                      "tag" : "Ty",
-                      "data" :
-                      [{"_ty" : "term",
-                        "term" :
-                        {"_ty" : "term'", "tag" : "Type", "data" : []},
-                        "assumptions" :
-                        {"_ty" : "assumptions", "free" : [], "bound" : []},
-                        "loc" :
-                        {"_ty" : "location",
-                         "tag" : "Known",
-                         "data" : ["./json.m31", 6, 17, 6, 21]}}]}]]},
-                  "assumptions" :
-                  {"_ty" : "assumptions", "free" : [], "bound" : [0]},
-                  "loc" :
-                  {"_ty" : "location",
-                   "tag" : "Known",
-                   "data" : ["./json.m31", 12, 26, 12, 27]}}]}]]},
-            "assumptions" :
-            {"_ty" : "assumptions", "free" : [], "bound" : []},
-            "loc" :
-            {"_ty" : "location",
-             "tag" : "Known",
-             "data" : ["./json.m31", 12, 14, 12, 30]}}]},
-         {"_ty" : "ty",
-          "tag" : "Ty",
-          "data" :
-          [{"_ty" : "term",
-            "term" :
-            {"_ty" : "term'",
-             "tag" : "Apply",
-             "data" :
-             [{"_ty" : "term",
-               "term" :
-               {"_ty" : "term'",
-                "tag" : "Constant",
-                "data" : [{"_ty" : "ident", "data" : "B"}]},
-               "assumptions" :
-               {"_ty" : "assumptions", "free" : [], "bound" : []},
-               "loc" :
-               {"_ty" : "location",
-                "tag" : "Known",
-                "data" : ["./json.m31", 12, 26, 12, 27]}},
-              [{"_ty" : "ident", "data" : "anon"},
-               {"_ty" : "ty",
-                "tag" : "Ty",
-                "data" :
-                [{"_ty" : "term",
-                  "term" :
-                  {"_ty" : "term'",
-                   "tag" : "Constant",
-                   "data" : [{"_ty" : "ident", "data" : "A"}]},
-                  "assumptions" :
-                  {"_ty" : "assumptions", "free" : [], "bound" : []},
-                  "loc" :
-                  {"_ty" : "location",
-                   "tag" : "Known",
-                   "data" : ["./json.m31", 6, 13, 6, 14]}}]},
-               {"_ty" : "ty",
-                "tag" : "Ty",
-                "data" :
-                [{"_ty" : "term",
-                  "term" : {"_ty" : "term'", "tag" : "Type", "data" : []},
-                  "assumptions" :
-                  {"_ty" : "assumptions", "free" : [], "bound" : []},
-                  "loc" :
-                  {"_ty" : "location",
-                   "tag" : "Known",
-                   "data" : ["./json.m31", 6, 17, 6, 21]}}]}]]},
-            "assumptions" :
-            {"_ty" : "assumptions", "free" : [], "bound" : []},
-            "loc" :
-            {"_ty" : "location",
-             "tag" : "Known",
-             "data" : ["./json.m31", 12, 26, 12, 27]}}]}]]},
-      "assumptions" : {"_ty" : "assumptions", "free" : [], "bound" : []},
-      "loc" :
-      {"_ty" : "location",
-       "tag" : "Known",
-       "data" : ["./json.m31", 12, 8, 12, 35]}}]}}]}
+["Term",
+ {"context" : {},
+  "term" :
+  [["Lambda",
+    ["f",
+     [["Prod",
+       ["x", [["Constant", "A"], {}],
+        [["Apply", [["Constant", "B"], {}],
+          [["anon", 11], [["Constant", "A"], {}], [["Type"], {}]],
+          [["Bound", 0], {"bound" : [0]}]], {"bound" : [0]}]]], {}],
+     [[["Apply", [["Bound", 0], {"bound" : [0]}],
+        ["x", [["Constant", "A"], {}],
+         [["Apply", [["Constant", "B"], {}],
+           [["anon", 11], [["Constant", "A"], {}], [["Type"], {}]],
+           [["Bound", 0], {"bound" : [0]}]], {"bound" : [0]}]],
+        [["Constant", "a"], {}]], {"bound" : [0]}],
+      [["Apply", [["Constant", "B"], {}],
+        [["anon", 11], [["Constant", "A"], {}], [["Type"], {}]],
+        [["Constant", "a"], {}]], {}]]]], {}],
+  "ty" :
+  [["Prod",
+    ["f",
+     [["Prod",
+       ["x", [["Constant", "A"], {}],
+        [["Apply", [["Constant", "B"], {}],
+          [["anon", 11], [["Constant", "A"], {}], [["Type"], {}]],
+          [["Bound", 0], {"bound" : [0]}]], {"bound" : [0]}]]], {}],
+     [["Apply", [["Constant", "B"], {}],
+       [["anon", 11], [["Constant", "A"], {}], [["Type"], {}]],
+       [["Constant", "a"], {}]], {}]]], {}]}]
 ()
 
-{"_ty" : "Runtime.value",
- "tag" : "Term",
- "data" :
- [{"_ty" : "Jdg.term",
-   "context" :
-   {"_ty" : "ctx",
-    "data" :
-    {{"_ty" : "atom", "data" : ["b", 50]} :
-     {"_ty" : "entry",
-      "ty" :
-      {"_ty" : "ty",
-       "tag" : "Ty",
-       "data" :
-       [{"_ty" : "term",
-         "term" :
-         {"_ty" : "term'",
-          "tag" : "Constant",
-          "data" : [{"_ty" : "ident", "data" : "A"}]},
-         "assumptions" : {"_ty" : "assumptions", "free" : [], "bound" : []},
-         "loc" :
-         {"_ty" : "location",
-          "tag" : "Known",
-          "data" : ["./json.m31", 17, 14, 17, 15]}}]},
-      "needed_by" : []},
-     {"_ty" : "atom", "data" : ["g", 49]} :
-     {"_ty" : "entry",
-      "ty" :
-      {"_ty" : "ty",
-       "tag" : "Ty",
-       "data" :
-       [{"_ty" : "term",
-         "term" :
-         {"_ty" : "term'",
-          "tag" : "Prod",
-          "data" :
-          [[{"_ty" : "ident", "data" : "anon"},
-            {"_ty" : "ty",
-             "tag" : "Ty",
-             "data" :
-             [{"_ty" : "term",
-               "term" :
-               {"_ty" : "term'",
-                "tag" : "Constant",
-                "data" : [{"_ty" : "ident", "data" : "A"}]},
-               "assumptions" :
-               {"_ty" : "assumptions", "free" : [], "bound" : []},
-               "loc" :
-               {"_ty" : "location",
-                "tag" : "Known",
-                "data" : ["./json.m31", 16, 14, 16, 15]}}]},
-            {"_ty" : "ty",
-             "tag" : "Ty",
-             "data" :
-             [{"_ty" : "term",
-               "term" :
-               {"_ty" : "term'",
-                "tag" : "Constant",
-                "data" : [{"_ty" : "ident", "data" : "A"}]},
-               "assumptions" :
-               {"_ty" : "assumptions", "free" : [], "bound" : []},
-               "loc" :
-               {"_ty" : "location",
-                "tag" : "Known",
-                "data" : ["./json.m31", 16, 18, 16, 19]}}]}]]},
-         "assumptions" : {"_ty" : "assumptions", "free" : [], "bound" : []},
-         "loc" :
-         {"_ty" : "location",
-          "tag" : "Known",
-          "data" : ["./json.m31", 16, 14, 16, 19]}}]},
-      "needed_by" : []}}},
-   "term" :
-   {"_ty" : "term",
-    "term" :
-    {"_ty" : "term'",
-     "tag" : "Apply",
-     "data" :
-     [{"_ty" : "term",
-       "term" :
-       {"_ty" : "term'",
-        "tag" : "Atom",
-        "data" : [{"_ty" : "atom", "data" : ["g", 49]}]},
-       "assumptions" :
-       {"_ty" : "assumptions",
-        "free" : [{"_ty" : "atom", "data" : ["g", 49]}],
-        "bound" : []},
-       "loc" :
-       {"_ty" : "location",
-        "tag" : "Known",
-        "data" : ["./json.m31", 16, 3, 18, 15]}},
-      [{"_ty" : "ident", "data" : "anon"},
-       {"_ty" : "ty",
-        "tag" : "Ty",
-        "data" :
-        [{"_ty" : "term",
-          "term" :
-          {"_ty" : "term'",
-           "tag" : "Constant",
-           "data" : [{"_ty" : "ident", "data" : "A"}]},
-          "assumptions" : {"_ty" : "assumptions", "free" : [], "bound" : []},
-          "loc" :
-          {"_ty" : "location",
-           "tag" : "Known",
-           "data" : ["./json.m31", 16, 14, 16, 15]}}]},
-       {"_ty" : "ty",
-        "tag" : "Ty",
-        "data" :
-        [{"_ty" : "term",
-          "term" :
-          {"_ty" : "term'",
-           "tag" : "Constant",
-           "data" : [{"_ty" : "ident", "data" : "A"}]},
-          "assumptions" : {"_ty" : "assumptions", "free" : [], "bound" : []},
-          "loc" :
-          {"_ty" : "location",
-           "tag" : "Known",
-           "data" : ["./json.m31", 16, 18, 16, 19]}}]}]]},
-    "assumptions" :
-    {"_ty" : "assumptions",
-     "free" :
-     [{"_ty" : "atom", "data" : ["g", 49]},
-      {"_ty" : "atom", "data" : ["b", 50]}],
-     "bound" : []},
-    "loc" :
-    {"_ty" : "location",
-     "tag" : "Known",
-     "data" : ["./json.m31", 18, 11, 18, 12]}},
-   "type" :
-   {"_ty" : "ty",
-    "tag" : "Ty",
-    "data" :
-    [{"_ty" : "term",
-      "term" :
-      {"_ty" : "term'",
-       "tag" : "Constant",
-       "data" : [{"_ty" : "ident", "data" : "A"}]},
-      "assumptions" : {"_ty" : "assumptions", "free" : [], "bound" : []},
-      "loc" :
-      {"_ty" : "location",
-       "tag" : "Known",
-       "data" : ["./json.m31", 16, 18, 16, 19]}}]}}]}
+["Term",
+ {"context" :
+  {["b", 50] : [[["Constant", "A"], {}], []],
+   ["g", 49] :
+   [[["Prod",
+      [["anon", 12], [["Constant", "A"], {}], [["Constant", "A"], {}]]], {
+     }], []]},
+  "term" :
+  [["Apply", [["Atom", ["g", 49]], {"free" : [["g", 49]]}],
+    [["anon", 12], [["Constant", "A"], {}], [["Constant", "A"], {}]],
+    [["Atom", ["b", 50]], {"free" : [["b", 50]]}]],
+   {"free" : [["g", 49], ["b", 50]]}],
+  "ty" : [["Constant", "A"], {}]}]
+()
+
+()
+
+["Term",
+ {"context" : {},
+  "term" : [["Type"], {}, ["./json.m31", 26, 10, 26, 14]],
+  "ty" : [["Type"], {}, ["./json.m31", 26, 10, 26, 14]]}]
+()
+
+["Term",
+ {"context" : {},
+  "term" : [["Constant", "A"], {}, ["./json.m31", 28, 10, 28, 11]],
+  "ty" : [["Type"], {}, ["./json.m31", 8, 13, 8, 17]]}]
+()
+
+["Term",
+ {"context" : {},
+  "term" :
+  [["Lambda",
+    ["f",
+     [["Prod",
+       ["x", [["Constant", "A"], {}, ["./json.m31", 15, 22, 15, 23]],
+        [["Apply", [["Constant", "B"], {}, ["./json.m31", 15, 26, 15, 27]],
+          [["anon", 11],
+           [["Constant", "A"], {}, ["./json.m31", 9, 13, 9, 14]],
+           [["Type"], {}, ["./json.m31", 9, 17, 9, 21]]],
+          [["Bound", 0], {"bound" : [0]}, ["./json.m31", 15, 22, 15, 23]]],
+         {"bound" : [0]}, ["./json.m31", 15, 26, 15, 27]]]], {},
+      ["./json.m31", 15, 14, 15, 30]],
+     [[["Apply",
+        [["Bound", 0], {"bound" : [0]}, ["./json.m31", 15, 14, 15, 30]],
+        ["x", [["Constant", "A"], {}, ["./json.m31", 15, 22, 15, 23]],
+         [["Apply", [["Constant", "B"], {}, ["./json.m31", 15, 26, 15, 27]],
+           [["anon", 11],
+            [["Constant", "A"], {}, ["./json.m31", 9, 13, 9, 14]],
+            [["Type"], {}, ["./json.m31", 9, 17, 9, 21]]],
+           [["Bound", 0], {"bound" : [0]}, ["./json.m31", 15, 22, 15, 23]]],
+          {"bound" : [0]}, ["./json.m31", 15, 26, 15, 27]]],
+        [["Constant", "a"], {}, ["./json.m31", 15, 34, 15, 35]]],
+       {"bound" : [0]}, ["./json.m31", 15, 32, 15, 33]],
+      [["Apply", [["Constant", "B"], {}, ["./json.m31", 15, 26, 15, 27]],
+        [["anon", 11], [["Constant", "A"], {}, ["./json.m31", 9, 13, 9, 14]],
+         [["Type"], {}, ["./json.m31", 9, 17, 9, 21]]],
+        [["Constant", "a"], {}, ["./json.m31", 15, 34, 15, 35]]], {},
+       ["./json.m31", 15, 26, 15, 27]]]]], {}, ["./json.m31", 15, 8, 15, 35]],
+  "ty" :
+  [["Prod",
+    ["f",
+     [["Prod",
+       ["x", [["Constant", "A"], {}, ["./json.m31", 15, 22, 15, 23]],
+        [["Apply", [["Constant", "B"], {}, ["./json.m31", 15, 26, 15, 27]],
+          [["anon", 11],
+           [["Constant", "A"], {}, ["./json.m31", 9, 13, 9, 14]],
+           [["Type"], {}, ["./json.m31", 9, 17, 9, 21]]],
+          [["Bound", 0], {"bound" : [0]}, ["./json.m31", 15, 22, 15, 23]]],
+         {"bound" : [0]}, ["./json.m31", 15, 26, 15, 27]]]], {},
+      ["./json.m31", 15, 14, 15, 30]],
+     [["Apply", [["Constant", "B"], {}, ["./json.m31", 15, 26, 15, 27]],
+       [["anon", 11], [["Constant", "A"], {}, ["./json.m31", 9, 13, 9, 14]],
+        [["Type"], {}, ["./json.m31", 9, 17, 9, 21]]],
+       [["Constant", "a"], {}, ["./json.m31", 15, 34, 15, 35]]], {},
+      ["./json.m31", 15, 26, 15, 27]]]], {}, ["./json.m31", 15, 8, 15, 35]]}]
+()
+
+["Term",
+ {"context" :
+  {["b", 54] : [[["Constant", "A"], {}, ["./json.m31", 33, 14, 33, 15]], []],
+   ["g", 53] :
+   [[["Prod",
+      [["anon", 13], [["Constant", "A"], {}, ["./json.m31", 32, 14, 32, 15]],
+       [["Constant", "A"], {}, ["./json.m31", 32, 18, 32, 19]]]], {},
+     ["./json.m31", 32, 14, 32, 19]], []]},
+  "term" :
+  [["Apply",
+    [["Atom", ["g", 53]], {"free" : [["g", 53]]},
+     ["./json.m31", 32, 3, 34, 15]],
+    [["anon", 13], [["Constant", "A"], {}, ["./json.m31", 32, 14, 32, 15]],
+     [["Constant", "A"], {}, ["./json.m31", 32, 18, 32, 19]]],
+    [["Atom", ["b", 54]], {"free" : [["b", 54]]},
+     ["./json.m31", 33, 3, 34, 15]]], {"free" : [["g", 53], ["b", 54]]},
+   ["./json.m31", 34, 11, 34, 12]],
+  "ty" : [["Constant", "A"], {}, ["./json.m31", 32, 18, 32, 19]]}]
 ()
 


### PR DESCRIPTION
The JSON output is still reversible, i.e., we should be able to reconstruct the original value if we know its type. In several places we shorten the output in the name of readibility without losing information (except when printing names we do not print fixity). For instance, when printing assumptions we output `{ }` instead of `{"free" : [], "bound" : []}`.

I also added a configuration option `--json-location` that turns on printing locations, and it can also be done via `external "config"`.