### PR TITLE
Ml ascription

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,6 +1,3 @@
-;; Source files should have newlines at the end.
-(setq require-final-newline t)
-
 ;; Support for compiling in subdirectories from Emacs. Adapted from Coq source.
 ((nil
   . ((eval

--- a/src/parser/desugar.ml
+++ b/src/parser/desugar.ml
@@ -462,6 +462,11 @@ let rec comp ~yield bound {Location.thing=c';loc} =
      let c = comp ~yield bound c in
      locate (Syntax.LetRec (lst, c)) loc
 
+  | Input.MLAscribe (c, sch) ->
+     let c = comp ~yield bound c in
+     let sch = ml_schema ~yield bound sch in
+     locate (Syntax.MLAscribe (c, sch)) loc
+
   | Input.Now (x,c1,c2) ->
      let y = Ctx.get_dynamic ~loc x bound
      and c1 = comp ~yield bound c1
@@ -669,8 +674,7 @@ and let_clauses ~loc ~yield bound lst =
        else
          let c = let_clause ~yield bound ys c in
          let t_opt = match t_opt with
-           | Some {Location.thing=Input.ML_Forall (params, t); loc} ->
-             Some (locate (Syntax.ML_Forall (params, mlty bound params t)) loc)
+           | Some sch -> Some (ml_schema ~yield bound sch)
            | None -> None
          in
          let bound' = Ctx.add_lexical x bound' in
@@ -719,6 +723,8 @@ and letrec_clause ~yield bound y ys c =
   let c = let_clause ~yield bound ys c in
   y, c
 
+and ml_schema ~yield bound {Location.thing=Input.ML_Forall (params, t); loc} =
+  locate (Syntax.ML_Forall (params, mlty bound params t)) loc
 
 (* Desugar a spine. This function is a bit messy because we need to untangle
    to env. But it's worth doing to make users happy. TODO outdated comment *)

--- a/src/parser/input.mli
+++ b/src/parser/input.mli
@@ -54,12 +54,10 @@ and pattern' =
 (** Sugared terms *)
 type term = term' Location.located
 and term' =
-  (* expressions *)
   | Var of Name.ident
   | Type
   | Function of Name.ident list * comp
   | Handler of handle_case list
-  (* computations *)
   | Handle of comp * handle_case list
   | With of expr * comp
   | List of comp list
@@ -67,6 +65,7 @@ and term' =
   | Match of comp * match_case list
   | Let of let_clause list  * comp
   | LetRec of letrec_clause list * comp
+  | MLAscribe of comp * ml_schema
   | Now of Name.ident * comp * comp
   | Lookup of comp
   | Update of comp * comp

--- a/src/parser/lexer.ml
+++ b/src/parser/lexer.ml
@@ -120,6 +120,7 @@ and token_aux ({ Ulexbuf.stream;_ } as lexbuf) =
   | ']'                      -> f (); RBRACK
   | "="                      -> f (); EQ
   | ':'                      -> f (); COLON
+  | ":>"                     -> f (); COLONGE
   | ','                      -> f (); COMMA
   | '?', name                -> f (); PATTVAR (let s = Ulexbuf.lexeme lexbuf in
                                                let s = String.sub s 1 (String.length s - 1) in

--- a/src/parser/parser.mly
+++ b/src/parser/parser.mly
@@ -23,7 +23,7 @@
 (* Parentheses & punctuations *)
 %token LPAREN RPAREN
 %token LBRACK RBRACK
-%token COLON COMMA
+%token COLON COMMA COLONGE
 %token ARROW DARROW
 
 (* Things specific to toplevel *)
@@ -209,6 +209,7 @@ plain_simple_term:
   | EXTERNAL s=QUOTED_STRING                            { External s }
   | s=QUOTED_STRING                                     { String s }
   | LBRACK lst=separated_list(COMMA, equal_term) RBRACK { List lst }
+  | LPAREN c=term COLONGE t=ml_schema RPAREN            { MLAscribe (c, t) }
   | LPAREN lst=separated_list(COMMA, term) RPAREN       { match lst with
                                                           | [{Location.thing=e;loc=_}] -> e
                                                           | _ -> Tuple lst }

--- a/src/runtime/eval.ml
+++ b/src/runtime/eval.ml
@@ -120,6 +120,9 @@ let rec infer {Location.thing=c'; loc} =
   | Syntax.LetRec (fxcs, c) ->
      letrec_bind fxcs (infer c)
 
+  | Syntax.MLAscribe (c, _) ->
+     infer c
+
   | Syntax.Now (x,c1,c2) ->
     infer c1 >>= fun v ->
     Runtime.now ~loc x v (infer c2)
@@ -388,6 +391,9 @@ and check ({Location.thing=c';loc} as c) t_check =
 
   | Syntax.LetRec (fxcs, c) ->
      letrec_bind fxcs (check c t_check)
+
+  | Syntax.MLAscribe (c, _) ->
+     check c t_check
 
   | Syntax.Now (x,c1,c2) ->
     infer c1 >>= fun v ->

--- a/src/syntax.mli
+++ b/src/syntax.mli
@@ -60,6 +60,7 @@ and 'annot comp' =
   | With of 'annot comp * 'annot comp
   | Let of 'annot let_clause list * 'annot comp
   | LetRec of 'annot letrec_clause list * 'annot comp
+  | MLAscribe of 'annot comp * ml_schema
   | Now of bound * 'annot comp * 'annot comp
   | Lookup of 'annot comp
   | Update of 'annot comp * 'annot comp
@@ -127,4 +128,3 @@ and 'annot toplevel' =
   | TopFail of 'annot comp
   | Verbosity of int
   | Included of (string * 'annot toplevel list) list
-

--- a/tests/everything.m31
+++ b/tests/everything.m31
@@ -22,6 +22,9 @@ constant a, b : A
 constant ( + ), ( * ), ( ^ ), ( - ), ( <= ) :
   (* non-dependent product type *) A -> A -> A
 
+(** Inlined ML-ascriptions *)
+let mlascribed = ((fun x => x) :> list judgment -> list judgment)
+
 (* Infixes and prefixes are printed as such. *)
 do lambda (x y z w : A), x + y * z ^ x ^ y - (z ^ x) ^ y <= w
 

--- a/tests/everything.m31.ref
+++ b/tests/everything.m31.ref
@@ -17,6 +17,8 @@ Constant ( ^ ) is declared.
 Constant ( - ) is declared.
 Constant ( <= ) is declared.
 
+val mlascribed : list judgment → list judgment
+
 ⊢ λ (x : A) (y : A) (z : A) (w : A), x + y * z ^ x ^ y - (z ^ x) ^ y <= w
   : A → A → A → A → A
 
@@ -29,7 +31,7 @@ val x0 : dummy
 dummy
 
 Successfully failed command with runtime error:
-File "./everything.m31", line 74, characters 6-9:
+File "./everything.m31", line 77, characters 6-9:
 Application of the non-function:
    ⊢ Type : Type
 
@@ -37,7 +39,7 @@ Application of the non-function:
 ⊢ refl Type : Type ≡ Type
 
 Successfully failed command with runtime error:
-File "./everything.m31", line 88, characters 6-18: cannot infer the type of
+File "./everything.m31", line 91, characters 6-18: cannot infer the type of
 T
 
 ⊢ λ (T : Type) (x : T), x : Π (A0 : Type), A0 → A0
@@ -45,7 +47,7 @@ T
 ⊢ λ (x : A), x : A → A
 
 Successfully failed command with runtime error:
-File "./everything.m31", line 96, characters 13-25: cannot infer the type of
+File "./everything.m31", line 99, characters 13-25: cannot infer the type of
 x
 
 val f : ∀ α, α → mlstring * (mlstring * α)

--- a/tests/mlascribe.m31
+++ b/tests/mlascribe.m31
@@ -1,0 +1,7 @@
+mltype cow = Bull end
+
+let id x = x
+
+let f = (id id :> cow -> cow)
+let l = ([] :> list judgment)
+

--- a/tests/mlascribe.m31.ref
+++ b/tests/mlascribe.m31.ref
@@ -1,0 +1,8 @@
+ML type cow declared.
+
+val id : ∀ α, α → α
+
+val f : cow → cow
+
+val l : list judgment
+

--- a/tests/mlascribe_wrong.m31
+++ b/tests/mlascribe_wrong.m31
@@ -1,0 +1,2 @@
+let id x = x
+do (id id :> forall a, a -> a)

--- a/tests/mlascribe_wrong.m31.ref
+++ b/tests/mlascribe_wrong.m31.ref
@@ -1,0 +1,3 @@
+
+File "./mlascribe_wrong.m31", line 2, characters 5-6:
+This computation cannot be polymorphic (value restriction)


### PR DESCRIPTION
The syntax for inlined ascriptions is `expr :> schema`. This follows opaque ascription of SML. We can generally use `:>` for ML-level type ascription.