### PR TITLE
Rename `#include_once` to `require`.

### DIFF
--- a/examples/UniMath/paths_facts.m31
+++ b/examples/UniMath/paths_facts.m31
@@ -1,7 +1,7 @@
 (* Prove that the axiomatisation of the inductive definition of paths inherits
    UIP from the reflective equality of andromeda. *)
 
-#include_once "paths.m31".
+require "paths.m31".
 
 Let eq_of_paths :=
   λ [A : Type] [a y : A] [p : paths A a y]

--- a/examples/UniMath/paths_uip.m31
+++ b/examples/UniMath/paths_uip.m31
@@ -1,4 +1,4 @@
-#include_once "paths.m31" "paths_facts.m31".
+require "paths.m31" "paths_facts.m31".
 
 Let UIP_aux :=
   λ [A : Type] [a b : A] [p q : paths A a b]

--- a/examples/UniMath/uu0a.m31
+++ b/examples/UniMath/uu0a.m31
@@ -1,7 +1,7 @@
 (* Transcription of the uu0a.coq file from UniMath *)
-#include_once "uuu.m31".
-#include_once "paths_facts.m31".
-#include_once "paths_uip.m31".
+require "uuu.m31".
+require "paths_facts.m31".
+require "paths_uip.m31".
 
 Let UU := Type.
 

--- a/examples/UniMath/uuu.m31
+++ b/examples/UniMath/uuu.m31
@@ -1,6 +1,6 @@
 (* vv's introduction to UniMath *)
 
-#include_once "../empty.m31" "../unit.m31" "../sum.m31" "../nat.m31" "paths.m31".
+require "../empty.m31" "../unit.m31" "../sum.m31" "../nat.m31" "paths.m31".
 
 Let UUU := Type.
 Let empty_rect := ind_empty.

--- a/examples/algebra.m31
+++ b/examples/algebra.m31
@@ -10,7 +10,7 @@ end
 
 let print_signature = external "print_signature"
 
-#include_once "struct-coerce.m31"
+require "struct-coerce.m31"
 
 (** *************** **)
 

--- a/examples/bool.m31
+++ b/examples/bool.m31
@@ -25,7 +25,7 @@ do Type
 
 (* Next we show that true and false are not equal. *)
 
- #include_once "empty.m31" "unit.m31"
+ require "empty.m31" "unit.m31"
 
 (* Be very careful about when reductions may happen
    Better hint management would help here. *)

--- a/examples/esystems.m31
+++ b/examples/esystems.m31
@@ -1,5 +1,5 @@
 (* Egbert's E-systems *)
-#include_once "../std/hippy.m31"
+require "../std/hippy.m31"
 
 signature catWithTerms = {
 

--- a/examples/finite.m31
+++ b/examples/finite.m31
@@ -1,4 +1,4 @@
-#include_once "unit.m31" "peano.m31"
+require "unit.m31" "peano.m31"
 
 let nat = N
 

--- a/examples/time.m31
+++ b/examples/time.m31
@@ -1,23 +1,14 @@
-#include_once "peano.m31"
+require "peano.m31"
 
-<<<<<<< HEAD
-now betas = add_betas [exp_def,times_def,plus_def,ind_N_Z,ind_N_S] betas
-=======
 now betas = add_betas [exp_def,times_def,plus_def,ind_N_Z,ind_N_S]
->>>>>>> haselwarter/simplify-equal
 
 let rec snf t =
   match t with
   | |- ?e1 ?e2 =>
     let e = (snf e1) (snf e2) in
     match do_whnf e with
-<<<<<<< HEAD
-      | Some (|- _ : _ == ?e) => snf e
-      | None => e
-=======
       | (Some (|- _ : _ == ?e), _) => snf e
       | (None, _) => e
->>>>>>> haselwarter/simplify-equal
     end
   | _ => match whnf t with |- _ : _ == ?e => e end
   end

--- a/examples/vect.m31
+++ b/examples/vect.m31
@@ -1,4 +1,4 @@
-#include_once "peano.m31" "unit.m31" "finite.m31"
+require "peano.m31" "unit.m31" "finite.m31"
 
 constant vect : forall (A : Type), N -> Type
 constant vnil : forall (A : Type), vect A Z

--- a/prelude.m31
+++ b/prelude.m31
@@ -1,2 +1,2 @@
-#include_once "std/base.m31"
-#include_once "std/equal.m31"
+require "std/base.m31"
+require "std/equal.m31"

--- a/src/parser/desugar.ml
+++ b/src/parser/desugar.ml
@@ -982,7 +982,7 @@ let rec toplevel ~basedir ctx {Location.thing=cmd; loc} =
     | Input.Verbosity n ->
        (ctx, locate (Syntax.Verbosity n) loc)
 
-    | Input.Include fs ->
+    | Input.Require fs ->
       let rec fold ctx res = function
         | [] -> (ctx, locate (Syntax.Included (List.rev res)) loc)
         | fn::fs ->

--- a/src/parser/input.mli
+++ b/src/parser/input.mli
@@ -139,5 +139,5 @@ and toplevel' =
   | TopDo of comp (** evaluate a computation at top level *)
   | TopFail of comp
   | Verbosity of int
-  | Include of string list
+  | Require of string list
 

--- a/src/parser/lexer.ml
+++ b/src/parser/lexer.ml
@@ -44,6 +44,7 @@ let reserved = [
   ("rec", REC) ;
   ("ref", REF) ;
   ("refl", REFL) ;
+  ("require", REQUIRE) ;
   ("val", VAL) ;
   ("verbosity", VERBOSITY) ;
   ("where", WHERE) ;
@@ -101,7 +102,6 @@ and token_aux ({ Ulexbuf.stream;_ } as lexbuf) =
   | newline                  -> f (); Ulexbuf.new_line lexbuf; token_aux lexbuf
   | start_longcomment        -> f (); comments 0 lexbuf
   | Plus hspace              -> f (); token_aux lexbuf
-  | "#include_once"          -> f (); INCLUDEONCE
   | quoted_string            -> f ();
      let s = Ulexbuf.lexeme lexbuf in
      let l = String.length s in

--- a/src/parser/parser.mly
+++ b/src/parser/parser.mly
@@ -75,7 +75,7 @@
 (* Toplevel directives *)
 %token VERBOSITY
 %token <string> QUOTED_STRING
-%token INCLUDEONCE
+%token REQUIRE
 
 %token EOF
 
@@ -127,7 +127,7 @@ plain_topcomp:
 (* Toplevel directive. *)
 topdirective: mark_location(plain_topdirective)      { $1 }
 plain_topdirective:
-  | INCLUDEONCE fs=QUOTED_STRING+                    { Include fs }
+  | REQUIRE fs=QUOTED_STRING+                        { Require fs }
 
 (* Main syntax tree *)
 

--- a/std/equal.m31
+++ b/std/equal.m31
@@ -1,5 +1,5 @@
-#include_once "utils.m31"
-#include_once "hints.m31"
+require "utils.m31"
+require "hints.m31"
 
 let typeof e =
   match e with ⊢ _ : ?A ⇒ A end

--- a/std/resolution.m31
+++ b/std/resolution.m31
@@ -2,7 +2,7 @@
    the reuslt of computing implicit arguments will be
    agressively simplified. *)
 
-#include_once "snf.m31"
+require "snf.m31"
 
 let resolve e = 
   let e' = resolve e in

--- a/std/utils.m31
+++ b/std/utils.m31
@@ -1,4 +1,4 @@
-#include_once "base.m31"
+require "base.m31"
 
 (** Reverse a list *)
 let rev =

--- a/tests/everything.m31
+++ b/tests/everything.m31
@@ -231,10 +231,10 @@ do assume x : A in
 do congr_apply (assume x : A in x) (refl (lambda (x : A), x)) eq (refl A) (refl A)
 
 (** Evaluate commands from another file *)
-#include_once "../std/hippy.m31"
+require "../std/hippy.m31"
 
-#include_once "everything.m31"
+require "everything.m31"
 
 (* both can be used with multiple files at once *)
-#include_once "../std/base.m31" "../std/equal.m31" "../std/base.m31"
+require "../std/base.m31" "../std/equal.m31" "../std/base.m31"
 


### PR DESCRIPTION
`#include_once` was the only "pragma" left and it sticks out in terms of syntax. This PR renames it to `require`. There is no need to syntactically indicate the fact that it happens at desugar time (users don't even know what that means).