### PR TITLE
Warning 52 prevents Andromeda from compiling under 4.03.0

### DIFF
--- a/src/nucleus/TT.ml
+++ b/src/nucleus/TT.ml
@@ -389,7 +389,7 @@ and print_app ?max_level ~penv e1 e2 ppf =
          match List.nth penv.forbidden k with
          | Name.Ident (_, Name.Prefix) as op -> Some (As_ident op)
          | Name.Ident (_, _) -> None
-         | exception Failure "nth" -> None
+         | exception Failure failure when failure = "nth" -> None
        end
     | Constant (Name.Ident (_, Name.Prefix) as op) -> Some (As_ident op)
     | Atom (Name.Atom (_, Name.Prefix, _) as op) -> Some (As_atom op)
@@ -422,7 +422,7 @@ and print_app ?max_level ~penv e1 e2 ppf =
                 | Name.Ident (_, Name.Infix fixity) as op ->
                    Some (As_ident op, fixity, e1)
                 | Name.Ident (_, (Name.Word | Name.Anonymous _| Name.Prefix)) -> None
-                | exception Failure "nth" -> None
+                | exception Failure failure when failure = "nth" -> None
               end
            | Apply ({term=Constant (Name.Ident (_, Name.Infix fixity) as op);_},
                     _, e1) ->


### PR DESCRIPTION
When compiling Andromeda under OCaml 4.03.0, I got the following two warnings:

```
File "src/nucleus/TT.ml", line 392, characters 29-34:
Warning 52: the argument of this constructor should not be matched against a
constant pattern; the actual value of the argument could change
in the future.
File "src/nucleus/TT.ml", line 425, characters 36-41:
Warning 52: the argument of this constructor should not be matched against a
constant pattern; the actual value of the argument could change
in the future.
```

Both were caused by a line of the form

```
| exception Failure "nth" -> None
```

As you treat all warnings as errors, the build is aborted. I propose replacing the two lines with

```
| exception Failure failure when failure = "nth" -> None
```

as that gives you exactly the same behaviour minus the warning. An alternative is to silence warning 52 like you do with some other ones, but I see no reason to do so.

I have tested the change and it works under both 4.02.1 and 4.03.0.
