### PR TITLE
Andromeda 2.0

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -12,6 +12,7 @@
             ;; m31 tags file
             (when m31-root-directory
               (setq tags-file-name (concat m31-root-directory "TAGS"))
+              (make-local-variable 'compilation-search-path)
               (add-to-list 'compilation-search-path m31-root-directory)
               ;; Setting the compilation directory to m31 root. This is
               ;; mutually exclusive with the setting of default-directory

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,11 @@
 #29: non-escaped end-of-line in string constant
 #50: unexpected documentation comment
 
+# Use this to not die on all warnings
+#OCAMLBUILD_FLAGS = -j 4 -lib unix -cflags -g,-annot,-w,+a-4-27-29-50 -use-ocamlfind -pkg menhirLib -pkg sedlex
+
 OCAMLBUILD_FLAGS = -j 4 -lib unix -cflags -g,-annot,-w,+a-4-27-29-50,"-warn-error +a" -use-ocamlfind -pkg menhirLib -pkg sedlex
+
 OCAMLBUILD_MENHIRFLAGS = -use-menhir -menhir "menhir --explain"
 #OCAMLBUILD_MENHIRFLAGS = -use-menhir -menhir "menhir --explain --trace"
 

--- a/prelude.m31
+++ b/prelude.m31
@@ -1,2 +1,2 @@
-(* require "std/base.m31" *)
+require "std/base.m31"
 (* require "std/equal.m31" *)

--- a/prelude.m31
+++ b/prelude.m31
@@ -1,2 +1,2 @@
-require "std/base.m31"
-require "std/equal.m31"
+(* require "std/base.m31" *)
+(* require "std/equal.m31" *)

--- a/src/dsyntax.mli
+++ b/src/dsyntax.mli
@@ -53,7 +53,7 @@ and tt_pattern' =
   | Patt_TT_IsTerm of tt_pattern * tt_pattern
   | Patt_TT_EqType of tt_pattern * tt_pattern
   | Patt_TT_EqTerm of tt_pattern * tt_pattern * tt_pattern
-  | Patt_TT_Abstraction of Name.ident option * tt_pattern option * tt_pattern
+  | Patt_TT_Abstraction of Name.ident option * tt_pattern * tt_pattern
 
 type ml_pattern = ml_pattern' located
 and ml_pattern' =

--- a/src/dsyntax.mli
+++ b/src/dsyntax.mli
@@ -71,7 +71,7 @@ and comp' =
   | Bound of bound
   | Function of Name.ident * arg_annotation * comp
   | Handler of handler
-  | AML_Constructor of Name.ident * comp list
+  | AMLConstructor of Name.ident * comp list
   | Tuple of comp list
   | Operation of Name.ident * comp list
   | With of comp * comp

--- a/src/dsyntax.mli
+++ b/src/dsyntax.mli
@@ -42,15 +42,10 @@ type let_annotation =
   | Let_annot_none
   | Let_annot_schema of ml_schema
 
-type tt_variable =
-  | PattVar of Name.ident
-  | NonPattVar of Name.ident
-
 type tt_pattern = tt_pattern' located
 and tt_pattern' =
   | Patt_TT_Anonymous
-  | Patt_TT_NewVar of Name.ident * bound (* new pattern variable *)
-  | Patt_TT_EquVar of bound (* must be equal to the given pattern variable *)
+  | Patt_TT_Var of Name.ident (* new pattern variable *)
   | Patt_TT_Interpolate of bound (* interpolated value *)
   | Patt_TT_As of tt_pattern * tt_pattern
   | Patt_TT_Constructor of Name.ident * tt_pattern list
@@ -58,13 +53,12 @@ and tt_pattern' =
   | Patt_TT_IsTerm of tt_pattern * tt_pattern
   | Patt_TT_EqType of tt_pattern * tt_pattern
   | Patt_TT_EqTerm of tt_pattern * tt_pattern * tt_pattern
-  | Patt_TT_Abstraction of Name.ident * bound option * tt_pattern option * tt_pattern
+  | Patt_TT_Abstraction of Name.ident option * tt_pattern option * tt_pattern
 
 type ml_pattern = ml_pattern' located
 and ml_pattern' =
   | Patt_Anonymous
-  | Patt_NewVar of Name.ident * bound
-  | Patt_EquVar of bound
+  | Patt_Var of Name.ident
   | Patt_Interpolate of bound
   | Patt_As of ml_pattern * ml_pattern
   | Patt_Judgement of tt_pattern
@@ -112,8 +106,8 @@ and comp' =
   | Natural of comp
 
 and let_clause =
-  | Let_clause_ML of Name.ident * let_annotation * comp
-  | Let_clause_patt of Name.ident list * ml_pattern * let_annotation * comp
+  | Let_clause_ML of Name.ident * let_annotation * comp (* [let (x :> t) = c] *)
+  | Let_clause_patt of ml_pattern * let_annotation * comp (* [let (?p :> t) = c] *)
 
 and letrec_clause = Name.ident * (Name.ident * arg_annotation) * let_annotation * comp
 
@@ -123,7 +117,7 @@ and handler = {
   handler_finally : match_case list;
 }
 
-and match_case = Name.ident list * ml_pattern * comp
+and match_case = ml_pattern * comp
 
 (** Match multiple patterns at once, with shared pattern variables *)
 and match_op_case = Name.ident list * ml_pattern list * ml_pattern option * comp

--- a/src/dsyntax.mli
+++ b/src/dsyntax.mli
@@ -47,7 +47,6 @@ type tt_pattern = tt_pattern' located
 and tt_pattern' =
   | Patt_TT_Anonymous
   | Patt_TT_Var of Name.ident (* new pattern variable *)
-(*  | Patt_TT_Interpolate of bound (* interpolated value *) *)
   | Patt_TT_As of tt_pattern * tt_pattern
   | Patt_TT_Constructor of Name.ident * tt_pattern list
   | Patt_TT_GenAtom of tt_pattern
@@ -61,7 +60,6 @@ type ml_pattern = ml_pattern' located
 and ml_pattern' =
   | Patt_Anonymous
   | Patt_Var of Name.ident
-(*  | Patt_Interpolate of bound *)
   | Patt_As of ml_pattern * ml_pattern
   | Patt_Judgement of tt_pattern
   | Patt_Constr of Name.ident * ml_pattern list

--- a/src/dsyntax.mli
+++ b/src/dsyntax.mli
@@ -8,9 +8,15 @@ type level = int
 
 type 'a located = 'a Location.located
 
-type ml_abstraction =
-  | ML_NotAbstract
-  | ML_Abstract of ml_abstraction
+type ml_judgement =
+  | ML_IsType
+  | ML_IsTerm
+  | ML_EqType
+  | ML_EqTerm
+
+type ml_abstracted_judgement =
+  | ML_NotAbstract of ml_judgement
+  | ML_Abstract of ml_judgement * ml_abstracted_judgement
 
 type ml_ty = ml_ty' located
 and ml_ty' =
@@ -20,10 +26,7 @@ and ml_ty' =
   | ML_Handler of ml_ty * ml_ty
   | ML_Ref of ml_ty
   | ML_Dynamic of ml_ty
-  | ML_IsType of ml_abstraction
-  | ML_IsTerm of ml_abstraction
-  | ML_EqType of ml_abstraction
-  | ML_EqTerm of ml_abstraction
+  | ML_Judgement of ml_abstracted_judgement
   | ML_String
   | ML_Bound of bound
   | ML_Anonymous
@@ -46,7 +49,7 @@ type tt_variable =
 type tt_pattern = tt_pattern' located
 and tt_pattern' =
   | Patt_TT_Anonymous
-  | Patt_TT_NewVar of bound (* new pattern variable *)
+  | Patt_TT_NewVar of Name.ident * bound (* new pattern variable *)
   | Patt_TT_EquVar of bound (* must be equal to the given pattern variable *)
   | Patt_TT_Interpolate of bound (* interpolated value *)
   | Patt_TT_As of tt_pattern * tt_pattern
@@ -60,7 +63,7 @@ and tt_pattern' =
 type ml_pattern = ml_pattern' located
 and ml_pattern' =
   | Patt_Anonymous
-  | Patt_NewVar of bound
+  | Patt_NewVar of Name.ident * bound
   | Patt_EquVar of bound
   | Patt_Interpolate of bound
   | Patt_As of ml_pattern * ml_pattern

--- a/src/dsyntax.mli
+++ b/src/dsyntax.mli
@@ -8,6 +8,10 @@ type level = int
 
 type 'a located = 'a Location.located
 
+type ml_abstraction =
+  | ML_NotAbstract
+  | ML_Abstract of ml_abstraction
+
 type ml_ty = ml_ty' located
 and ml_ty' =
   | ML_Arrow of ml_ty * ml_ty
@@ -16,10 +20,10 @@ and ml_ty' =
   | ML_Handler of ml_ty * ml_ty
   | ML_Ref of ml_ty
   | ML_Dynamic of ml_ty
-  | ML_IsType
-  | ML_IsTerm
-  | ML_EqType
-  | ML_EqTerm
+  | ML_IsType of ml_abstraction
+  | ML_IsTerm of ml_abstraction
+  | ML_EqType of ml_abstraction
+  | ML_EqTerm of ml_abstraction
   | ML_String
   | ML_Bound of bound
   | ML_Anonymous

--- a/src/dsyntax.mli
+++ b/src/dsyntax.mli
@@ -8,6 +8,7 @@ type level = int
 
 type 'a located = 'a Location.located
 
+(* The types called ml_* are AML types *)
 type ml_judgement =
   | ML_IsType
   | ML_IsTerm
@@ -53,7 +54,7 @@ and tt_pattern' =
   | Patt_TT_IsTerm of tt_pattern * tt_pattern
   | Patt_TT_EqType of tt_pattern * tt_pattern
   | Patt_TT_EqTerm of tt_pattern * tt_pattern * tt_pattern
-  | Patt_TT_Abstraction of Name.ident option * tt_pattern * tt_pattern
+  | Patt_TT_Abstraction of Name.ident * tt_pattern * tt_pattern
 
 type ml_pattern = ml_pattern' located
 and ml_pattern' =

--- a/src/dsyntax.mli
+++ b/src/dsyntax.mli
@@ -16,7 +16,7 @@ type ml_judgement =
 
 type ml_abstracted_judgement =
   | ML_NotAbstract of ml_judgement
-  | ML_Abstract of ml_judgement * ml_abstracted_judgement
+  | ML_Abstract of ml_abstracted_judgement
 
 type ml_ty = ml_ty' located
 and ml_ty' =

--- a/src/dsyntax.mli
+++ b/src/dsyntax.mli
@@ -47,7 +47,7 @@ type tt_pattern = tt_pattern' located
 and tt_pattern' =
   | Patt_TT_Anonymous
   | Patt_TT_Var of Name.ident (* new pattern variable *)
-  | Patt_TT_Interpolate of bound (* interpolated value *)
+(*  | Patt_TT_Interpolate of bound (* interpolated value *) *)
   | Patt_TT_As of tt_pattern * tt_pattern
   | Patt_TT_Constructor of Name.ident * tt_pattern list
   | Patt_TT_GenAtom of tt_pattern
@@ -61,7 +61,7 @@ type ml_pattern = ml_pattern' located
 and ml_pattern' =
   | Patt_Anonymous
   | Patt_Var of Name.ident
-  | Patt_Interpolate of bound
+(*  | Patt_Interpolate of bound *)
   | Patt_As of ml_pattern * ml_pattern
   | Patt_Judgement of tt_pattern
   | Patt_Constr of Name.ident * ml_pattern list
@@ -113,7 +113,7 @@ and handler = {
 and match_case = ml_pattern * comp
 
 (** Match multiple patterns at once, with shared pattern variables *)
-and match_op_case = ml_pattern list * ml_pattern option * comp
+and match_op_case = ml_pattern list * tt_pattern option * comp
 
 type top_op_case = Name.ident list * Name.ident option * comp
 

--- a/src/dsyntax.mli
+++ b/src/dsyntax.mli
@@ -87,21 +87,12 @@ and comp' =
   | Ref of comp
   | Sequence of comp * comp
   | Assume of (Name.ident * comp) * comp
-  | Where of comp * comp * comp
   | Match of comp * match_case list
   | Ascribe of comp * comp
   | TT_Constructor of Name.ident * comp list
   | Apply of comp * comp
   | Abstract of Name.ident * comp option * comp
   | Yield of comp
-  | CongrAbstractTy of comp * comp * comp
-  | CongrAbstract of comp * comp * comp * comp
-  | Reflexivity_type of comp
-  | Symmetry_type of comp
-  | Transitivity_type of comp * comp
-  | Reflexivity_term of comp
-  | Symmetry_term of comp
-  | Transitivity_term of comp * comp
   | String of string
   | Occurs of comp * comp
   | Context of comp
@@ -122,7 +113,7 @@ and handler = {
 and match_case = ml_pattern * comp
 
 (** Match multiple patterns at once, with shared pattern variables *)
-and match_op_case = Name.ident list * ml_pattern list * ml_pattern option * comp
+and match_op_case = ml_pattern list * ml_pattern option * comp
 
 type top_op_case = Name.ident list * Name.ident option * comp
 
@@ -138,7 +129,6 @@ and toplevel' =
   | DefMLType of (Name.ty * (Name.ty list * ml_tydef)) list
   | DefMLTypeRec of (Name.ty * (Name.ty list * ml_tydef)) list
   | DeclOperation of Name.operation * (ml_ty list * ml_ty)
-  | DeclConstants of Name.constant list * comp
   | DeclExternal of Name.ident * ml_schema * string
   | TopHandle of (Name.operation * top_op_case) list
   | TopLet of let_clause list

--- a/src/dsyntax.mli
+++ b/src/dsyntax.mli
@@ -99,10 +99,10 @@ and comp' =
   | Natural of comp
 
 and let_clause =
-  | Let_clause_ML of Name.ident * let_annotation * comp (* [let (x :> t) = c] *)
-  | Let_clause_patt of ml_pattern * let_annotation * comp (* [let (?p :> t) = c] *)
+  | Let_clause of ml_pattern * let_annotation * comp (* [let (?p :> t) = c] *)
 
-and letrec_clause = Name.ident * (Name.ident * arg_annotation) * let_annotation * comp
+and letrec_clause =
+  | Letrec_clause of Name.ident * (Name.ident * arg_annotation) * let_annotation * comp
 
 and handler = {
   handler_val: match_case list;

--- a/src/dsyntax.mli
+++ b/src/dsyntax.mli
@@ -47,7 +47,7 @@ type tt_pattern = tt_pattern' located
 and tt_pattern' =
   | Patt_TT_Anonymous
   | Patt_TT_NewVar of bound (* new pattern variable *)
-  | Patt_TT_EqVar of bound (* must be equal to the given pattern variable *)
+  | Patt_TT_EquVar of bound (* must be equal to the given pattern variable *)
   | Patt_TT_Interpolate of bound (* interpolated value *)
   | Patt_TT_As of tt_pattern * tt_pattern
   | Patt_TT_Constructor of Name.ident * tt_pattern list

--- a/src/dsyntax.mli
+++ b/src/dsyntax.mli
@@ -54,7 +54,7 @@ and tt_pattern' =
   | Patt_TT_IsTerm of tt_pattern * tt_pattern
   | Patt_TT_EqType of tt_pattern * tt_pattern
   | Patt_TT_EqTerm of tt_pattern * tt_pattern * tt_pattern
-  | Patt_TT_Abstraction of Name.ident * tt_pattern * tt_pattern
+  | Patt_TT_Abstraction of Name.ident option * tt_pattern * tt_pattern
 
 type ml_pattern = ml_pattern' located
 and ml_pattern' =

--- a/src/dsyntax.mli
+++ b/src/dsyntax.mli
@@ -51,6 +51,7 @@ and tt_pattern' =
   | Patt_TT_As of tt_pattern * tt_pattern
   | Patt_TT_Constructor of Name.ident * tt_pattern list
   | Patt_TT_GenAtom of tt_pattern
+  | Patt_TT_IsType of tt_pattern
   | Patt_TT_IsTerm of tt_pattern * tt_pattern
   | Patt_TT_EqType of tt_pattern * tt_pattern
   | Patt_TT_EqTerm of tt_pattern * tt_pattern * tt_pattern

--- a/src/nucleus/TT.ml
+++ b/src/nucleus/TT.ml
@@ -364,6 +364,28 @@ and fully_instantiate_abstraction
      and abstr = fully_instantiate_abstraction inst_u ~lvl:(lvl+1) es abstr
      in Abstract (x, t, abstr)
 
+(** Unabstract *)
+
+let unabstract_type x t1 t2 =
+  let a = fresh_atom x t1 in
+  a, instantiate_type (mk_atom a) t2
+
+let unabstract_term x t e =
+  let a = fresh_atom x t in
+  a, instantiate_term (mk_atom a) e
+
+let unabstract_eq_type x t eq =
+  let a = fresh_atom x t in
+  a, instantiate_eq_type (mk_atom a) eq
+
+let unabstract_eq_term x t eq =
+  let a = fresh_atom x t in
+  a, instantiate_eq_term (mk_atom a) eq
+
+let unabstract_abstraction instantiate_u x t abstr =
+  let a = fresh_atom x t in
+  a, instantiate_abstraction instantiate_u (mk_atom a) abstr
+
 (** Abstract *)
 
 let rec abstract_term x ?(lvl=0) = function
@@ -430,8 +452,8 @@ and abstract_eq_term x ?(lvl=0) (EqTerm (asmp, e1, e2, t)) =
   in EqTerm (asmp, e1, e2, t)
 
 and abstract_abstraction
-  : 'a .(Name.atom -> ?lvl:int -> 'a -> 'a) ->
-        Name.atom -> ?lvl:int -> 'a abstraction -> 'a abstraction
+  : 'a . (Name.atom -> ?lvl:int -> 'a -> 'a) ->
+         Name.atom -> ?lvl:int -> 'a abstraction -> 'a abstraction
   = fun abstr_v x ?(lvl=0) ->
   function
   | NotAbstract v ->

--- a/src/nucleus/TT.ml
+++ b/src/nucleus/TT.ml
@@ -98,6 +98,16 @@ and assumptions_abstraction
 
 let assumptions_arguments = assumptions_arguments ~lvl:0
 
+let context_u assumptions_u t =
+  let asmp = assumptions_u t in
+  let free, bound = Assumption.unpack asmp in
+  assert (Assumption.BoundSet.is_empty bound) ;
+  let free = Name.AtomMap.bindings free in
+  List.map (fun (atom_name, atom_type) -> {atom_name; atom_type}) free
+
+let context_abstraction assumptions_u =
+  context_u (assumptions_abstraction ?lvl:None assumptions_u)
+
 (* Helper functions *)
 
 let fresh_atom x t =

--- a/src/nucleus/TT.ml
+++ b/src/nucleus/TT.ml
@@ -369,7 +369,7 @@ and fully_instantiate_abstraction
 let rec abstract_term x ?(lvl=0) = function
   | (TermAtom {atom_name=y; atom_type=t}) as e ->
      begin match Name.eq_atom x y with
-     | false -> e (* XXX check that t does not depend on x !!! *)
+     | false -> ignore e ; failwith "(* XXX check that t does not depend on x, then give me e !!! *)"
      | true -> TermBound lvl
      end
 
@@ -444,11 +444,11 @@ and abstract_abstraction
      Abstract (y, u, abstr)
 
 (** Substitute *)
-let substitute_term x e0 e =
+let substitute_term e0 x e =
   let e = abstract_term x e in
   instantiate_term e0 e
 
-let substitute_type x e0 t =
+let substitute_type e0 x t =
   let t = abstract_type x t in
   instantiate_type e0 t
 
@@ -491,7 +491,7 @@ and occurs_assumptions k asmp =
 
 (****** Alpha equality ******)
 
-let rec alpha_equal e1 e2 =
+let rec alpha_equal_term e1 e2 =
   e1 == e2 || (* a shortcut in case the terms are identical *)
   begin match e1, e2 with
 
@@ -503,7 +503,7 @@ let rec alpha_equal e1 e2 =
        Name.eq_ident c c' && alpha_equal_args args args'
 
     | TermConvert (e1, _, _), TermConvert (e2, _, _) ->
-       alpha_equal e1 e2
+       alpha_equal_term e1 e2
 
     | (TermAtom _ | TermBound _ | TermConstructor _  | TermConvert _), _ ->
       false
@@ -520,7 +520,7 @@ and alpha_equal_args args args' =
   | [], [] -> true
 
   | (ArgIsTerm e)::args, (ArgIsTerm e')::args' ->
-     alpha_equal_abstraction alpha_equal e e' && alpha_equal_args args args'
+     alpha_equal_abstraction alpha_equal_term e e' && alpha_equal_args args args'
 
   | (ArgIsType t)::args, (ArgIsType t')::args' ->
      alpha_equal_abstraction alpha_equal_type t t' && alpha_equal_args args args'

--- a/src/nucleus/TT.ml
+++ b/src/nucleus/TT.ml
@@ -572,7 +572,7 @@ and alpha_equal_args args args' =
      assert false
 
 and alpha_equal_abstraction
-  : 'a .('a -> 'a -> bool) -> 'a abstraction -> 'a abstraction -> bool
+  : 'a . ('a -> 'a -> bool) -> 'a abstraction -> 'a abstraction -> bool
   = fun equal_v e e' ->
   e == e' ||
   (* XXX try e = e' ? *)

--- a/src/nucleus/TT.ml
+++ b/src/nucleus/TT.ml
@@ -2,23 +2,14 @@
 
 type bound = int
 
-(** An abstracted entity. Note that abstractions only ever appear as arguments
-   to constructors. Thus we do not carry any type information for the abstracted
-   variable, as it can be recovered from the constructor. *)
-type ('a, 'b) abstraction =
-  | Abstract of Name.ident * 'a * ('a,'b) abstraction
-  | NotAbstract of 'b
+type ty =
+  | TypeConstructor of Name.constructor * argument list
 
-type 'a argument_abstraction = (unit, 'a) abstraction
-
-type term =
-  | TermAtom of Name.atom * ty
+and term =
+  | TermAtom of ty atom
   | TermBound of bound
   | TermConstructor of Name.constructor * argument list
   | TermConvert of term * assumption * ty
-
-and ty =
-  | TypeConstructor of Name.constructor * argument list
 
 and eq_type = EqType of assumption * ty * ty
 
@@ -26,19 +17,30 @@ and eq_term = EqTerm of assumption * term * term * ty
 
 and assumption = ty Assumption.t
 
+and 't atom = { atom_name : Name.atom ; atom_type : 't }
+
 (** An argument of a term or a type constructor *)
 and argument =
-  | ArgIsTerm of term argument_abstraction
-  | ArgIsType of ty argument_abstraction
-  | ArgEqType of assumption argument_abstraction
-  | ArgEqTerm of assumption argument_abstraction
+  | ArgIsTerm of term abstraction
+  | ArgIsType of ty abstraction
+  | ArgEqType of eq_type abstraction
+  | ArgEqTerm of eq_term abstraction
+
+(** An abstracted entity. Note that abstractions only ever appear as arguments
+   to constructors. Thus we do not carry any type information for the abstracted
+   variable, as it can be recovered from the constructor. *)
+and 'a abstraction =
+  | Abstract of Name.ident * ty * 'a abstraction
+  | NotAbstract of 'a
+
 
 (** Manipulation of assumptions. *)
 
 (** The assumptions of a term [e] are the atoms and bound variables appearing in [e]. *)
 let rec assumptions_term ~lvl = function
 
-  | TermAtom (x, t) -> Assumption.add_free x t (assumptions_type ~lvl t)
+  | TermAtom {atom_name=x; atom_type=t} ->
+     Assumption.add_free x t (assumptions_type ~lvl t)
 
   | TermBound k ->
      if k < lvl then
@@ -75,33 +77,28 @@ and assumptions_eq_term ~lvl (EqTerm (asmp, e1, e2, t)) =
     (Assumption.union (assumptions_term ~lvl e1) (assumptions_term ~lvl e2))
 
 and assumptions_argument ~lvl = function
-  | ArgIsType abstr -> assumptions_abstraction assumptions_unit assumptions_type ~lvl abstr
-  | ArgIsTerm abstr -> assumptions_abstraction assumptions_unit assumptions_term ~lvl abstr
-  | ArgEqType abstr -> assumptions_abstraction assumptions_unit assumptions_assumptions ~lvl abstr
-  | ArgEqTerm abstr -> assumptions_abstraction assumptions_unit assumptions_assumptions ~lvl abstr
-
-and assumptions_unit ~lvl _ = Assumption.empty
+  | ArgIsType abstr -> assumptions_abstraction assumptions_type ~lvl abstr
+  | ArgIsTerm abstr -> assumptions_abstraction assumptions_term ~lvl abstr
+  | ArgEqType abstr -> assumptions_abstraction assumptions_assumptions ~lvl abstr
+  | ArgEqTerm abstr -> assumptions_abstraction assumptions_assumptions ~lvl abstr
 
 and assumptions_assumptions ~lvl asmp = Assumption.shift ~lvl asmp
 
 and assumptions_abstraction
-  : 'a 'b . (lvl:bound -> 'a -> assumption) ->
-            (lvl:bound -> 'b -> assumption) ->
-            lvl:bound -> ('a, 'b) abstraction -> assumption
- = fun asmp_u asmp_v ~lvl -> function
+  : 'a .(lvl:bound -> 'a -> assumption) ->
+        lvl:bound -> 'a abstraction -> assumption
+ = fun asmp_v ~lvl -> function
   | NotAbstract v -> asmp_v ~lvl v
   | Abstract (x, u, abstr) ->
      Assumption.union
-       (asmp_u ~lvl u)
-       (assumptions_abstraction asmp_u asmp_v ~lvl:(lvl+1) abstr)
+       (assumptions_type ~lvl u)
+       (assumptions_abstraction asmp_v ~lvl:(lvl+1) abstr)
 
 (* Helper functions *)
 
-let mk_atom x t = TermAtom (x, t)
-
-let fresh_atom x t =
+let mk_atom x t =
   let x = Name.fresh x in
-  mk_atom x t
+  { atom_name = x; atom_type = t }
 
 let mk_type_constructor c args = failwith "todo"
 
@@ -117,22 +114,21 @@ let mk_abstract x t abstr = Abstract (x, t, abstr)
 (** Instantiate *)
 
 let rec instantiate_abstraction
-  : 'a 'b . (term -> ?lvl:bound -> 'a -> 'a) ->
-            (term -> ?lvl:bound -> 'b -> 'b) ->
-            term -> ?lvl:bound -> ('a, 'b) abstraction -> ('a, 'b) abstraction
-  = fun inst_u inst_v e0 ?(lvl=0) ->
+  : 'a .(term -> ?lvl:bound -> 'a -> 'a) ->
+        term -> ?lvl:bound -> 'a abstraction -> 'a abstraction
+  = fun inst_v e0 ?(lvl=0) ->
   function
   | NotAbstract v ->
      let v = inst_v e0 ~lvl v in
      NotAbstract v
 
   | Abstract (x, u, abstr) ->
-     let u = inst_u e0 ~lvl u
-     and abstr = instantiate_abstraction inst_u inst_v e0 ~lvl:(lvl+1) abstr
+     let u = instantiate_type e0 ~lvl u
+     and abstr = instantiate_abstraction inst_v e0 ~lvl:(lvl+1) abstr
      in
      Abstract (x, u, abstr)
 
-let rec instantiate_term e0 ?(lvl=0) = function
+and instantiate_term e0 ?(lvl=0) = function
 
     | TermConstructor (c, args) ->
        let args = instantiate_arguments e0 ~lvl args in
@@ -166,19 +162,19 @@ and instantiate_arguments e0 ~lvl args =
 and instantiate_argument e0 ?(lvl=0) = function
 
     | ArgIsType t ->
-       let t = instantiate_abstraction instantiate_unit instantiate_type e0 ~lvl t in
+       let t = instantiate_abstraction instantiate_type e0 ~lvl t in
        ArgIsType t
 
     | ArgIsTerm e ->
-       let e = instantiate_abstraction instantiate_unit instantiate_term e0 ~lvl e in
+       let e = instantiate_abstraction instantiate_term e0 ~lvl e in
        ArgIsTerm e
 
     | ArgEqType asmp ->
-       let asmp = instantiate_abstraction instantiate_unit instantiate_assumptions e0 ~lvl asmp in
+       let asmp = instantiate_abstraction instantiate_assumptions e0 ~lvl asmp in
        ArgEqType asmp
 
     | ArgEqTerm asmp ->
-       let asmp = instantiate_abstraction instantiate_unit instantiate_assumptions e0 ~lvl asmp in
+       let asmp = instantiate_abstraction instantiate_assumptions e0 ~lvl asmp in
        ArgEqTerm asmp
 
 and instantiate_eq_type e0 ?(lvl=0) (EqType (asmp, t1, t2)) =
@@ -198,14 +194,12 @@ and instantiate_assumptions e0 ?(lvl=0) asmp =
   let asmp' = assumptions_term ~lvl e0 in
   Assumption.instantiate asmp' ~lvl asmp
 
-and instantiate_unit _ ?(lvl=0) () = ()
-
 (** Abstract *)
 
 let rec abstract_term x ?(lvl=0) = function
-  | (TermAtom (y, t)) as e ->
+  | (TermAtom {atom_name=y; atom_type=t}) as e ->
      begin match Name.eq_atom x y with
-     | false -> e
+     | false -> e (* XXX check that t does not depend on x !!! *)
      | true -> TermBound lvl
      end
 
@@ -237,16 +231,16 @@ and abstract_arguments x ?(lvl=0) args =
 
 and abstract_argument x ?(lvl=0) = function
 
-    | ArgIsType t -> ArgIsType (abstract_abstraction abstract_unit abstract_type x ~lvl t)
+    | ArgIsType t -> ArgIsType (abstract_abstraction abstract_type x ~lvl t)
 
-    | ArgIsTerm e -> ArgIsTerm (abstract_abstraction abstract_unit abstract_term x ~lvl e)
+    | ArgIsTerm e -> ArgIsTerm (abstract_abstraction abstract_term x ~lvl e)
 
     | ArgEqType asmp ->
-       let asmp = abstract_abstraction abstract_unit abstract_assumptions x ~lvl asmp in
+       let asmp = abstract_abstraction abstract_assumptions x ~lvl asmp in
        ArgEqType asmp
 
     | ArgEqTerm asmp ->
-       let asmp = abstract_abstraction abstract_unit abstract_assumptions x ~lvl asmp in
+       let asmp = abstract_abstraction abstract_assumptions x ~lvl asmp in
        ArgEqTerm asmp
 
 and abstract_assumptions x ?(lvl=0) asmp =
@@ -265,21 +259,18 @@ and abstract_eq_term x ?(lvl=0) (EqTerm (asmp, e1, e2, t)) =
   and t = abstract_type x ~lvl t
   in EqTerm (asmp, e1, e2, t)
 
-and abstract_unit _ ?(lvl=0) () = ()
-
 and abstract_abstraction
-  : 'a 'b . (Name.atom -> ?lvl:int -> 'a -> 'a) ->
-            (Name.atom -> ?lvl:int -> 'b -> 'b) ->
-            Name.atom -> ?lvl:int -> ('a, 'b) abstraction -> ('a, 'b) abstraction
-  = fun abstr_u abstr_v x ?(lvl=0) ->
+  : 'a .(Name.atom -> ?lvl:int -> 'a -> 'a) ->
+        Name.atom -> ?lvl:int -> 'a abstraction -> 'a abstraction
+  = fun abstr_v x ?(lvl=0) ->
   function
   | NotAbstract v ->
      let v = abstr_v x ~lvl v in
      NotAbstract v
 
   | Abstract (y, u, abstr) ->
-     let u = abstr_u x ~lvl u in
-     let abstr = abstract_abstraction abstr_u abstr_v x ~lvl:(lvl+1) abstr in
+     let u = abstract_type x ~lvl u in
+     let abstr = abstract_abstraction abstr_v x ~lvl:(lvl+1) abstr in
      Abstract (y, u, abstr)
 
 (** Substitute *)
@@ -306,10 +297,10 @@ and occurs_args k = function
   | arg :: args -> occurs_arg k arg || occurs_args k args
 
 and occurs_arg k = function
-  | ArgIsType t  -> occurs_abstraction occurs_unit occurs_type k t
-  | ArgIsTerm e  -> occurs_abstraction occurs_unit occurs_term k e
-  | ArgEqType abstr -> occurs_abstraction occurs_unit occurs_assumptions k abstr
-  | ArgEqTerm abstr -> occurs_abstraction occurs_unit occurs_assumptions k abstr
+  | ArgIsType t  -> occurs_abstraction occurs_type k t
+  | ArgIsTerm e  -> occurs_abstraction occurs_term k e
+  | ArgEqType abstr -> occurs_abstraction occurs_assumptions k abstr
+  | ArgEqTerm abstr -> occurs_abstraction occurs_assumptions k abstr
 
 and occurs_eq_type k (EqType (asmp, t1, t2)) =
   occurs_assumptions k asmp || occurs_type k t1 || occurs_type k t2
@@ -317,17 +308,13 @@ and occurs_eq_type k (EqType (asmp, t1, t2)) =
 and occurs_eq_term k (EqTerm (asmp, e1, e2, t)) =
   occurs_assumptions k asmp || occurs_term k e1 || occurs_term k e2 || occurs_type k t
 
-and occurs_unit _ _ = false
-
 and occurs_abstraction
-  : 'a 'b . (bound -> 'a -> bool) ->
-            (bound -> 'b -> bool) ->
-            bound -> ('a, 'b) abstraction -> bool
-  = fun occurs_u occurs_v k ->
+  : 'a . (bound -> 'a -> bool) -> bound -> 'a abstraction -> bool
+  = fun occurs_v k ->
   function
   | NotAbstract v -> occurs_v k v
   | Abstract (_, u, abstr) ->
-     occurs_u k u || occurs_abstraction occurs_u occurs_v (k+1) abstr
+     occurs_type k u || occurs_abstraction occurs_v (k+1) abstr
 
 and occurs_assumptions k asmp =
   Assumption.mem_bound k asmp
@@ -338,7 +325,7 @@ let rec alpha_equal e1 e2 =
   e1 == e2 || (* a shortcut in case the terms are identical *)
   begin match e1, e2 with
 
-    | TermAtom (x, _), TermAtom (y, _) -> Name.eq_atom x y
+    | TermAtom {atom_name=x;_}, TermAtom {atom_name=y;_} -> Name.eq_atom x y
 
     | TermBound i, TermBound j -> i = j
 
@@ -352,7 +339,7 @@ let rec alpha_equal e1 e2 =
       false
   end
 
-and alpha_equal_ty t1 t2 =
+and alpha_equal_type t1 t2 =
   match t1, t2 with
   | TypeConstructor (c, args), TypeConstructor (c', args') ->
      Name.eq_ident c c' && alpha_equal_args args args'
@@ -363,10 +350,10 @@ and alpha_equal_args args args' =
   | [], [] -> true
 
   | (ArgIsTerm e)::args, (ArgIsTerm e')::args' ->
-     alpha_equal_abstraction alpha_equal_unit alpha_equal e e' && alpha_equal_args args args'
+     alpha_equal_abstraction alpha_equal e e' && alpha_equal_args args args'
 
   | (ArgIsType t)::args, (ArgIsType t')::args' ->
-     alpha_equal_abstraction alpha_equal_unit alpha_equal_ty t t' && alpha_equal_args args args'
+     alpha_equal_abstraction alpha_equal_ty t t' && alpha_equal_args args args'
 
   | ArgEqType _ :: args, ArgEqType _ :: args' -> alpha_equal_args args args'
 
@@ -382,19 +369,15 @@ and alpha_equal_args args args' =
         with that *)
      assert false
 
-and alpha_equal_unit () () = true
-
 and alpha_equal_abstraction
-  : 'a 'b . ('a -> 'a -> bool) ->
-            ('b -> 'b -> bool) ->
-            ('a, 'b) abstraction -> ('a, 'b) abstraction -> bool
-  = fun equal_u equal_v e e' ->
+  : 'a .('a -> 'a -> bool) -> 'a abstraction -> 'a abstraction -> bool
+  = fun equal_v e e' ->
   e == e' ||
   match e, e' with
 
   | Abstract (_, u, abstr), Abstract(_, u', abstr') ->
-     equal_u u u' &&
-     alpha_equal_abstraction equal_u equal_v abstr abstr'
+     alpha_equal_type u u' &&
+     alpha_equal_abstraction equal_v abstr abstr'
 
   | NotAbstract v, NotAbstract v' -> equal_v v v'
 
@@ -407,29 +390,25 @@ type print_env =
 
 let add_forbidden x penv = { penv with forbidden = x :: penv.forbidden }
 
-(** [print_abstraction occurs_u print_xu occurs_v print_v ?max_level ~penv abstr
-   ppf] prints an abstraction using formatter [ppf]. *)
-let print_abstraction
-   : 'a 'b . (bound -> 'a -> bool) ->
-             (penv:print_env -> Name.ident * 'a -> Format.formatter -> unit) ->
-             (bound -> 'b -> bool) ->
-             (?max_level:Level.t -> penv:print_env -> 'b -> Format.formatter -> unit) ->
-             ?max_level:Level.t ->
-             penv:print_env ->
-             ('a, 'b) abstraction ->
-             Format.formatter -> unit
-  = fun occurs_u print_xu occurs_v print_v ?max_level ~penv abstr ppf ->
+let rec print_abstraction
+   : 'b . (bound -> 'b -> bool) ->
+          (?max_level:Level.t -> penv:print_env -> 'b -> Format.formatter -> unit) ->
+          ?max_level:Level.t ->
+          penv:print_env ->
+          'b abstraction ->
+          Format.formatter -> unit
+  = fun occurs_v print_v ?max_level ~penv abstr ppf ->
   let rec fold penv xus = function
 
     | NotAbstract v ->
        let xus = List.rev xus in
        Print.print ?max_level ppf ~at_level:Level.binder "@[<hov 2>%t@ %t@]"
-              (Print.sequence (print_xu ~penv) "" xus)
+              (Print.sequence (print_binder ~penv) "" xus)
               (print_v ~penv v)
 
     | Abstract (x, u, abstr) ->
        let x =
-         (if occurs_abstraction occurs_u occurs_v 0 abstr then
+         (if occurs_abstraction occurs_v 0 abstr then
             Name.refresh penv.forbidden x
           else
             Name.anonymous ())
@@ -441,9 +420,9 @@ let print_abstraction
 
   fold penv [] abstr
 
-let rec print_term ?max_level ~penv e ppf =
+and print_term ?max_level ~penv e ppf =
   match e with
-  | TermAtom (x, _) ->
+  | TermAtom {atom_name=x; _} ->
      Name.print_atom ~printer:(penv.atoms) x ppf
 
   | TermBound k -> Name.print_debruijn penv.forbidden k ppf
@@ -468,22 +447,16 @@ and print_constructor ?max_level ~penv c args ppf =
 
 and print_arg ~penv arg ppf =
   match arg with
-  | ArgIsTerm abstr -> print_argument_abstraction occurs_term print_term ~penv abstr ppf
-  | ArgIsType abstr -> print_argument_abstraction occurs_type print_type ~penv abstr ppf
+  | ArgIsTerm abstr -> print_abstraction occurs_term print_term ~penv abstr ppf
+  | ArgIsType abstr -> print_abstraction occurs_type print_type ~penv abstr ppf
   | ArgEqType _ -> ()
   | ArgEqTerm _ -> ()
 
-and print_argument_abstraction
-  : 'a . (bound -> 'a -> bool) ->
-         (?max_level:Level.t -> penv:print_env -> 'a -> Format.formatter -> unit) ->
-         penv:print_env -> 'a argument_abstraction -> Format.formatter -> unit
-  = fun occurs_v print_v ~penv abstr ppf ->
-  print_abstraction
-    occurs_unit
-    (fun ~penv (x, ()) ppf -> Print.print ppf "%t" (Name.print_ident ~parentheses:true x))
-    occurs_v
-    print_v
-    ~max_level:Level.app_right ~penv abstr ppf
+and print_binder ~penv (x,t) ppf =
+  Print.print ppf "(%t@ :@ %t)"
+    (Name.print_ident ~parentheses:true x)
+    (print_type ~penv t)
+
 
 (** Conversion to JSON *)
 
@@ -493,7 +466,7 @@ struct
   let rec term e =
     match e with
 
-      | TermAtom (x, t) -> Json.tag "TermAtom" [Name.Json.atom x; ty t]
+      | TermAtom {atom_name=x; atom_type=t} -> Json.tag "TermAtom" [Name.Json.atom x; ty t]
 
       | TermBound b -> Json.tag "TermBound" [Json.Int b]
 
@@ -513,12 +486,12 @@ struct
         | ArgEqTerm _ -> Json.tag "ArgEqTerm" [])
        lst)
 
-  and abstraction : 'a . ('a -> Json.t) -> Name.ident list -> (unit, 'a) abstraction -> Json.t list =
-    fun json_u xs ->
+  and abstraction : 'a . ('a -> Json.t) -> (Name.ident * ty) list -> 'a abstraction -> Json.t list =
+    fun json_u xts ->
     function
-    | Abstract (x, (), abstr) ->
-       abstraction json_u (x::xs) abstr
+    | Abstract (x, t, abstr) ->
+       abstraction json_u ((x,t) :: xts) abstr
     | NotAbstract u ->
-       let xs = List.map Name.Json.ident (List.rev xs) in
-       [Json.tuple xs ; json_u u]
+       let xts = List.map (fun (x, t) -> Json.List [Name.Json.ident x; ty t])  (List.rev xts) in
+       [Json.tuple xts ; json_u u]
 end

--- a/src/nucleus/TT.ml
+++ b/src/nucleus/TT.ml
@@ -96,6 +96,8 @@ and assumptions_abstraction
        (assumptions_type ~lvl u)
        (assumptions_abstraction asmp_v ~lvl:(lvl+1) abstr)
 
+let assumptions_arguments = assumptions_arguments ~lvl:0
+
 (* Helper functions *)
 
 let fresh_atom x t =

--- a/src/nucleus/TT.ml
+++ b/src/nucleus/TT.ml
@@ -619,7 +619,7 @@ and print_arg ~penv arg ppf =
   match arg with
   | ArgIsTerm abstr -> print_abstraction occurs_term print_term ~penv abstr ppf
   | ArgIsType abstr -> print_abstraction occurs_type print_type ~penv abstr ppf
-  | ArgEqType _ -> ()
+  | ArgEqType _ -> () (* XXX should we print something to indicate the argument is there? *)
   | ArgEqTerm _ -> ()
 
 and print_binder ~penv (x,t) ppf =

--- a/src/nucleus/TT.ml
+++ b/src/nucleus/TT.ml
@@ -543,6 +543,7 @@ and alpha_equal_abstraction
   : 'a .('a -> 'a -> bool) -> 'a abstraction -> 'a abstraction -> bool
   = fun equal_v e e' ->
   e == e' ||
+  (* XXX try e = e' ? *)
   match e, e' with
 
   | Abstract (_, u, abstr), Abstract(_, u', abstr') ->

--- a/src/nucleus/TT.ml
+++ b/src/nucleus/TT.ml
@@ -33,7 +33,6 @@ and argument =
   | ArgEqType of eq_type argument_abstraction
   | ArgEqTerm of eq_term argument_abstraction
 
-
 (** Manipulation of assumptions. *)
 
 (** The assumptions of a term [e] are the atoms and bound variables appearing in [e]. *)
@@ -92,15 +91,11 @@ and assumptions_abstraction
 
 (* Helper functions *)
 
-(* let ty_hyps {Location.thing={assumptions=a;_};_} = a
- *
- * let rec hyp_union acc = function
- *   | [] -> acc
- *   | x::rem -> hyp_union (Assumption.union acc x) rem *)
+let mk_atom x t = TermAtom (x, t)
 
-let mk_atom x t =
+let fresh_atom x t =
   let x = Name.fresh x in
-  TermAtom (x, t)
+  mk_atom x t
 
 let mk_type_constructor c args = failwith "todo"
 

--- a/src/nucleus/TT.ml
+++ b/src/nucleus/TT.ml
@@ -2,41 +2,46 @@
 
 type bound = int
 
+(** An abstracted entity. Note that abstractions only ever appear as arguments
+   to constructors. Thus we do not carry any type information for the abstracted
+   variable, as it can be recovered from the constructor. *)
+type ('a, 'b) abstraction =
+  | Abstract of Name.ident * 'a * ('a,'b) abstraction
+  | NotAbstract of 'b
+
+type 'a argument_abstraction = (unit, 'a) abstraction
+
 type term =
-  | Atom of Name.atom
-  | Bound of bound
+  | TermAtom of Name.atom * ty
+  | TermBound of bound
   | TermConstructor of Name.constructor * argument list
-  | TermConvert of term * Assumption.t * ty
+  | TermConvert of term * assumption * ty
 
 and ty =
   | TypeConstructor of Name.constructor * argument list
 
-and eq_type = EqType of Assumption.t
+and eq_type = EqType of assumption
 
-and eq_term = EqTerm of Assumption.t
+and eq_term = EqTerm of assumption
+
+and assumption = ty Assumption.t
 
 (** An argument of a term or a type constructor *)
 and argument =
-  | ArgIsTerm of term abstraction
-  | ArgIsType of ty abstraction
-  | ArgEqType of eq_type abstraction
-  | ArgEqTerm of eq_term abstraction
+  | ArgIsTerm of term argument_abstraction
+  | ArgIsType of ty argument_abstraction
+  | ArgEqType of eq_type argument_abstraction
+  | ArgEqTerm of eq_term argument_abstraction
 
-(** An abstracted entity. Note that abstractions only ever appear as arguments
-   to constructors. Thus we do not carry any type information for the abstracted
-   variable, as it can be recovered from the constructor. *)
-and 'a abstraction =
-  | Abstract of Name.ident * 'a abstraction
-  | NotAbstract of 'a
 
 (** Manipulation of assumptions. *)
 
 (** The assumptions of a term [e] are the atoms and bound variables appearing in [e]. *)
 let rec assumptions_term ~lvl = function
 
-  | Atom x -> Assumption.singleton_free x
+  | TermAtom (x, t) -> Assumption.add_free x t (assumptions_type ~lvl t)
 
-  | Bound k ->
+  | TermBound k ->
      if k < lvl then
        Assumption.empty
      else
@@ -67,16 +72,23 @@ and assumptions_eq_term ~lvl (EqTerm asmp) =
   Assumption.shift lvl asmp
 
 and assumptions_argument ~lvl = function
-  | ArgIsType abstr -> assumptions_abstraction assumptions_type ~lvl abstr
-  | ArgIsTerm abstr -> assumptions_abstraction assumptions_term ~lvl abstr
-  | ArgEqType asmp -> assumptions_abstraction assumptions_eq_type ~lvl asmp
-  | ArgEqTerm asmp -> assumptions_abstraction assumptions_eq_term ~lvl asmp
+  | ArgIsType abstr -> assumptions_abstraction assumptions_unit assumptions_type ~lvl abstr
+  | ArgIsTerm abstr -> assumptions_abstraction assumptions_unit assumptions_term ~lvl abstr
+  | ArgEqType asmp -> assumptions_abstraction assumptions_unit assumptions_eq_type ~lvl asmp
+  | ArgEqTerm asmp -> assumptions_abstraction assumptions_unit assumptions_eq_term ~lvl asmp
+
+and assumptions_unit ~lvl _ = Assumption.empty
 
 and assumptions_abstraction
- : 'a . (lvl:bound -> 'a -> Assumption.t) -> lvl:bound -> 'a abstraction -> Assumption.t
- = fun assumptions_u ~lvl -> function
-  | NotAbstract u -> assumptions_u ~lvl u
-  | Abstract (_, abstr) -> assumptions_abstraction assumptions_u ~lvl:(lvl+1) abstr
+  : 'a 'b . (lvl:bound -> 'a -> assumption) ->
+            (lvl:bound -> 'b -> assumption) ->
+            lvl:bound -> ('a, 'b) abstraction -> assumption
+ = fun asmp_u asmp_v ~lvl -> function
+  | NotAbstract v -> asmp_v ~lvl v
+  | Abstract (x, u, abstr) ->
+     Assumption.union
+       (asmp_u ~lvl u)
+       (assumptions_abstraction asmp_u asmp_v ~lvl:(lvl+1) abstr)
 
 (* Helper functions *)
 
@@ -86,7 +98,9 @@ and assumptions_abstraction
  *   | [] -> acc
  *   | x::rem -> hyp_union (Assumption.union acc x) rem *)
 
-let mk_atom x = Atom x
+let mk_atom x t =
+  let x = Name.fresh x in
+  TermAtom (x, t)
 
 let mk_type_constructor c args = failwith "todo"
 
@@ -97,11 +111,27 @@ let mk_arg_eq_term s = ArgEqTerm s
 
 let mk_not_abstract e = NotAbstract e
 
-let mk_abstract x abstr = Abstract (x, abstr)
+let mk_abstract x t abstr = Abstract (x, t, abstr)
 
 (** Instantiate *)
 
-let rec instantiate_term e0 ~lvl = function
+let rec instantiate_abstraction
+  : 'a 'b . (term -> ?lvl:bound -> 'a -> 'a) ->
+            (term -> ?lvl:bound -> 'b -> 'b) ->
+            term -> ?lvl:bound -> ('a, 'b) abstraction -> ('a, 'b) abstraction
+  = fun inst_u inst_v e0 ?(lvl=0) ->
+  function
+  | NotAbstract v ->
+     let v = inst_v e0 ~lvl v in
+     NotAbstract v
+
+  | Abstract (x, u, abstr) ->
+     let u = inst_u e0 ~lvl u
+     and abstr = instantiate_abstraction inst_u inst_v e0 ~lvl:(lvl+1) abstr
+     in
+     Abstract (x, u, abstr)
+
+let rec instantiate_term e0 ?(lvl=0) = function
 
     | TermConstructor (c, args) ->
        let args = instantiate_arguments e0 ~lvl args in
@@ -113,18 +143,18 @@ let rec instantiate_term e0 ~lvl = function
        and t = instantiate_type e0 ~lvl t in
        TermConvert (e, asmp, t)
 
-    | Atom _ as e -> e
+    | TermAtom _ as e -> e
 
-    | Bound k as e ->
+    | TermBound k as e ->
        if k < lvl then
          e
        else
          if k = lvl then
            e0
          else
-           Bound (k - 1)
+           TermBound (k - 1)
 
-and instantiate_type e0 ~lvl = function
+and instantiate_type e0 ?(lvl=0) = function
   | TypeConstructor (c, args) ->
      let args = instantiate_arguments e0 ~lvl args in
      TypeConstructor (c, args)
@@ -132,68 +162,48 @@ and instantiate_type e0 ~lvl = function
 and instantiate_arguments e0 ~lvl args =
   List.map (instantiate_argument e0 ~lvl) args
 
-and instantiate_argument e0 ~lvl = function
+and instantiate_argument e0 ?(lvl=0) = function
 
     | ArgIsType t ->
-       let t = instantiate_abstraction instantiate_type e0 ~lvl t in
+       let t = instantiate_abstraction instantiate_unit instantiate_type e0 ~lvl t in
        ArgIsType t
 
     | ArgIsTerm e ->
-       let e = instantiate_abstraction instantiate_term e0 ~lvl e in
+       let e = instantiate_abstraction instantiate_unit instantiate_term e0 ~lvl e in
        ArgIsTerm e
 
     | ArgEqType asmp ->
-       let asmp = instantiate_abstraction instantiate_eq_type e0 ~lvl asmp in
+       let asmp = instantiate_abstraction instantiate_unit instantiate_eq_type e0 ~lvl asmp in
        ArgEqType asmp
 
     | ArgEqTerm asmp ->
-       let asmp = instantiate_abstraction instantiate_eq_term e0 ~lvl asmp in
+       let asmp = instantiate_abstraction instantiate_unit instantiate_eq_term e0 ~lvl asmp in
        ArgEqTerm asmp
 
-and instantiate_eq_type e0 ~lvl (EqType asmp) =
+and instantiate_eq_type e0 ?(lvl=0) (EqType asmp) =
   let asmp = assumptions_term ~lvl e0 in
   EqType asmp
 
-and instantiate_eq_term e0 ~lvl (EqTerm asmp) =
+and instantiate_eq_term e0 ?(lvl=0) (EqTerm asmp) =
   let asmp = assumptions_term ~lvl e0 in
   EqTerm asmp
 
-and instantiate_assumptions e0 ~lvl asmp =
+and instantiate_assumptions e0 ?(lvl=0) asmp =
   let asmp' = assumptions_term ~lvl e0 in
   Assumption.instantiate asmp' ~lvl asmp
 
-and instantiate_abstraction :
-      'a . (term -> lvl:bound -> 'a -> 'a) -> term ->
-           lvl:bound -> 'a abstraction -> 'a abstraction =
-  fun inst_u e0 ~lvl ->
-  function
-  | NotAbstract u ->
-     let u = inst_u e0 ~lvl u in
-     NotAbstract u
-
-  | Abstract (x, abstr) ->
-     let e0 = e0 (* XXX shift e0 by 1 *) in
-     let abstr = instantiate_abstraction inst_u e0 ~lvl:(lvl+1) abstr in
-     Abstract (x, abstr)
-
-let unabstract_term x ~lvl e =
-  let e0 = mk_atom x in
-  instantiate_term e0 ~lvl e
-
-let unabstract_type x ~lvl t =
-  let e0 = mk_atom x in
-  instantiate_type e0 ~lvl t
+and instantiate_unit _ ?(lvl=0) () = ()
 
 (** Abstract *)
 
-let rec abstract_term x ~lvl = function
-  | (Atom y) as e ->
+let rec abstract_term x ?(lvl=0) = function
+  | (TermAtom (y, t)) as e ->
      begin match Name.eq_atom x y with
      | false -> e
-     | true -> Bound lvl
+     | true -> TermBound lvl
      end
 
-  | Bound k as e ->
+  | TermBound k as e ->
      if k < lvl then
        e
      else
@@ -211,61 +221,66 @@ let rec abstract_term x ~lvl = function
      and t = abstract_type x ~lvl t in
      TermConvert (c, asmp, t)
 
-and abstract_type x ~lvl = function
+and abstract_type x ?(lvl=0) = function
   | TypeConstructor (c, args) ->
      let args = abstract_arguments x ~lvl args in
      TypeConstructor (c, args)
 
-and abstract_arguments x ~lvl args =
+and abstract_arguments x ?(lvl=0) args =
   List.map (abstract_argument x ~lvl) args
 
-and abstract_argument x ~lvl = function
+and abstract_argument x ?(lvl=0) = function
 
-    | ArgIsType t -> ArgIsType (abstract_abstraction abstract_type x ~lvl t)
+    | ArgIsType t -> ArgIsType (abstract_abstraction abstract_unit abstract_type x ~lvl t)
 
-    | ArgIsTerm e -> ArgIsTerm (abstract_abstraction abstract_term x ~lvl e)
+    | ArgIsTerm e -> ArgIsTerm (abstract_abstraction abstract_unit abstract_term x ~lvl e)
 
     | ArgEqType asmp ->
-       let asmp = abstract_abstraction abstract_eq_type x ~lvl asmp in
+       let asmp = abstract_abstraction abstract_unit abstract_eq_type x ~lvl asmp in
        ArgEqType asmp
 
     | ArgEqTerm asmp ->
-       let asmp = abstract_abstraction abstract_eq_term x ~lvl asmp in
+       let asmp = abstract_abstraction abstract_unit abstract_eq_term x ~lvl asmp in
        ArgEqTerm asmp
 
-and abstract_eq_type x ~lvl (EqType asmp) =
+and abstract_eq_type x ?(lvl=0) (EqType asmp) =
   let asmp = Assumption.abstract x ~lvl asmp in
   EqType asmp
 
-and abstract_eq_term x ~lvl (EqTerm asmp) =
+and abstract_eq_term x ?(lvl=0) (EqTerm asmp) =
   let asmp = Assumption.abstract x ~lvl asmp in
   EqTerm asmp
 
-and abstract_abstraction :
-      'a . (Name.atom -> lvl:int -> 'a -> 'a) -> Name.atom -> lvl:int -> 'a abstraction -> 'a abstraction =
-  fun inst_u x ~lvl ->
-  function
-  | NotAbstract u ->
-     let u = inst_u x ~lvl u in
-     NotAbstract u
+and abstract_unit _ ?(lvl=0) () = ()
 
-  | Abstract (y, abstr) ->
-     let abstr = abstract_abstraction inst_u x ~lvl:(lvl+1) abstr in
-     Abstract (y, abstr)
+and abstract_abstraction
+  : 'a 'b . (Name.atom -> ?lvl:int -> 'a -> 'a) ->
+            (Name.atom -> ?lvl:int -> 'b -> 'b) ->
+            Name.atom -> ?lvl:int -> ('a, 'b) abstraction -> ('a, 'b) abstraction
+  = fun abstr_u abstr_v x ?(lvl=0) ->
+  function
+  | NotAbstract v ->
+     let v = abstr_v x ~lvl v in
+     NotAbstract v
+
+  | Abstract (y, u, abstr) ->
+     let u = abstr_u x ~lvl u in
+     let abstr = abstract_abstraction abstr_u abstr_v x ~lvl:(lvl+1) abstr in
+     Abstract (y, u, abstr)
 
 (** Substitute *)
 let substitute_term x e0 e =
-  let e = abstract_term x ~lvl:0 e in
-  instantiate_term e0 ~lvl:0 e
+  let e = abstract_term x e in
+  instantiate_term e0 e
 
 let substitute_type x e0 t =
-  let t = abstract_type x ~lvl:0 t in
-  instantiate_type e0 ~lvl:0 t
+  let t = abstract_type x t in
+  instantiate_type e0 t
 
 (* Does the bound variable [k] occur in an expression? Used only for printing. *)
 let rec occurs_term k = function
-  | Atom _ -> false
-  | Bound m -> k = m
+  | TermAtom _ -> false
+  | TermBound m -> k = m
   | TermConstructor (_, args) -> occurs_args k args
   | TermConvert (e, asmp, t) -> occurs_term k e || occurs_assumptions k asmp || occurs_type k t
 
@@ -277,20 +292,26 @@ and occurs_args k = function
   | arg :: args -> occurs_arg k arg || occurs_args k args
 
 and occurs_arg k = function
-  | ArgIsType t  -> occurs_abstraction occurs_type k t
-  | ArgIsTerm e  -> occurs_abstraction occurs_term k e
-  | ArgEqType abstr -> occurs_abstraction occurs_eq_type k abstr
-  | ArgEqTerm abstr -> occurs_abstraction occurs_eq_term k abstr
+  | ArgIsType t  -> occurs_abstraction occurs_unit occurs_type k t
+  | ArgIsTerm e  -> occurs_abstraction occurs_unit occurs_term k e
+  | ArgEqType abstr -> occurs_abstraction occurs_unit occurs_eq_type k abstr
+  | ArgEqTerm abstr -> occurs_abstraction occurs_unit occurs_eq_term k abstr
 
 and occurs_eq_type k (EqType asmp) = occurs_assumptions k asmp
 
 and occurs_eq_term k (EqTerm asmp) = occurs_assumptions k asmp
 
-and occurs_abstraction : 'a . (bound -> 'a -> bool) -> bound -> 'a abstraction -> bool =
-  fun occurs_u k ->
+and occurs_unit _ _ = false
+
+and occurs_abstraction
+  : 'a 'b . (bound -> 'a -> bool) ->
+            (bound -> 'b -> bool) ->
+            bound -> ('a, 'b) abstraction -> bool
+  = fun occurs_u occurs_v k ->
   function
-  | NotAbstract u -> occurs_u k u
-  | Abstract (_, abstr) -> occurs_abstraction occurs_u (k+1) abstr
+  | NotAbstract v -> occurs_v k v
+  | Abstract (_, u, abstr) ->
+     occurs_u k u || occurs_abstraction occurs_u occurs_v (k+1) abstr
 
 and occurs_assumptions k asmp =
   Assumption.mem_bound k asmp
@@ -301,9 +322,9 @@ let rec alpha_equal e1 e2 =
   e1 == e2 || (* a shortcut in case the terms are identical *)
   begin match e1, e2 with
 
-    | Atom x, Atom y -> Name.eq_atom x y
+    | TermAtom (x, _), TermAtom (y, _) -> Name.eq_atom x y
 
-    | Bound i, Bound j -> i = j
+    | TermBound i, TermBound j -> i = j
 
     | TermConstructor (c, args), TermConstructor (c', args') ->
        Name.eq_ident c c' && alpha_equal_args args args'
@@ -311,7 +332,7 @@ let rec alpha_equal e1 e2 =
     | TermConvert (e1, _, _), TermConvert (e2, _, _) ->
        alpha_equal e1 e2
 
-    | (Atom _ | Bound _ | TermConstructor _  | TermConvert _), _ ->
+    | (TermAtom _ | TermBound _ | TermConstructor _  | TermConvert _), _ ->
       false
   end
 
@@ -322,24 +343,45 @@ and alpha_equal_ty t1 t2 =
 
 and alpha_equal_args args args' =
   match args, args' with
+
   | [], [] -> true
-  | (ArgIsTerm e)::args, (ArgIsTerm e')::args' -> alpha_equal_abstraction alpha_equal e e' && alpha_equal_args args args'
-  | (ArgIsType t)::args, (ArgIsType t')::args' -> alpha_equal_abstraction alpha_equal_ty t t' && alpha_equal_args args args'
+
+  | (ArgIsTerm e)::args, (ArgIsTerm e')::args' ->
+     alpha_equal_abstraction alpha_equal_unit alpha_equal e e' && alpha_equal_args args args'
+
+  | (ArgIsType t)::args, (ArgIsType t')::args' ->
+     alpha_equal_abstraction alpha_equal_unit alpha_equal_ty t t' && alpha_equal_args args args'
+
   | ArgEqType _ :: args, ArgEqType _ :: args' -> alpha_equal_args args args'
+
   | ArgEqTerm _ :: args, ArgEqTerm _ :: args' -> alpha_equal_args args args'
+
   | (ArgIsTerm _ | ArgIsType _ | ArgEqType _ | ArgEqTerm _)::_, _::_
+
   | (_::_), []
+
   | [], (_::_) ->
      (* we should never get here, because that implies that a constructor
         was applied in two different ways, and somehow the nucleus was happy
         with that *)
      assert false
 
-and alpha_equal_abstraction : 'a . ('a -> 'a -> bool) -> 'a abstraction -> 'a abstraction -> bool =
-  fun equal_u u u' ->
-  match u, u' with
-  | Abstract (_, abstr), Abstract(_, abstr') -> alpha_equal_abstraction equal_u abstr abstr'
-  | NotAbstract u, NotAbstract u' -> equal_u u u'
+and alpha_equal_unit () () = true
+
+and alpha_equal_abstraction
+  : 'a 'b . ('a -> 'a -> bool) ->
+            ('b -> 'b -> bool) ->
+            ('a, 'b) abstraction -> ('a, 'b) abstraction -> bool
+  = fun equal_u equal_v e e' ->
+  e == e' ||
+  match e, e' with
+
+  | Abstract (_, u, abstr), Abstract(_, u', abstr') ->
+     equal_u u u' &&
+     alpha_equal_abstraction equal_u equal_v abstr abstr'
+
+  | NotAbstract v, NotAbstract v' -> equal_v v v'
+
   | (Abstract _ | NotAbstract _), _ -> false
 
 (****** Printing routines *****)
@@ -349,12 +391,46 @@ type print_env =
 
 let add_forbidden x penv = { penv with forbidden = x :: penv.forbidden }
 
+(** [print_abstraction occurs_u print_xu occurs_v print_v ?max_level ~penv abstr
+   ppf] prints an abstraction using formatter [ppf]. *)
+let print_abstraction
+   : 'a 'b . (bound -> 'a -> bool) ->
+             (penv:print_env -> Name.ident * 'a -> Format.formatter -> unit) ->
+             (bound -> 'b -> bool) ->
+             (?max_level:Level.t -> penv:print_env -> 'b -> Format.formatter -> unit) ->
+             ?max_level:Level.t ->
+             penv:print_env ->
+             ('a, 'b) abstraction ->
+             Format.formatter -> unit
+  = fun occurs_u print_xu occurs_v print_v ?max_level ~penv abstr ppf ->
+  let rec fold penv xus = function
+
+    | NotAbstract v ->
+       let xus = List.rev xus in
+       Print.print ?max_level ppf ~at_level:Level.binder "@[<hov 2>%t@ %t@]"
+              (Print.sequence (print_xu ~penv) "" xus)
+              (print_v ~penv v)
+
+    | Abstract (x, u, abstr) ->
+       let x =
+         (if occurs_abstraction occurs_u occurs_v 0 abstr then
+            Name.refresh penv.forbidden x
+          else
+            Name.anonymous ())
+       in
+       let penv = add_forbidden x penv in
+       fold penv ((x,u) :: xus) abstr
+
+  in
+
+  fold penv [] abstr
+
 let rec print_term ?max_level ~penv e ppf =
   match e with
-  | Atom x ->
+  | TermAtom (x, _) ->
      Name.print_atom ~printer:(penv.atoms) x ppf
 
-  | Bound k -> Name.print_debruijn penv.forbidden k ppf
+  | TermBound k -> Name.print_debruijn penv.forbidden k ppf
 
   | TermConstructor (c, args) ->
      print_constructor ?max_level ~penv c args ppf
@@ -376,34 +452,22 @@ and print_constructor ?max_level ~penv c args ppf =
 
 and print_arg ~penv arg ppf =
   match arg with
-  | ArgIsTerm abstr -> print_abstraction occurs_term print_term ~max_level:Level.app_right ~penv abstr ppf
-  | ArgIsType abstr -> print_abstraction occurs_type print_type ~max_level:Level.app_right ~penv abstr ppf
+  | ArgIsTerm abstr -> print_argument_abstraction occurs_term print_term ~penv abstr ppf
+  | ArgIsType abstr -> print_argument_abstraction occurs_type print_type ~penv abstr ppf
   | ArgEqType _ -> ()
   | ArgEqTerm _ -> ()
 
-(** [print_abstraction occurs_u print_u ?max_level ~penv abstr ppf] prints an abstraction using formatter [ppf]. *)
-and print_abstraction :
-      'a . (int -> 'a -> bool) ->
-           (?max_level:Level.t -> penv:print_env -> 'a -> Format.formatter -> unit) ->
-           ?max_level:Level.t ->
-           penv:print_env ->
-           'a abstraction ->
-           Format.formatter -> unit =
-  fun occurs_u print_u ?max_level ~penv abstr ppf ->
-  let rec fold penv xs = function
-
-    | NotAbstract e ->
-       let xs = List.rev xs in
-       Print.print ?max_level ppf ~at_level:Level.binder "@[<hov 2>{%t}@ %t@]"
-              (Print.sequence (Name.print_ident ~parentheses:true) "" xs)
-              (print_u ~penv e)
-
-    | Abstract (x, abstr) ->
-       let x = (if occurs_abstraction occurs_u 0 abstr then Name.refresh penv.forbidden x else Name.anonymous ()) in
-       let penv = add_forbidden x penv in
-       fold penv (x :: xs) abstr
-  in
-  fold penv [] abstr
+and print_argument_abstraction
+  : 'a . (bound -> 'a -> bool) ->
+         (?max_level:Level.t -> penv:print_env -> 'a -> Format.formatter -> unit) ->
+         penv:print_env -> 'a argument_abstraction -> Format.formatter -> unit
+  = fun occurs_v print_v ~penv abstr ppf ->
+  print_abstraction
+    occurs_unit
+    (fun ~penv (x, ()) ppf -> Print.print ppf "%t" (Name.print_ident ~parentheses:true x))
+    occurs_v
+    print_v
+    ~max_level:Level.app_right ~penv abstr ppf
 
 (** Conversion to JSON *)
 
@@ -413,9 +477,9 @@ struct
   let rec term e =
     match e with
 
-      | Atom a -> Json.tag "Atom" [Name.Json.atom a]
+      | TermAtom (x, t) -> Json.tag "TermAtom" [Name.Json.atom x; ty t]
 
-      | Bound b -> Json.tag "Bound" [Json.Int b]
+      | TermBound b -> Json.tag "TermBound" [Json.Int b]
 
       | TermConstructor (c, lst) -> Json.tag "TermConstructor" (Name.Json.ident c :: args lst)
 
@@ -433,10 +497,10 @@ struct
         | ArgEqTerm _ -> Json.tag "ArgEqTerm" [])
        lst)
 
-  and abstraction : 'a . ('a -> Json.t) -> Name.ident list -> 'a abstraction -> Json.t list =
+  and abstraction : 'a . ('a -> Json.t) -> Name.ident list -> (unit, 'a) abstraction -> Json.t list =
     fun json_u xs ->
     function
-    | Abstract (x, abstr) ->
+    | Abstract (x, (), abstr) ->
        abstraction json_u (x::xs) abstr
     | NotAbstract u ->
        let xs = List.map Name.Json.ident (List.rev xs) in

--- a/src/nucleus/TT.mli
+++ b/src/nucleus/TT.mli
@@ -94,6 +94,14 @@ val instantiate_term: term -> ?lvl:bound -> term -> term
 (** [instantiate_term e0 ~lvl:k t] replaces bound variable [k] (default [0]) with term [e0] in type [t]. *)
 val instantiate_type: term -> ?lvl:bound -> ty -> ty
 
+(** [instantiate_eq_type e0 ~lvl:k eq] replaces bound variable [k] (default [0])
+   with term [e0] in equation [eq]. *)
+val instantiate_eq_type : term -> ?lvl:bound -> eq_type -> eq_type
+
+(** [instantiate_eq_term e0 ~lvl:k eq] replaces bound variable [k] (default [0])
+   with term [e0] in equation [eq]. *)
+val instantiate_eq_term : term -> ?lvl:bound -> eq_term -> eq_term
+
 (** [instantiate_abstraction inst_u e0 ~lvl:k abstr] instantiates bound variable [k]
    (default [0]) with term [e0] in the given abstraction. *)
 val instantiate_abstraction :
@@ -110,11 +118,44 @@ val fully_instantiate_type : ?lvl:bound -> term list -> ty -> ty
 (** [fully_instantiate_term ~lvl:k es e] fully instantiates term [e] with the given [es]. All bound variables are eliminated. *)
 val fully_instantiate_term : ?lvl:bound -> term list -> term -> term
 
-(** [abstract_term x0 ~lvl:k e] replaces atom [x0] in term [e] with bound variable [k] (default [0]). *)
-val abstract_term : Name.atom -> ?lvl:bound -> term -> term
+(** [unabstract_type x t1 t2] instantiates bound variable [0] in [t2] with a fresh atom of type [t1].
+    The freshly generated atom is returned, as well as the type. *)
+val unabstract_type : Name.ident -> ty ->  ty -> ty atom * ty
+
+(** [unabstract_term x t e] instantiates bound variable [0] in [e] with a fresh atom of type [t].
+    The freshly generated atom is returned, as well as the type. *)
+val unabstract_term : Name.ident -> ty ->  term -> ty atom * term
+
+(** [unabstract_eq_type x t eq] instantiates bound variable [0] in [eq] with a fresh atom of type [t].
+    The freshly generated atom is returned, as well as the type. *)
+val unabstract_eq_type : Name.ident -> ty ->  eq_type -> ty atom * eq_type
+
+(** [unabstract_eq_term x t eq] instantiates bound variable [0] in [eq] with a fresh atom of type [t].
+    The freshly generated atom is returned, as well as the type. *)
+val unabstract_eq_term : Name.ident -> ty ->  eq_term -> ty atom * eq_term
+
+(** [unabstract_abstraction inst_u x t abstr] instantiates bond variable [0] in [abstr] with a fresh atom of type [t].
+    The freshly generated atom is returned, as well as the type. *)
+val unabstract_abstraction :
+  (term -> ?lvl:bound -> 'a -> 'a) -> Name.ident -> ty -> 'a abstraction -> ty atom * 'a abstraction
 
 (** [abstract_term x0 ~lvl:k t] replaces atom [x0] in type [t] with bound variable [k] (default [0]). *)
 val abstract_type : Name.atom -> ?lvl:bound -> ty -> ty
+
+(** [abstract_term x0 ~lvl:k e] replaces atom [x0] in term [e] with bound variable [k] (default [0]). *)
+val abstract_term : Name.atom -> ?lvl:bound -> term -> term
+
+(** [abstract_eq_type x0 ~lvl:k eq] replaces atom [x0] in equation [eq] with bound variable [k] (default [0]). *)
+val abstract_eq_type : Name.atom -> ?lvl:bound -> eq_type -> eq_type
+
+(** [abstract_eq_term x0 ~lvl:k eq] replaces atom [x0] in equation [eq] with bound variable [k] (default [0]). *)
+val abstract_eq_term : Name.atom -> ?lvl:bound -> eq_term -> eq_term
+
+(** [abstract_abstraaction abstract_u x0 ~lvl:k abstr] replaces atom [x0] in
+   abstraction [abstr] with bound variable [k] (default [0]). *)
+val abstract_abstraction :
+  (Name.atom -> ?lvl:bound -> 'a -> 'a) ->
+  Name.atom -> ?lvl:bound -> 'a abstraction -> 'a abstraction
 
 (** abstract followed by instantiate *)
 val substitute_term : term -> Name.atom -> term -> term

--- a/src/nucleus/TT.mli
+++ b/src/nucleus/TT.mli
@@ -142,6 +142,9 @@ val alpha_equal_term : term -> term -> bool
 (** [alpha_equal_type t1 t2] returns [true] if types [t1] and [t2] are alpha equal. *)
 val alpha_equal_type : ty -> ty -> bool
 
+val alpha_equal_abstraction
+  : ('a -> 'a -> bool) -> 'a abstraction -> 'a abstraction -> bool
+
 val occurs_term : bound -> term -> bool
 
 val occurs_type : bound -> ty -> bool

--- a/src/nucleus/TT.mli
+++ b/src/nucleus/TT.mli
@@ -2,11 +2,8 @@
 
 type bound
 
-(** The type of TT terms.
-
-    We use locally nameless syntax: names for free variables and deBruijn
-    indices for bound variables.
-*)
+(** We use locally nameless syntax: names for free variables and deBruijn
+   indices for bound variables. *)
 
 (** An abstracted entity. *)
 type ('a, 'b) abstraction = private
@@ -34,18 +31,18 @@ and ty = private
   (** a type constructor *)
   | TypeConstructor of Name.constant * argument list
 
-and eq_type = private EqType of assumption
+and eq_type = private EqType of assumption * ty * ty
 
-and eq_term = private EqTerm of assumption
+and eq_term = private EqTerm of assumption * term * term * ty
 
 and assumption = ty Assumption.t
 
-(** an argument of a term or type constructor *)
+(** An argument of a term or type constructor. *)
 and argument = private
   | ArgIsTerm of term argument_abstraction
   | ArgIsType of ty argument_abstraction
-  | ArgEqType of eq_type argument_abstraction
-  | ArgEqTerm of eq_term argument_abstraction
+  | ArgEqType of assumption argument_abstraction
+  | ArgEqTerm of assumption argument_abstraction
 
 (** Term constructors, these do not check for legality of constructions. *)
 

--- a/src/nucleus/TT.mli
+++ b/src/nucleus/TT.mli
@@ -20,7 +20,8 @@ and term = private
   (** a term constructor *)
   | TermConstructor of Name.constant * argument list
 
-  (** a term conversion *)
+  (** a term conversion from the natural type of the term to the given type, we do not
+     allow two consecutive conversions *)
   | TermConvert of term * assumption * ty
 
 and eq_type = private EqType of assumption * ty * ty
@@ -66,6 +67,8 @@ val mk_arg_eq_term : eq_term abstraction -> argument
 val mk_eq_type : assumption -> ty -> ty -> eq_type
 val mk_eq_term : assumption -> term -> term -> ty -> eq_term
 
+(** Make a term conversion. It is illegal to pile a term conversion on top of another term
+   conversion. *)
 val mk_term_convert : term -> assumption -> ty -> term
 
 (** Make a non-abstracted constructor argument *)
@@ -97,11 +100,11 @@ val substitute_term : Name.atom -> term -> term -> term
 
 val substitute_type : Name.atom -> term -> ty -> ty
 
-(** The asssumptions used by a term. *)
-val assumptions_term : lvl:bound -> term -> assumption
+(** The asssumptions used by a term. Caveat: alpha-equal terms may have different assumptions. *)
+val assumptions_term : ?lvl:bound -> term -> assumption
 
-(** The assumptions used by a type. *)
-val assumptions_type : lvl:bound -> ty -> assumption
+(** The assumptions used by a type. Caveat: alpha-equal types may have different assumptions. *)
+val assumptions_type : ?lvl:bound -> ty -> assumption
 
 (** [alpha_equal e1 e2] returns [true] if term [e1] and [e2] are alpha equal. *)
 val alpha_equal: term -> term -> bool

--- a/src/nucleus/TT.mli
+++ b/src/nucleus/TT.mli
@@ -117,9 +117,9 @@ val abstract_term : Name.atom -> ?lvl:bound -> term -> term
 val abstract_type : Name.atom -> ?lvl:bound -> ty -> ty
 
 (** abstract followed by instantiate *)
-val substitute_term : Name.atom -> term -> term -> term
+val substitute_term : term -> Name.atom -> term -> term
 
-val substitute_type : Name.atom -> term -> ty -> ty
+val substitute_type : term -> Name.atom -> ty -> ty
 
 (** The asssumptions used by a term. Caveat: alpha-equal terms may have different assumptions. *)
 val assumptions_term : ?lvl:bound -> term -> assumption
@@ -127,10 +127,17 @@ val assumptions_term : ?lvl:bound -> term -> assumption
 (** The assumptions used by a type. Caveat: alpha-equal types may have different assumptions. *)
 val assumptions_type : ?lvl:bound -> ty -> assumption
 
+val assumptions_eq_type : ?lvl:bound -> eq_type -> assumption
+
+val assumptions_eq_term : ?lvl:bound -> eq_term -> assumption
+
 val assumptions_arguments : argument list -> assumption
 
-(** [alpha_equal e1 e2] returns [true] if term [e1] and [e2] are alpha equal. *)
-val alpha_equal: term -> term -> bool
+val assumptions_abstraction :
+  (?lvl:bound -> 'a -> assumption) -> ?lvl:bound -> 'a abstraction -> assumption
+
+(** [alpha_equal_term e1 e2] returns [true] if term [e1] and [e2] are alpha equal. *)
+val alpha_equal_term : term -> term -> bool
 
 (** [alpha_equal_type t1 t2] returns [true] if types [t1] and [t2] are alpha equal. *)
 val alpha_equal_type : ty -> ty -> bool

--- a/src/nucleus/TT.mli
+++ b/src/nucleus/TT.mli
@@ -47,15 +47,26 @@ and 'a abstraction = private
 (** Term constructors, these do not check for legality of constructions. *)
 
 (** Create a fresh atom of the given type. *)
-val mk_atom : Name.ident -> 't -> 't atom
+val fresh_atom : Name.ident -> 't -> 't atom
+
+(** Create the judgement that an atom has its type. *)
+val mk_atom : ty atom -> term
 
 (** Create a fully applied type constructor *)
-val mk_type_constructor : Name.constant -> argument list -> ty
+val mk_type_constructor : Name.constructor -> argument list -> ty
+
+(** Create a fully applied term constructor *)
+val mk_term_constructor : Name.constructor -> argument list -> term
 
 val mk_arg_is_type : ty abstraction -> argument
 val mk_arg_is_term : term abstraction -> argument
 val mk_arg_eq_type : eq_type abstraction -> argument
 val mk_arg_eq_term : eq_term abstraction -> argument
+
+val mk_eq_type : assumption -> ty -> ty -> eq_type
+val mk_eq_term : assumption -> term -> term -> ty -> eq_term
+
+val mk_term_convert : term -> assumption -> ty -> term
 
 (** Make a non-abstracted constructor argument *)
 val mk_not_abstract : 'a -> 'a abstraction
@@ -95,8 +106,8 @@ val assumptions_type : lvl:bound -> ty -> assumption
 (** [alpha_equal e1 e2] returns [true] if term [e1] and [e2] are alpha equal. *)
 val alpha_equal: term -> term -> bool
 
-(** [alpha_equal_ty t1 t2] returns [true] if types [t1] and [t2] are alpha equal. *)
-val alpha_equal_ty: ty -> ty -> bool
+(** [alpha_equal_type t1 t2] returns [true] if types [t1] and [t2] are alpha equal. *)
+val alpha_equal_type : ty -> ty -> bool
 
 val occurs_term : bound -> term -> bool
 

--- a/src/nucleus/TT.mli
+++ b/src/nucleus/TT.mli
@@ -150,7 +150,10 @@ val occurs_eq_type : bound -> eq_type -> bool
 
 val occurs_eq_term : bound -> eq_term -> bool
 
-type print_env = private
+(* XXX Printing names is a trusted activity, thus the atom printing and all
+   trusted parts of name management should probably be moved to the nucleus,
+   at which time print_env can be made abstract. *)
+type print_env =
   { forbidden : Name.ident list ;
     atoms : Name.atom_printer ; }
 

--- a/src/nucleus/TT.mli
+++ b/src/nucleus/TT.mli
@@ -48,7 +48,12 @@ and argument = private
   | ArgEqTerm of eq_term argument_abstraction
 
 (** Term constructors, these do not check for legality of constructions. *)
-val mk_atom: Name.ident -> ty -> term
+
+(** Create an atom of the given type. *)
+val mk_atom : Name.atom -> ty -> term
+
+(** Create an atom of the given type, with a fresh name. *)
+val fresh_atom : Name.ident -> ty -> term
 
 (** Create a fully applied type constructor *)
 val mk_type_constructor : Name.constant -> argument list -> ty

--- a/src/nucleus/TT.mli
+++ b/src/nucleus/TT.mli
@@ -177,6 +177,12 @@ val assumptions_arguments : argument list -> assumption
 val assumptions_abstraction :
   (?lvl:bound -> 'a -> assumption) -> ?lvl:bound -> 'a abstraction -> assumption
 
+(** Compute the list of atoms occurring in an abstraction. Similar to
+    assumptions_XYZ functions, but allows use of the assumptions as atoms.
+    May only be called on closed terms. *)
+val context_abstraction :
+  (?lvl:bound -> 'a -> assumption) -> 'a abstraction -> ty atom list
+
 (** [alpha_equal_term e1 e2] returns [true] if term [e1] and [e2] are alpha equal. *)
 val alpha_equal_term : term -> term -> bool
 

--- a/src/nucleus/TT.mli
+++ b/src/nucleus/TT.mli
@@ -5,17 +5,14 @@ type bound
 (** We use locally nameless syntax: names for free variables and deBruijn
    indices for bound variables. *)
 
-(** An abstracted entity. *)
-type ('a, 'b) abstraction = private
-  | Abstract of Name.ident * 'a * ('a,'b) abstraction
-  | NotAbstract of 'b
+(** The type of TT types. *)
+type ty = private
+  (** a type constructor *)
+  | TypeConstructor of Name.constant * argument list
 
-(** An abstracted argument of a constructor (does not carry any type information). *)
-type 'a argument_abstraction = (unit, 'a) abstraction
-
-type term = private
+and term = private
   (** a free variable *)
-  | TermAtom of Name.atom * ty
+  | TermAtom of ty atom
 
   (** a bound variable *)
   | TermBound of bound
@@ -26,45 +23,45 @@ type term = private
   (** a term conversion *)
   | TermConvert of term * assumption * ty
 
-(** The type of TT types. *)
-and ty = private
-  (** a type constructor *)
-  | TypeConstructor of Name.constant * argument list
-
 and eq_type = private EqType of assumption * ty * ty
 
 and eq_term = private EqTerm of assumption * term * term * ty
 
 and assumption = ty Assumption.t
 
+and 't atom = private { atom_name : Name.atom ; atom_type : 't }
+
 (** An argument of a term or type constructor. *)
 and argument = private
-  | ArgIsTerm of term argument_abstraction
-  | ArgIsType of ty argument_abstraction
-  | ArgEqType of assumption argument_abstraction
-  | ArgEqTerm of assumption argument_abstraction
+  | ArgIsTerm of term abstraction
+  | ArgIsType of ty abstraction
+  | ArgEqType of eq_type abstraction
+  | ArgEqTerm of eq_term abstraction
+
+(** An abstracted entity. *)
+and 'a abstraction = private
+  | Abstract of Name.ident * ty * 'a abstraction
+  | NotAbstract of 'a
+
 
 (** Term constructors, these do not check for legality of constructions. *)
 
-(** Create an atom of the given type. *)
-val mk_atom : Name.atom -> ty -> term
-
-(** Create an atom of the given type, with a fresh name. *)
-val fresh_atom : Name.ident -> ty -> term
+(** Create a fresh atom of the given type. *)
+val mk_atom : Name.ident -> 't -> 't atom
 
 (** Create a fully applied type constructor *)
 val mk_type_constructor : Name.constant -> argument list -> ty
 
-val mk_arg_is_type : ty argument_abstraction -> argument
-val mk_arg_is_term : term argument_abstraction -> argument
-val mk_arg_eq_type : eq_type argument_abstraction -> argument
-val mk_arg_eq_term : eq_term argument_abstraction -> argument
+val mk_arg_is_type : ty abstraction -> argument
+val mk_arg_is_term : term abstraction -> argument
+val mk_arg_eq_type : eq_type abstraction -> argument
+val mk_arg_eq_term : eq_term abstraction -> argument
 
 (** Make a non-abstracted constructor argument *)
-val mk_not_abstract : 'b -> ('a, 'b) abstraction
+val mk_not_abstract : 'a -> 'a abstraction
 
 (** Abstract a term argument *)
-val mk_abstract : Name.ident -> 'a -> ('a, 'b) abstraction -> ('a, 'b) abstraction
+val mk_abstract : Name.ident -> ty -> 'a abstraction -> 'a abstraction
 
 (** [instantiate_term e0 ~lvl:k e] replaces bound variable [k] (defualt [0])  with term [e0] in term [e]. *)
 val instantiate_term: term -> ?lvl:bound -> term -> term
@@ -76,8 +73,7 @@ val instantiate_type: term -> ?lvl:bound -> ty -> ty
     [k] (default [0]) with term [e0] in the given abstraction. *)
 val instantiate_abstraction :
   (term -> ?lvl:bound -> 'a -> 'a) ->
-  (term -> ?lvl:bound -> 'b -> 'b) ->
-  term -> ?lvl:bound -> ('a, 'b) abstraction -> ('a, 'b) abstraction
+  term -> ?lvl:bound -> 'a abstraction -> 'a abstraction
 
 (** [abstract_term x0 ~lvl:k e] replaces atom [x0] in term [e] with bound variable [k] (default [0]). *)
 val abstract_term : Name.atom -> ?lvl:bound -> term -> term
@@ -117,14 +113,13 @@ type print_env = private
 (** Forbid the given identifier from being used as a bound variable. *)
 val add_forbidden : Name.ident -> print_env -> print_env
 
+(** [print_abstraction occurs_v print_v ?max_level ~penv abstr ppf] prints an abstraction using formatter [ppf]. *)
 val print_abstraction :
    (bound -> 'a -> bool) ->
-   (penv:print_env -> Name.ident * 'a -> Format.formatter -> unit) ->
-   (bound -> 'b -> bool) ->
-   (?max_level:Level.t -> penv:print_env -> 'b -> Format.formatter -> unit) ->
+   (?max_level:Level.t -> penv:print_env -> 'a -> Format.formatter -> unit) ->
    ?max_level:Level.t ->
    penv:print_env ->
-   ('a, 'b) abstraction ->
+   'a abstraction ->
    Format.formatter -> unit
 
 val print_type : ?max_level:Level.t -> penv:print_env -> ty -> Format.formatter -> unit

--- a/src/nucleus/TT.mli
+++ b/src/nucleus/TT.mli
@@ -127,7 +127,7 @@ val assumptions_term : ?lvl:bound -> term -> assumption
 (** The assumptions used by a type. Caveat: alpha-equal types may have different assumptions. *)
 val assumptions_type : ?lvl:bound -> ty -> assumption
 
-val assumptions_arguments : ?lvl:bound -> argument list -> assumption
+val assumptions_arguments : argument list -> assumption
 
 (** [alpha_equal e1 e2] returns [true] if term [e1] and [e2] are alpha equal. *)
 val alpha_equal: term -> term -> bool

--- a/src/nucleus/assumption.ml
+++ b/src/nucleus/assumption.ml
@@ -16,7 +16,7 @@ let mem_atom x s = AtomMap.mem x s.free
 
 let mem_bound k s = BoundSet.mem k s.bound
 
-let shift lvl s =
+let shift ~lvl s =
   { s with
     bound = BoundSet.fold
               (fun k s -> if k < lvl then s else BoundSet.add (k - lvl) s)

--- a/src/nucleus/assumption.ml
+++ b/src/nucleus/assumption.ml
@@ -12,6 +12,8 @@ let empty = { free = AtomMap.empty; bound = BoundSet.empty }
 let is_empty {free;bound} =
   AtomMap.is_empty free && BoundSet.is_empty bound
 
+let unpack {free; bound} = free, bound
+
 let mem_atom x s = AtomMap.mem x s.free
 
 let mem_bound k s = BoundSet.mem k s.bound

--- a/src/nucleus/assumption.ml
+++ b/src/nucleus/assumption.ml
@@ -56,7 +56,7 @@ let instantiate asmp0 ~lvl asmp =
 
 let fully_instantiate asmps ~lvl asmp =
   let rec fold asmp = function
-    | [] -> asmps
+    | [] -> asmp
     | asmp0 :: asmps ->
        let asmp = instantiate asmp0 ~lvl asmp
        in fold asmp asmps

--- a/src/nucleus/assumption.mli
+++ b/src/nucleus/assumption.mli
@@ -2,48 +2,43 @@
 module BoundSet : Set.S with type elt = int
 
 (** A pair of sets, corresponding to free and bound assumptions *)
-type t
+type 'a t
 
-val empty : t
+val empty : 'a t
 
-val is_empty : t -> bool
+val is_empty : 'a t -> bool
 
-val mem_atom : Name.atom -> t -> bool
+val mem_atom : Name.atom -> 'a t -> bool
 
-val mem_bound : int -> t -> bool
+val mem_bound : int -> 'a t -> bool
 
 (** [shift lvl asmp] removes bound variables below [lvl] and subtracts [lvl] from the other ones. *)
-val shift : int -> t -> t
+val shift : int -> 'a t -> 'a t
 
-val singleton_free : Name.atom -> t
+val singleton_free : Name.atom -> 'a -> 'a t
 
-val singleton_bound : int -> t
+val singleton_bound : int -> 'a t
 
-val add_atoms : Name.AtomSet.t -> t -> t
+val add_free : Name.atom -> 'a -> 'a t -> 'a t
 
-val add_free : Name.atom -> t -> t
+val add_bound : int -> 'a t -> 'a t
 
-val add_bound : int -> t -> t
-
-val union : t -> t -> t
+val union : 'a t -> 'a t -> 'a t
 
 (** [instantiate a0 k a] replaces bound variable [k] with the assumptions of [a0] *)
-val instantiate : t -> lvl:int -> t -> t
+val instantiate : 'a t -> lvl:int -> 'a t -> 'a t
 
 (** [abstract x k l] replaces the free variable [x] by the bound variables [k]. *)
-val abstract : Name.atom -> lvl:int -> t -> t
+val abstract : Name.atom -> lvl:int -> 'a t -> 'a t
 
 (** If [hyps] are the assumptions on a term, [bind hyps] are the assumptions after putting the term under a binder. *)
-val bind1 : t -> t
+val bind1 : 'a t -> 'a t
 
-(** If [a] has no bound assumptions, [as_atom_set a] returns the set of free assumptions. *)
-val as_atom_set : t -> Name.AtomSet.t
-
-val equal : t -> t -> bool
+val equal : 'a t -> 'a t -> bool
 
 module Json :
 sig
 
-  val assumptions : t -> Json.t
+  val assumptions : 'a t -> Json.t
 
 end

--- a/src/nucleus/assumption.mli
+++ b/src/nucleus/assumption.mli
@@ -32,7 +32,7 @@ val union : 'a t -> 'a t -> 'a t
 val instantiate : 'a t -> lvl:int -> 'a t -> 'a t
 
 (** [fully_instantiate asmps ~lvl:k asmp] replaces bound variables in [asmp] with assumptions [asmps]. *)
-val fully_instantiate : 'a t list -> ?lvl:int -> 'a t -> 'a t
+val fully_instantiate : 'a t list -> lvl:int -> 'a t -> 'a t
 
 (** [abstract x k l] replaces the free variable [x] by the bound variables [k]. *)
 val abstract : Name.atom -> lvl:int -> 'a t -> 'a t

--- a/src/nucleus/assumption.mli
+++ b/src/nucleus/assumption.mli
@@ -8,6 +8,8 @@ val empty : 'a t
 
 val is_empty : 'a t -> bool
 
+val unpack : 'a t -> 'a Name.AtomMap.t * BoundSet.t
+
 val mem_atom : Name.atom -> 'a t -> bool
 
 val mem_bound : int -> 'a t -> bool

--- a/src/nucleus/assumption.mli
+++ b/src/nucleus/assumption.mli
@@ -13,7 +13,7 @@ val mem_atom : Name.atom -> 'a t -> bool
 val mem_bound : int -> 'a t -> bool
 
 (** [shift lvl asmp] removes bound variables below [lvl] and subtracts [lvl] from the other ones. *)
-val shift : int -> 'a t -> 'a t
+val shift : lvl:int -> 'a t -> 'a t
 
 val singleton_free : Name.atom -> 'a -> 'a t
 

--- a/src/nucleus/assumption.mli
+++ b/src/nucleus/assumption.mli
@@ -12,8 +12,11 @@ val mem_atom : Name.atom -> 'a t -> bool
 
 val mem_bound : int -> 'a t -> bool
 
-(** [shift lvl asmp] removes bound variables below [lvl] and subtracts [lvl] from the other ones. *)
-val shift : lvl:int -> 'a t -> 'a t
+(** [at_level ~lvl asmp] removes bound variables below [lvl] and subtracts [lvl] from the other ones. *)
+val at_level : lvl:int -> 'a t -> 'a t
+
+(** [shift ~lvl k asmp] shifts bound variables above [lvl] by [k]. *)
+val shift : lvl:int -> int -> 'a t -> 'a t
 
 val singleton_free : Name.atom -> 'a -> 'a t
 
@@ -25,8 +28,11 @@ val add_bound : int -> 'a t -> 'a t
 
 val union : 'a t -> 'a t -> 'a t
 
-(** [instantiate a0 k a] replaces bound variable [k] with the assumptions of [a0] *)
+(** [instantiate asmp0 ~lvl:k asmp] replaces bound variable [k] with the assumptions [asmp0] in [asmp]. *)
 val instantiate : 'a t -> lvl:int -> 'a t -> 'a t
+
+(** [fully_instantiate asmps ~lvl:k asmp] replaces bound variables in [asmp] with assumptions [asmps]. *)
+val fully_instantiate : 'a t list -> ?lvl:int -> 'a t -> 'a t
 
 (** [abstract x k l] replaces the free variable [x] by the bound variables [k]. *)
 val abstract : Name.atom -> lvl:int -> 'a t -> 'a t

--- a/src/nucleus/jdg.ml
+++ b/src/nucleus/jdg.ml
@@ -402,6 +402,8 @@ let type_of_atom {TT.atom_type=t;_} = t
 
 let form_is_term_atom = TT.mk_atom
 
+let fresh_atom = TT.fresh_atom
+
 let form_is_term_convert sgn e (TT.EqType (asmp, t1, t2)) =
   match e with
   | TT.TermConvert (e, asmp0, t0) ->
@@ -429,6 +431,8 @@ let form_is_term_convert sgn e (TT.EqType (asmp, t1, t2)) =
        TT.mk_term_convert e asmp t2
      else
        error (InvalidConvert (t0, t1))
+
+let abstract_not_abstract = TT.mk_not_abstract
 
 (** Destructors *)
 
@@ -505,6 +509,9 @@ let mk_alpha_equal_term sgn e1 e2 =
   let t1 = type_of_term sgn e1
   and t2 = type_of_term sgn e2
   in
+  (* XXX if e1 and e2 are α-equal, we may apply uniqueness of typing to
+     conclude that their types are equal, so we don't have to compute t1, t2,
+     and t1 =α= t2. *)
   match TT.alpha_equal_type t1 t2 with
   | false -> error (AlphaEqualTypeMismatch (t1, t2))
   | true ->
@@ -523,6 +530,8 @@ let mk_alpha_equal_term sgn e1 e2 =
 let alpha_equal_is_term = TT.alpha_equal_term
 
 let alpha_equal_is_type = TT.alpha_equal_type
+
+let alpha_equal_abstraction = TT.alpha_equal_abstraction
 
 let symmetry_term (TT.EqTerm (asmp, e1, e2, t)) = TT.mk_eq_term asmp e2 e1 t
 

--- a/src/nucleus/jdg.ml
+++ b/src/nucleus/jdg.ml
@@ -24,6 +24,8 @@ type premise =
   | PremiseEqType of eq_type abstraction
   | PremiseEqTerm of eq_term abstraction
 
+type assumption = is_type Assumption.t
+
 type stump_is_type =
   | TypeConstructor of Name.constructor * premise list
 
@@ -321,6 +323,11 @@ let natural_type sgn = function
 
   | TT.TermConvert (e, _, _) -> type_of_term sgn e
 
+let natural_type_eq sgn e =
+  let natural = natural_type sgn e
+  and given = type_of_term sgn e in
+  TT.mk_eq_type Assumption.empty natural given
+
 let check_premise sgn metas s p =
   match s, p with
 
@@ -501,6 +508,20 @@ let invert_eq_type_abstraction eq =
 
 let invert_eq_term_abstraction eq =
   invert_abstraction TT.instantiate_eq_term eq
+
+let context_is_type_abstraction = TT.context_abstraction TT.assumptions_type
+let context_is_term_abstraction = TT.context_abstraction TT.assumptions_term
+let context_eq_type_abstraction = TT.context_abstraction TT.assumptions_eq_type
+let context_eq_term_abstraction = TT.context_abstraction TT.assumptions_eq_term
+
+let occurs_abstraction assumptions_u a abstr =
+  let asmp = TT.(assumptions_abstraction assumptions_u abstr) in
+  Assumption.mem_atom a.TT.atom_name asmp
+
+let occurs_is_type_abstraction = occurs_abstraction TT.assumptions_type
+let occurs_is_term_abstraction = occurs_abstraction TT.assumptions_term
+let occurs_eq_type_abstraction = occurs_abstraction TT.assumptions_eq_type
+let occurs_eq_term_abstraction = occurs_abstraction TT.assumptions_eq_term
 
 (** Substitution *)
 let substitute_type e0 {TT.atom_name=a;_} t = TT.substitute_type e0 a t

--- a/src/nucleus/jdg.ml
+++ b/src/nucleus/jdg.ml
@@ -613,73 +613,56 @@ let congruence_term_constructor sgn c eqs =
 
 
 
-(** Convenience functions *)
+(** Printing functions *)
 
-let print_is_term ~penv ?max_level abstr ppf =
-  (* TODO: print invisible assumptions, or maybe the entire context *)
+let print_is_term ?max_level ~penv e ppf =
   Print.print ?max_level ~at_level:Level.jdg ppf
-              "%s @[<hv>%t@]"
+              "%s @[<hv>@[<hov>%t@]@;<1 -2>@]"
               (Print.char_vdash ())
-              (TT.print_abstraction
-                 TT.occurs_term
-                 (fun ?max_level ~penv e ppf ->
-                   Print.print ppf "@[<hv>@[<hov>%t@]@;<1 -2>t@]"
-                               (TT.print_term ~max_level:Level.highest ~penv e)
-                               (* XXX print the type of the term also *)
-                  )
-                 ~max_level:Level.highest
-                 ~penv
-                 abstr)
+              (TT.print_term ~max_level:Level.highest ~penv e)
+              (* XXX print the type of the term also *)
 
-let print_is_type ~penv ?max_level abstr ppf =
-  (* TODO: print invisible assumptions, or maybe the entire context *)
+let print_is_type ?max_level ~penv t ppf =
   Print.print ?max_level ~at_level:Level.jdg ppf
-              "%s @[<hv>%t@]"
+              "%s @[<hv>@[<hov>%t@]@;<1 -2> type@]"
               (Print.char_vdash ())
-              (TT.print_abstraction
-                 TT.occurs_type
-                 (fun ?max_level ~penv t ppf ->
-                   Print.print ppf "@[<hv>@[<hov>%t@]@;<1 -2>: type@]"
-                               (TT.print_type ~max_level:Level.highest ~penv t)
-                 )
-                 ~max_level:Level.highest
-                 ~penv
-                 abstr)
+              (TT.print_type ~max_level:Level.highest ~penv t)
 
-let print_eq_term ~penv ?max_level abstr ppf =
-  (* TODO: print invisible assumptions, or maybe the entire context *)
+let print_eq_type ?max_level ~penv (TT.EqType (_asmp, t1, t2)) ppf =
+  (* TODO: print _asmp? *)
   Print.print ?max_level ~at_level:Level.jdg ppf
-              "%s @[<hv>%t@]"
+              "%s @[<hv>@[<hov>%t@]@ %s@ @[<hov>%t@]@]"
               (Print.char_vdash ())
-              (TT.print_abstraction
-                 TT.occurs_eq_term
-                 (fun ?max_level ~penv (TT.EqTerm (_asmp, e1, e2, t)) ppf ->
-                   Print.print ppf "@[<hv>@[<hov>%t@]@ %s@ @[<hov>%t@]@ :@ @[<hov>%t@]@]"
-                               (TT.print_term ~penv e1)
-                               (Print.char_equal ())
-                               (TT.print_term ~penv e2)
-                               (TT.print_type ~penv t)
-                 )
-                 ~penv
-                 ~max_level:Level.highest
-                 abstr)
+              (TT.print_type ~penv t1)
+              (Print.char_equal ())
+              (TT.print_type ~penv t2)
 
-let print_eq_type ~penv ?max_level abstr ppf =
-  (* TODO: print invisible assumptions, or maybe the entire context *)
+let print_eq_term ?max_level ~penv (TT.EqTerm (_asmp, e1, e2, t)) ppf =
+  (* TODO: print _asmp? *)
   Print.print ?max_level ~at_level:Level.jdg ppf
-              "%s @[<hv>%t@]"
+              "%s @[<hv>@[<hov>%t@]@ %s@ @[<hov>%t@]@ :@ @[<hov>%t@]@]"
               (Print.char_vdash ())
-              (TT.print_abstraction
-                 TT.occurs_eq_type
-                 (fun ?max_level ~penv (TT.EqType (_asmp, t1, t2)) ppf ->
-                   Print.print ppf "@[<hv>@[<hov>%t@]@ %s@ @[<hov>%t@]@]"
-                               (TT.print_type ~penv t1)
-                               (Print.char_equal ())
-                               (TT.print_type ~penv t2)
-                 )
-                 ~penv
-                 ~max_level:Level.highest
-                 abstr)
+              (TT.print_term ~penv e1)
+              (Print.char_equal ())
+              (TT.print_term ~penv e2)
+              (TT.print_type ~penv t)
+
+
+let print_is_term_abstraction ?max_level ~penv abstr ppf =
+  (* TODO: print invisible assumptions, or maybe the entire context *)
+  TT.print_abstraction TT.occurs_term print_is_term ?max_level ~penv abstr ppf
+
+let print_is_type_abstraction ?max_level ~penv abstr ppf =
+  (* TODO: print invisible assumptions, or maybe the entire context *)
+  TT.print_abstraction TT.occurs_type print_is_type ?max_level ~penv abstr ppf
+
+let print_eq_type_abstraction ?max_level ~penv abstr ppf =
+  (* TODO: print invisible assumptions, or maybe the entire context *)
+  TT.print_abstraction TT.occurs_eq_type print_eq_type ?max_level ~penv abstr ppf
+
+let print_eq_term_abstraction ?max_level ~penv abstr ppf =
+  (* TODO: print invisible assumptions, or maybe the entire context *)
+  TT.print_abstraction TT.occurs_eq_term print_eq_term ?max_level ~penv abstr ppf
 
 let print_error ~penv err ppf =
   match err with

--- a/src/nucleus/jdg.ml
+++ b/src/nucleus/jdg.ml
@@ -68,7 +68,6 @@ let error ~loc err = Pervasives.raise (Error (Location.locate err loc))
 
 module Rule = struct
 
-
   module Schema = struct
 
     type meta = int  (* meta-variables appearing in rules *)
@@ -77,26 +76,28 @@ module Rule = struct
     type term =
       | TermBound of bound
       | TermConstructor of Name.constructor * argument list
-      | TermMV of meta * argument list
+      | TermMeta of meta * argument list
 
     and ty =
       | TypeConstructor of Name.constructor * argument list
-      | TypeMV of meta * argument list
+      | TypeMeta of meta * argument list
 
     and argument =
-      | ArgIsType of abstraction * ty
-      | ArgIsTerm of abstraction * term
-      | ArgEqType               (* TODO add abstractions here *)
+      | ArgIsType of ty abstraction
+      | ArgIsTerm of term abstraction
+      | ArgEqType
       | ArgEqTerm
 
-    and abstraction = Name.ident list
+    and 'a abstraction =
+      | NotAbstract of 'a
+      | Abstract of Name.ident * ty * 'a abstraction
 
-    type premise = lctx * jdg
-    and lctx = (Name.ident * ty) list
-    and jdg = IsType of Name.ident  (* name of the newly introduced MV *)
-            | IsTerm of Name.ident * ty
-            | EqType of ty * ty
-            | EqTerm of term * term * ty
+
+    type premise =
+      | PremiseIsType of Name.ident * unit abstraction
+      | PremiseIsTerm of Name.ident * ty abstraction
+      | PremiseEqType of (ty * ty) abstraction
+      | PremiseEqTerm of (term * term * ty) abstraction
 
     type is_type = premise list
     type is_term = premise list * ty
@@ -105,205 +106,122 @@ module Rule = struct
 
   end
 
-  (* let rec check_type *)
-  (*   : TT.argument list -> Schema.ty -> TT.ty -> unit *)
-  (*   = fun metas t_schema t -> *)
-  (*   match t_schema, t.TT.thing with *)
+  let rec check_type ~loc (metas : TT.argument list) (schema : Schema.ty) (premise : TT.ty) =
+    match schema, premise with
 
-  (*     | Schema.TypeMeta m, t -> *)
-  (*        (\* lookup m and compare with t, they should be equal *\) *)
-  (*        assert false *)
+    | Schema.TypeConstructor (c_schema, args_schema), TT.TypeConstructor (c, args) ->
+       if Name.eq_ident c_schema c then
+         check_args ~loc metas args_schema args
+       else
+         failwith "some mismatch"
 
-  (*     | Schema.TypeConstructor (c, premises), TT.TypeConstructor (c', args) -> *)
-  (*        begin *)
-  (*          match Name.eq_ident c c' with *)
-  (*          | false -> failwith "match failure, we wish we had a location" *)
-  (*          | true -> check_premises metas premises args *)
-  (*        end *)
-
-  (*     | _, _ -> failwith "put an error message here" *)
-
-  (* and check_term metas e_schema e = *)
-  (*   match e_schema, e.TT.thing with *)
-
-  (*   | Schema.TermMV (m, premises), TT.TermConstructor -> *)
-  (*      failwith "todo"          (\* was: assert false *\) *)
-
-  (*   | Schema.TermConstructor (c, premises), TT.TermConstructor (c', args) -> *)
-  (*        begin *)
-  (*          match Name.eq_ident c c' with *)
-  (*          | false -> failwith "match failure, we wish we had a location" *)
-  (*          | true -> check_premises metas premises args *)
-  (*        end *)
-
-  (*   | _, _ -> failwith "put an error message here" (\* Consider other values, such as TT.Atom! *\) *)
-
-  (* and check_premises metas premises args = *)
-  (*   match premises, args with *)
-  (*   | [], [] -> () *)
-  (*   | premise :: premises, arg :: args -> check_premise metas premise arg *)
-  (*   | [], _::_ -> failwith "too many arguments are applied to this constructor" *)
-  (*   | _::_, [] -> failwith "too few arguments are applied to this constructor" *)
-
-  (* and check_premise *)
-  (*   : TT.argument list -> Schema.argument -> TT.argument -> unit *)
-  (*   = fun metas premise arg -> *)
-  (*   match premise, arg with *)
-  (*   | Schema.ArgIsType t_schema, TT.ArgIsType t -> check_abstraction check_type metas t_schema t *)
-  (*   | Schema.ArgIsTerm e_schema, TT.ArgIsTerm e -> check_abstraction check_term metas e_schema e *)
-  (*   | Schema.ArgEqType, TT.ArgEqType -> () *)
-  (*   | Schema.ArgEqTerm, TT.ArgEqTerm -> () *)
-  (*   | _, _ -> failwith "place an error message here" *)
-
-  (* and check_abstraction : *)
-  (*   'a 'b . (TT.argument list -> 'a -> 'b -> unit) -> TT.argument list -> *)
-  (*           'a Schema.abstraction -> 'b TT.abstraction -> unit = *)
-  (*   fun check_u metas abstr_schema abstr -> *)
-  (*   let rec fold metas abstr_schema abstr = *)
-  (*     match abstr_schema, abstr with *)
-  (*     | Schema.NotAbstract u_schema, TT.NotAbstract u -> check_u metas u_schema u *)
-  (*     | Schema.Abstract (_, abstr_schema), TT.Abstract (_, abstr) -> fold metas abstr_schema abstr *)
-  (*     | _, _ -> failwith "place an error message here" *)
-  (*   in *)
-  (*   fold metas abstr_schema abstr *)
-
-  (* let rec match_premise_abstraction *)
-  (*   (\* : (TT.argument list -> 'schema_jdg_form -> 'premise_jdg_form -> TT.argument) *\) *)
-  (*   (\*     -> TT.argument list *\) *)
-  (*   (\*     -> 'schema_jdg_form Schema.premise_abstraction *\) *)
-  (*   (\*     -> 'premise_jdg_form abstraction *\) *)
-  (*   (\*     -> TT.argument *\) *)
-  (*     = fun match_jdg abstract_arg metas schema abstr -> *)
-  (*     match schema, abstr with *)
-
-  (*     | Schema.PremiseNotAbstract jdg_schema, NotAbstract jdg_premise -> *)
-  (*        let arg = match_jdg metas jdg_schema jdg_premise in *)
-  (*        arg *)
-
-  (*     | Schema.PremiseAbstract ((_, t_schema), schema), Abstract ((x, t), abstr) -> *)
-  (*        check_type metas t_schema t ; *)
-  (*        let abstr = match_premise_abstraction match_jdg abstract_arg metas schema abstr in *)
-  (*        (\* [abstr] is a TT.argument, we need to abstract it by [x] *\) *)
-  (*        (\* XXX use TT.mk_abstract abstract_u here instead *\) *)
-  (*        (\* TT.mk_abstract_argument x abstr *\) *)
-  (*        TT.mk_abstract abstract_arg x abstr *)
-
-  (*     | _, _ -> *)
-  (*        failwith "premise match fail" *)
-
-  (* let match_is_type *)
-  (*   : TT.argument list -> Name.ident -> TT.ty -> TT.argument *)
-  (*   = fun metas _x t -> *)
-  (*   TT.mk_arg_is_type t *)
-
-  (* let match_is_term metas t_schema (e, t) = *)
-  (*   check_type metas t_schema t ; *)
-  (*   TT.mk_arg_eq_term e *)
-
-  (* let match_eq_type metas (t1_schema, t2_schema) (t1, t2) = *)
-  (*   check_type metas t1_schema t1 ; *)
-  (*   check_type metas t2_schema t2 ; *)
-  (*   TT.mk_arg_eq_type () *)
-
-  (* let match_eq_term metas (e1_schema, e2_schema, t_schema) (e1, e2, t) = *)
-  (*   check_type metas t_schema t ; *)
-  (*   check_term metas e1_schema e1 ; *)
-  (*   check_term metas e2_schema e2 ; *)
-  (*   TT.mk_arg_eq_term () *)
-
-  (* let match_eq_type = failwith "todo" *)
-
-  (* let match_is_term = failwith "todo" *)
-
-  (* let match_premise_obsolete ~loc metas_ctx metas premise_schema premise = *)
-  (*   let ctx, m = *)
-  (*     match premise_schema, premise with *)
-
-  (*     | Schema.PremiseIsType (mv_id, t_schema), PremiseIsType (IsType (ctx, abstr)) -> *)
-  (*        ctx, match_premise_abstraction match_is_type TT.mk_arg_is_type metas t_schema abstr *)
-
-  (*     | Schema.PremiseIsTerm (mv_id, e_schema), PremiseIsTerm (IsTerm (ctx, abstr)) -> *)
-  (*        ctx, match_premise_abstraction match_is_term TT.mk_arg_is_term metas e_schema abstr *)
-
-  (*     | Schema.PremiseEqType eqty_schema, PremiseEqType (EqType (ctx, eqty)) -> *)
-  (*        ctx, match_premise_abstraction match_eq_type TT.mk_arg_eq_type metas eqty_schema eqty *)
-
-  (*     | Schema.PremiseEqTerm eqterm_schema, PremiseEqTerm (EqTerm (ctx, eqterm)) -> *)
-  (*        ctx, match_premise_abstraction match_eq_term TT.mk_arg_eq_term metas eqterm_schema eqterm *)
-
-  (*     | _, _ -> *)
-  (*        failwith "wrong premise form" *)
-  (*   in *)
-  (*   let ctx = Ctx.join ~loc metas_ctx ctx in *)
-  (*   ctx, m *)
+    | Schema.TypeMeta (k, args), ty ->
+       let args = List.map (instantiate_argument metas) args in
+       begin
+         (* XXX TODO List.nth could fail miserably here *)
+         match List.nth metas k with
+         | TT.ArgIsType abstr ->
+            let ty' = instantiate_abstraction instantiate_type abstr args in
+            if not (TT.alpha_equal_type ty ty') then
+              failwith "type mismatch"
+         | TT.ArgIsTerm _ | TT.ArgEqType _ | TT.ArgEqTerm _ ->
+            failwith "expected a type meta-variable but got something else"
+       end
 
 
-  let check_type ~loc (metas : TT.argument list) (schema : Schema.ty) (premise : TT.ty) =
-    if true then failwith "todo"
+  and check_args ~loc metas args_schema args =
+    match args_schema, args with
+
+    | [], [] -> ()
+
+    | arg_schema :: args_schema, arg :: args ->
+       check_arg ~loc metas arg_schema arg ;
+       check_args ~loc metas args_schema args
+
+    | [], _::_ | _::_, [] -> failwith "too many or too few arguments"
+
+  and check_arg ~loc metas arg_schema arg =
+    match arg_schema, arg with
+    | Schema.ArgIsType t_schema, TT.ArgIsType t -> check_abstraction check_type ~loc metas t_schema t
+    | Schema.ArgIsTerm e_schema, TT.ArgIsTerm e -> check_abstraction check_term ~loc metas e_schema e
+    | Schema.ArgEqType eq_schema, TT.ArgEqType eq -> failwith "not done"
+    | Schema.ArgEqTerm eq_schmea, TT.ArgEqTerm eq -> failwith "not done"
 
   let check_term ~loc (metas : TT.argument list) (schema : Schema.term) (premise : TT.term) =
     if true then failwith "todo"
 
+  let rec check_abstraction ~loc metas check_u s_abstr p_abstr =
+    match s_abstr, p_abstr with
 
-  let check_jdg ~loc (metas : TT.argument list) (schema : Schema.jdg) (premise : Concrete.bare_jdg) =
-    match (schema, premise) with
-    | Schema.IsType _s_ty, Concrete.BareIsType _p_ty -> ()
-    | Schema.IsTerm (_, s_ty), Concrete.BareIsTerm (_, p_ty) -> check_type ~loc metas s_ty p_ty
-    | Schema.EqType (s_ty1, s_ty2), Concrete.BareEqType (p_ty1, p_ty2) ->
-       check_type ~loc metas s_ty1 p_ty1; check_type ~loc metas s_ty2 p_ty2
-    | Schema.EqTerm (s_e1, s_e2, s_ty), Concrete.BareEqTerm (p_e1, p_e2, p_ty) ->
-       check_type ~loc metas s_ty p_ty;
-       check_term ~loc metas s_e1 p_e1;
-       check_term ~loc metas s_e2 p_e2
+    | Schema.NotAbstract u_schema, TT.NotAbstract u ->
+       check_u ~loc metas u_schema u
 
-    | _ -> failwith "mismatched premise" (* XXX error: expected schema but got premise *)
+    | Schema.Abstract (_, t_schema, s_abstr), TT.Abstract (_, t, p_abstr) ->
+       check_type ~loc metas t_schema t ;
+       check_abstraction ~loc metas check_u s_abstr p_abstr
 
+    | _, _ -> failwith "TODO please reasonable error in Jdg.check_abstraction"
 
-  let arg_of_premise (lctx : Concrete.lctx) (jdg : Concrete.bare_jdg) : TT.argument =
-    match jdg with
-    | Concrete.BareIsType ty ->
-       let _abstr = TT.mk_not_abstract ty in
-       failwith "todo"
-    | Concrete.BareIsTerm (_, _) -> failwith "todo"
-    | Concrete.BareEqType (_, _) -> failwith "todo"
-    | Concrete.BareEqTerm (_, _, _) -> failwith "todo"
+  let check_premise ~loc metas s p =
+    match s, p with
 
-  let rec check_lctxs ~loc metas = function
-    | [], [] -> ()
-    | [], _::_ -> failwith "premise has more abstractions than rule"
-    | _::_, [] -> failwith "premise has fewer abstractions than rule"
-    | (_, s_ty) :: ss, (_, p_ty) :: ps ->
-       (check_type ~loc metas s_ty p_ty ;
-        check_lctxs ~loc metas (ss, ps))
+    | Schema.PremiseIsType (_, s_abstr), PremiseIsType p_abstr ->
+       check_abstraction ~loc
+         metas
+         (fun ~loc _ _ _ -> ())
+         s_abstr p_abstr
 
-  let match_premise ~loc ctx metas
-      ((s_lctx, s_jdg) : Schema.premise)
-      (p : premise) : ctx * TT.argument =
-    let ((p_ctx, _p_strength, p_lctx, p_jdg) : ctx * 'a * Concrete.lctx * Concrete.bare_jdg) =
-      Concrete.premise p
-    in
-    check_lctxs ~loc metas (s_lctx, p_lctx) ;
-    check_jdg  ~loc metas s_jdg  p_jdg ;
-    let arg = arg_of_premise p_lctx p_jdg
-    and ctx = Ctx.join ~loc ctx p_ctx in
-    ctx, arg
+    | Schema.PremiseIsTerm (_, s_abstr), PremiseIsTerm p_abstr ->
+       check_abstraction ~loc
+         metas
+         (fun ~loc metas t_schema e -> check_type ~loc metas t_schema (typeof e))
+         s_abstr p_abstr
+
+    | Schema.PremiseEqType s_abstr, PremiseEqType p_abstr ->
+       check_abstraction ~loc
+         metas
+         (fun ~loc metas (t1_schema, t2_schema) (TT.EqType (_asmp, t1, t2)) ->
+           check_type ~loc metas t1_schema t1 ;
+           check_type ~loc metas t2_schema t2)
+         s_abstr p_abstr
+
+    | Schema.PremiseEqTerm s_abstr, PremiseEqTerm p_abstr ->
+       check_abstraction ~loc
+         metas
+         (fun ~loc metas (e1_schema, e2_schema, t_schema) (TT.EqTerm (_asmp, e1, e2, t)) ->
+           check_term ~loc metas e1_schema e1 ;
+           check_term ~loc metas e2_schema e2 ;
+           check_type ~loc metas t_schema t)
+         s_abstr p_abstr
+
+    | _, _ -> failwith "TODO better error in check_premise"
+
+  let arg_of_premise = function
+    | PremiseIsType t -> TT.mk_arg_is_type t
+    | PremiseIsTerm e -> TT.mk_arg_is_term e
+    | PremiseEqType eq -> TT.mk_arg_eq_type eq
+    | PremiseEqTerm eq-> TT.mk_arg_eq_term eq
+
+  let match_premise ~loc metas (s : Schema.premise) (p : premise) : TT.argument =
+    check_premise ~loc metas s p ;
+    arg_of_premise p
 
   let match_premises ~loc
       (schema_premises : Schema.premise list) (premises : premise list) =
-    let rec fold ctx args = function
-      | [], [] -> ctx, args
+    let rec fold args = function
+      | [], [] -> List.rev args
       | [], _::_ -> failwith "too many arguments"
       | _::_, [] -> failwith "too few arguments"
       | s :: ss, p :: ps ->
-         let (ctx, arg) = match_premise ~loc ctx args s p in
-         fold ctx (arg :: args) (ss, ps)
+         let metas = args in (* args also serves as the list of collected metas *)
+         let arg = match_premise ~loc metas s p in
+         fold (arg :: args) (ss, ps)
     in
-    fold Ctx.empty [] (schema_premises, premises)
+    fold [] (schema_premises, premises)
 
   let form_is_type ~loc c (schema_premises as _rule : Schema.is_type) premises =
-    let ctx, args = match_premises ~loc schema_premises premises in
-    let ty = TT.mk_type_constructor c args in
-    IsType (ctx, NotAbstract ty)
+    let args = match_premises ~loc schema_premises premises in
+    TT.mk_type_constructor c args
 
   let form_is_term rule premises = failwith "Rule.form_is_term is not implemented"
 
@@ -521,7 +439,7 @@ let form_is_term ~loc sgn = function
     TT.mk_term_constructor c args
 
  | TermConvert (e, TT.EqType (asmp, t1, t2)) ->
-    begin match e with
+    begieta match e with
     | TT.TermConvert (e, asmp0, t0) ->
        if TT.alpha_equal_type t0 t1 then
          (* here we rely on transitivity of equality *)
@@ -593,7 +511,7 @@ let mk_alpha_equal_term ~loc sgn e1 e2 =
   match TT.alpha_equal_type t1 t2 with
   | false -> error ~loc (AlphaEqualTypeMismatch (t1, t2))
   | true ->
-     begin match TT.alpha_equal e1 e2 with
+     begieta match TT.alpha_equal e1 e2 with
      | false -> None
      | true ->
         (* We may keep the assumptions empty here. One might worry
@@ -617,7 +535,7 @@ let transitivity_term ~loc (EqTerm (asmp, e1, e2, t)) (EqTerm (asmp', e1', e2', 
   match TT.alpha_equal_type t t' with
   | false -> error ~loc (AlphaEqualTypeMismatch (t, t'))
   | true ->
-     begin match TT.alpha_equal e2 e1' with
+     begieta match TT.alpha_equal e2 e1' with
      | false -> error ~loc (AlphaEqualTermMismatch (e2, e1'))
      | true ->
         (* XXX could use assumptions of [e1'] instead, or whichever is better. *)
@@ -626,7 +544,7 @@ let transitivity_term ~loc (EqTerm (asmp, e1, e2, t)) (EqTerm (asmp', e1', e2', 
      end
 
 let transitivity_type ~loc (EqType (asmp1, t1, t2)) (EqType (asmp2, u1, u2)) =
-  begin match TT.alpha_equal_type t2 u1 with
+  begieta match TT.alpha_equal_type t2 u1 with
      | false -> error ~loc (AlphaEqualTypeMismatch (t2, u1))
      | true ->
         (* XXX could use assumptions of [u1] instead, or whichever is better. *)

--- a/src/nucleus/jdg.ml
+++ b/src/nucleus/jdg.ml
@@ -432,7 +432,9 @@ let form_is_term_convert sgn e (TT.EqType (asmp, t1, t2)) =
      else
        error (InvalidConvert (t0, t1))
 
-let abstract_not_abstract = TT.mk_not_abstract
+let rec form_abstraction = function
+  | NotAbstract u -> TT.mk_not_abstract u
+  | Abstract (x, u) -> TT.mk_abstract (Name.ident_of_atom x.atom_name) x.atom_type (form_abstraction u)
 
 (** Destructors *)
 

--- a/src/nucleus/jdg.ml
+++ b/src/nucleus/jdg.ml
@@ -12,7 +12,6 @@ type eq_type = TT.eq_type
 
 type eq_term = TT.eq_term
 
-
 (** Stumps (defined below) are used to construct and invert judgements. The
    [form_XYZ] functions below take a stump and construct a judgement from it,
    whereas the [invert_XYZ] functions do the opposite. We can think of stumps as
@@ -39,18 +38,22 @@ type stump_eq_type =
 type stump_eq_term =
   | EqTerm of TT.assumption * is_term * is_term * is_type
 
+type 'a stump_abstraction =
+  | NotAbstract of 'a
+  | Abstract of is_atom * 'a abstraction
+
+type congruence_premise =
+  | CongrIsType of is_type abstraction * is_type abstraction * eq_type abstraction
+  | CongrIsTerm of is_term abstraction * is_term abstraction * eq_term abstraction
+  | CongrEqType of eq_type abstraction * eq_type abstraction
+  | CongrEqTerm of eq_term abstraction * eq_term abstraction
+
 (** Error messages emitted by this module. *)
 
 type error =
-  | ConstantDependency
-  | AbstractInvalidType of Name.atom * TT.ty * TT.ty
-  | SubstitutionDependency of Name.atom * TT.term * Name.atom
-  | SubstitutionInvalidType of Name.atom * TT.ty * TT.ty
-  | NotAType
   | AlphaEqualTypeMismatch of TT.ty * TT.ty
   | AlphaEqualTermMismatch of TT.term * TT.term
   | InvalidConvert of TT.ty * TT.ty
-  | RuleInputMismatch of string * TT.ty * string * TT.ty * string
 
 exception Error of error
 
@@ -229,7 +232,7 @@ and check_term (metas : TT.argument list) (schema : Rule.term) (premise : TT.ter
        | TT.ArgIsTerm abstr ->
           let es = meta_instantiate_terms metas es_schema in
           let e' = fully_apply_abstraction (TT.fully_instantiate_term ?lvl:None) abstr es in
-          if not (TT.alpha_equal e e') then
+          if not (TT.alpha_equal_term e e') then
             failwith "term mismatch"
 
        | TT.ArgIsType _ | TT.ArgEqType _ | TT.ArgEqTerm _ ->
@@ -275,11 +278,11 @@ and check_abstraction
   | _, _ -> failwith "TODO please reasonable error in Jdg.check_abstraction"
 
 
-(** [typeof sgn e] gives a type judgment [t], where [t] is the type of [e].
+(** [type_of_term sgn e] gives a type judgment [t], where [t] is the type of [e].
       Note that [t] itself gives no evidence that [e] actually has type [t].
       However, the assumptions of [e] are sufficient to show that [e] has
       type [t].  *)
-let typeof sgn = function
+let type_of_term sgn = function
   | TT.TermAtom {TT.atom_type=t; _} -> t
 
   | TT.TermBound k ->
@@ -298,7 +301,16 @@ let typeof sgn = function
   | TT.TermConvert (e, _, t) -> t
 
 
-let check_premise metas s p =
+(** [natural_type sgn e] gives the judgment that the natural type [t] of [e] is derivable.
+    We maintain the invariant that no further assumptions are needed (apart from those
+    already present in [e]) to derive that [e] actually has type [t]. *)
+let natural_type sgn = function
+  | (TT.TermAtom _ | TT.TermBound _ | TT.TermConstructor _) as e ->
+     type_of_term sgn e
+
+  | TT.TermConvert (e, _, _) -> type_of_term sgn e
+
+let check_premise sgn metas s p =
   match s, p with
 
   | Rule.PremiseIsType (_, s_abstr), PremiseIsType p_abstr ->
@@ -308,7 +320,7 @@ let check_premise metas s p =
 
   | Rule.PremiseIsTerm (_, s_abstr), PremiseIsTerm p_abstr ->
      check_abstraction
-       (fun metas t_schema e -> check_type metas t_schema (typeof sgn e))
+       (fun metas t_schema e -> check_type metas t_schema (type_of_term sgn e))
        metas s_abstr p_abstr
 
   | Rule.PremiseEqType s_abstr, PremiseEqType p_abstr ->
@@ -335,205 +347,56 @@ let arg_of_premise = function
   | PremiseEqType eq -> TT.mk_arg_eq_type eq
   | PremiseEqTerm eq-> TT.mk_arg_eq_term eq
 
-let match_premise metas (s : Rule.premise) (p : premise) : TT.argument =
-  check_premise metas s p ;
+let match_premise sgn metas (s : Rule.premise) (p : premise) : TT.argument =
+  check_premise sgn metas s p ;
   arg_of_premise p
 
-let match_premises (schema_premises : Rule.premise list) (premises : premise list) =
+let match_premises sgn (schema_premises : Rule.premise list) (premises : premise list) =
   let rec fold args = function
     | [], [] -> List.rev args
     | [], _::_ -> failwith "too many arguments"
     | _::_, [] -> failwith "too few arguments"
     | s :: ss, p :: ps ->
        let metas = args in (* args also serves as the list of collected metas *)
-       let arg = match_premise metas s p in
+       let arg = match_premise sgn metas s p in
        fold (arg :: args) (ss, ps)
   in
   fold [] (schema_premises, premises)
 
+(** Judgement formation *)
+
+(** Formation of judgements from rules *)
+
 let form_is_type_rule sgn c premises =
   let schema_premises = Signature.lookup_is_type_rule c sgn in
-  let args = match_premises schema_premises premises in
+  let args = match_premises sgn schema_premises premises in
   TT.mk_type_constructor c args
 
 let form_is_term_rule sgn c premises =
   let (schema_premises, _) = Signature.lookup_is_term_rule c sgn in
-  let args = match_premises schema_premises premises in
+  let args = match_premises sgn schema_premises premises in
   TT.mk_term_constructor c args
 
-let form_eq_type_rule (schema_premises, (lhs_schema, rhs_schema)) premises =
-  let args = match_premises schema_premises premises in
+let form_eq_type_rule sgn c premises =
+  let (schema_premises, (lhs_schema, rhs_schema)) =
+    Signature.lookup_eq_type_rule c sgn in
+  let args = match_premises sgn schema_premises premises in
   let asmp = TT.assumptions_arguments args
   and lhs = meta_instantiate_is_type ~lvl:0 args lhs_schema
   and rhs = meta_instantiate_is_type ~lvl:0 args rhs_schema
   in TT.mk_eq_type asmp lhs rhs
 
-let form_eq_term_rule c (schema_premises, (e1_schema, e2_schema, t_schema)) premises =
-  let args = match_premises schema_premises premises in
+let form_eq_term_rule sgn c premises =
+  let (schema_premises, (e1_schema, e2_schema, t_schema)) =
+    Signature.lookup_eq_term_rule c sgn in
+  let args = match_premises sgn schema_premises premises in
   let asmp = TT.assumptions_arguments args
   and e1 = meta_instantiate_is_term ~lvl:0 args e1_schema
   and e2 = meta_instantiate_is_term ~lvl:0 args e2_schema
   and t = meta_instantiate_is_type ~lvl:0 args t_schema
   in TT.mk_eq_term asmp e1 e2 t
 
-let invert_is_term rule args = failwith "Rule.invert_is_term is not implemented"
-
-let invert_is_type rule args = failwith "Rule.invert_is_type is not implemented"
-
-
-(*************** END RULE *******************)
-
-(** Judgements *)
-
-(** [natural_type sgn e] gives the judgment that the natural type [t] of [e] is derivable.
-    We maintain the invariant that no further assumptions are needed (apart from those
-    already present in [e]) to derive that [e] actually has type [t]. *)
-let natural_type sgn = function
-  | (TT.TermAtom _ | TT.TermBound _ | TT.TermConstructor _) as e ->
-     typeof sgn e
-
-  | TT.TermConvert (e, _, _) -> typeof sgn e
-
-
-let atom_is_type {TT.atom_type=t;_} = t
-
-let atom_is_term = TT.mk_atom
-
-(** Printing *)
-
-let print_is_type ~penv ?max_level abstr ppf =
-  (* TODO: print invisible assumptions, or maybe the entire context *)
-  Print.print ?max_level ~at_level:Level.jdg ppf
-              "%s @[<hv>%t@]"
-              (Print.char_vdash ())
-              (TT.print_abstraction
-                 TT.occurs_type
-                 (fun ?max_level ~penv t ppf ->
-                   Print.print ppf "@[<hv>@[<hov>%t@]@;<1 -2>: type@]"
-                               (TT.print_type ~max_level:Level.highest ~penv t)
-                 )
-                 ~max_level:Level.highest
-                 ~penv
-                 abstr)
-
-let print_eq_term ~penv ?max_level abstr ppf =
-  (* TODO: print invisible assumptions, or maybe the entire context *)
-  Print.print ?max_level ~at_level:Level.jdg ppf
-              "%s @[<hv>%t@]"
-              (Print.char_vdash ())
-              (TT.print_abstraction
-                 (fun k (e1, e2, t) -> TT.occurs_term k e1 || TT.occurs_term k e2 || TT.occurs_type k t)
-                 (fun ?max_level ~penv (e1, e2, t) ppf ->
-                   Print.print ppf "@[<hv>@[<hov>%t@]@ %s@ @[<hov>%t@]@ :@ @[<hov>%t@]@]"
-                               (TT.print_term ~penv e1)
-                               (Print.char_equal ())
-                               (TT.print_term ~penv e2)
-                               (TT.print_type ~penv t)
-                 )
-                 ~penv
-                 ~max_level:Level.highest
-                 abstr)
-
-let print_eq_type ~penv ?max_level abstr ppf =
-  (* TODO: print invisible assumptions, or maybe the entire context *)
-  Print.print ?max_level ~at_level:Level.jdg ppf
-              "%s @[<hv>%t@]"
-              (Print.char_vdash ())
-              (TT.print_abstraction
-                 (fun k (t1, t2) -> TT.occurs_type k t1 || TT.occurs_type k t2)
-                 (fun ?max_level ~penv (t1, t2) ppf ->
-                   Print.print ppf "@[<hv>@[<hov>%t@]@ %s@ @[<hov>%t@]@]"
-                               (TT.print_type ~penv t1)
-                               (Print.char_equal ())
-                               (TT.print_type ~penv t2)
-                 )
-                 ~penv
-                 ~max_level:Level.highest
-                 abstr)
-
-let print_error ~penv err ppf =
-  match err with
-
-  | ConstantDependency ->
-     Format.fprintf ppf "constants may not depend on assumptions"
-
-  | NotAType -> Format.fprintf ppf "Not a type."
-
-  | AbstractInvalidType (x, t1, t2) ->
-     Format.fprintf ppf "cannot abstract@ %t@ with type@ %t@ because it must have type@ %t"
-                    (Name.print_atom ~printer:penv.TT.atoms x)
-                    (TT.print_type ~penv t1)
-                    (TT.print_type ~penv t2)
-
-  | SubstitutionDependency (x, e, y) ->
-     Format.fprintf ppf "cannot substitute@ %t@ with@ %t,@ dependency cycle at@ %t"
-                    (Name.print_atom ~printer:penv.TT.atoms x)
-                    (TT.print_term ~penv e)
-                    (Name.print_atom ~printer:penv.TT.atoms y)
-
-  | SubstitutionInvalidType (x, x_ty, t) ->
-     Format.fprintf ppf "cannot substitute term of type %t for %t of type %t"
-                    (TT.print_type ~penv t)
-                    (Name.print_atom ~printer:penv.TT.atoms x)
-                    (TT.print_type ~penv x_ty)
-
-  | InvalidConvert (t1, t2) ->
-     Format.fprintf ppf "Trying to convert something at@ %t@ using an equality on@ %t@."
-                    (TT.print_type ~penv t1) (TT.print_type ~penv t2)
-
-  | AlphaEqualTypeMismatch (t1, t2) ->
-     Format.fprintf ppf "The types@ %t@ and@ %t@ should be alpha equal."
-                    (TT.print_type ~penv t1) (TT.print_type ~penv t2)
-
-  | AlphaEqualTermMismatch (e1, e2) ->
-     Format.fprintf ppf "The terms@ %t@ and@ %t@ should be alpha equal."
-                    (TT.print_term ~penv e1) (TT.print_term ~penv e2)
-
-  | RuleInputMismatch (rule, t1, desc1, t2, desc2) ->
-     Format.fprintf ppf "@[<v>In the %s rule, the following types should be identical\
-                         :@,   @[<hov>%t@]@ (%s) and@,   @[<hov>%t@]@ (%s)@]@."
-                    rule (TT.print_type ~penv t1) desc1 (TT.print_type ~penv t2) desc2
-
-(** Destructors *)
-
-let invert_arg = function
-  | TT.ArgIsTerm abstr -> PremiseIsTerm abstr
-  | TT.ArgIsType abstr -> PremiseIsType abstr
-  | TT.ArgEqType abstr -> PremiseEqType abstr
-  | TT.ArgEqTerm abstr -> PremiseEqTerm abstr
-
-let invert_args args = List.map invert_arg args
-
-let invert_is_term sgn = function
-
-  | TT.TermAtom a -> TermAtom a
-
-  | TT.TermBound _ -> assert false
-
-  | TT.TermConstructor (c, args) ->
-     let premises = invert_args args in
-     TermConstructor (c, premises)
-
-  | TT.TermConvert (e, asmp, t) ->
-     let t' = natural_type sgn e in
-     let eq = TT.mk_eq_type asmp t' t in
-     TermConvert (e, eq)
-
-let invert_is_type = function
-  | TT.TypeConstructor (c, args) ->
-     let premises = invert_args args in
-     TypeConstructor (c, premises)
-
-let invert_eq_type eq = eq
-
-let invert_eq_term eq = eq
-
-let invert_abstraction inst_v invert_v = function
-  | TT.Abstract (x, t, abstr) ->
-     let a = TT.mk_atom (TT.fresh_atom x t) in
-     let abstr = TT.instantiate_abstraction inst_v a abstr in
-     (Some a, abstr)
-  | TT.NotAbstract v -> (None, invert_v v)
+let type_of_atom {TT.atom_type=t;_} = t
 
 (** Construct judgements *)
 
@@ -567,13 +430,51 @@ let form_is_term_convert sgn e (TT.EqType (asmp, t1, t2)) =
      else
        error (InvalidConvert (t0, t1))
 
+(** Destructors *)
+
+let invert_arg = function
+  | TT.ArgIsTerm abstr -> PremiseIsTerm abstr
+  | TT.ArgIsType abstr -> PremiseIsType abstr
+  | TT.ArgEqType abstr -> PremiseEqType abstr
+  | TT.ArgEqTerm abstr -> PremiseEqTerm abstr
+
+let invert_args args = List.map invert_arg args
+
+let invert_is_term sgn = function
+
+  | TT.TermAtom a -> TermAtom a
+
+  | TT.TermBound _ -> assert false
+
+  | TT.TermConstructor (c, args) ->
+     let premises = invert_args args in
+     TermConstructor (c, premises)
+
+  | TT.TermConvert (e, asmp, t) ->
+     let t' = natural_type sgn e in
+     let eq = TT.mk_eq_type asmp t' t in
+     TermConvert (e, eq)
+
+let invert_is_type _sgn = function
+  | TT.TypeConstructor (c, args) ->
+     let premises = invert_args args in
+     TypeConstructor (c, premises)
+
+let invert_eq_type _sgn (TT.EqType (asmp, t1, t2)) = EqType (asmp, t1, t2)
+
+let invert_eq_term _sgn (TT.EqTerm (asmp, e1, e2, t)) = EqTerm (asmp, e1, e2, t)
+
+let invert_abstraction inst_v = function
+  | TT.Abstract (x, t, abstr) ->
+     let a = TT.fresh_atom x t in
+     let abstr = TT.instantiate_abstraction inst_v (TT.mk_atom a) abstr in
+     Abstract (a, abstr)
+  | TT.NotAbstract v -> NotAbstract v
 
 (** Substitution *)
-let substitute_ty a e0 t =
-  TT.substitute_type a e0 t
+let substitute_type e0 {TT.atom_name=a;_} t = TT.substitute_type e0 a t
 
-let substitute_term a e0 e =
-  TT.substitute_term a e0 e
+let substitute_term e0 {TT.atom_name=a;_} e = TT.substitute_term e0 a e
 
 (** Conversion *)
 
@@ -588,26 +489,26 @@ let convert_eq_term (TT.EqTerm (asmp1, e1, e2, t0)) (TT.EqType (asmp2, t1, t2)) 
 
 (** Constructors *)
 
-let reflexivity sgn e =
-  let t = typeof sgn e in
-  EqTerm (Assumption.empty, e, e, t)
+let reflexivity_term sgn e =
+  let t = type_of_term sgn e in
+  TT.mk_eq_term Assumption.empty e e t
 
-let reflexivity_type sgn t =
-  EqType (Assumption.empty, t, t)
+let reflexivity_type t =
+  TT.mk_eq_type Assumption.empty t t
 
-let mk_alpha_eq_type t1 t2 =
+let mk_alpha_equal_type t1 t2 =
   match TT.alpha_equal_type t1 t2 with
   | false -> None
-  | true -> Some (EqType (Assumption.empty, t1, t2))
+  | true -> Some (TT.mk_eq_type Assumption.empty t1 t2)
 
 let mk_alpha_equal_term sgn e1 e2 =
-  let t1 = typeof sgn e1
-  and t2 = typeof sgn e2
+  let t1 = type_of_term sgn e1
+  and t2 = type_of_term sgn e2
   in
   match TT.alpha_equal_type t1 t2 with
   | false -> error (AlphaEqualTypeMismatch (t1, t2))
   | true ->
-     begin match TT.alpha_equal e1 e2 with
+     begin match TT.alpha_equal_term e1 e2 with
      | false -> None
      | true ->
         (* We may keep the assumptions empty here. One might worry
@@ -616,73 +517,184 @@ let mk_alpha_equal_term sgn e1 e2 =
            [t1 == t2] (without assumptions as they are alpha-equal!),
            hence by conversion [e2 : t1], and whatever assumptions are
            required for [e2 : t2], they're already present in [e2]. *)
-        Some (EqTerm (Assumption.empty, e1, e2, t1))
+        Some (TT.mk_eq_term Assumption.empty e1 e2 t1)
      end
 
-let alpha_equal_is_term = TT.alpha_equal
+let alpha_equal_is_term = TT.alpha_equal_term
 
 let alpha_equal_is_type = TT.alpha_equal_type
 
-let symmetry_term (EqTerm (asmp, e1, e2, t)) = EqTerm (asmp, e2, e1, t)
+let symmetry_term (TT.EqTerm (asmp, e1, e2, t)) = TT.mk_eq_term asmp e2 e1 t
 
-let symmetry_type (EqType (asmp, t1, t2)) = EqType (asmp, t2, t1)
+let symmetry_type (TT.EqType (asmp, t1, t2)) = TT.mk_eq_type asmp t2 t1
 
-let transitivity_term (EqTerm (asmp, e1, e2, t)) (EqTerm (asmp', e1', e2', t')) =
+let transitivity_term (TT.EqTerm (asmp, e1, e2, t)) (TT.EqTerm (asmp', e1', e2', t')) =
   match TT.alpha_equal_type t t' with
   | false -> error (AlphaEqualTypeMismatch (t, t'))
   | true ->
-     begin match TT.alpha_equal e2 e1' with
+     begin match TT.alpha_equal_term e2 e1' with
      | false -> error (AlphaEqualTermMismatch (e2, e1'))
      | true ->
         (* XXX could use assumptions of [e1'] instead, or whichever is better. *)
         let asmp = Assumption.union asmp (Assumption.union asmp' (TT.assumptions_term e2))
-        in EqTerm (asmp, e1, e2', t)
+        in TT.mk_eq_term asmp e1 e2' t
      end
 
-let transitivity_type (EqType (asmp1, t1, t2)) (EqType (asmp2, u1, u2)) =
+let transitivity_type (TT.EqType (asmp1, t1, t2)) (TT.EqType (asmp2, u1, u2)) =
   begin match TT.alpha_equal_type t2 u1 with
   | false -> error (AlphaEqualTypeMismatch (t2, u1))
   | true ->
      (* XXX could use assumptions of [u1] instead, or whichever is better. *)
      let asmp = Assumption.union asmp1 (Assumption.union asmp2 (TT.assumptions_type t2))
-     in EqType (asmp, t1, u2)
+     in TT.mk_eq_type asmp t1 u2
   end
 
-(** Congruence *)
+(** Congruence rules *)
 
+let process_congruence_args args =
 
-(** Given a list of (possibly abstracted) equations between arguments, create an equation
-   between [c] applied to the arguments of the left-hand sides and the right-hand sides,
-   respectively. *)
-let congruence_term_constructor sgn c eqs =
-  let (asmp, lhs, rhs) =
-    List.fold_left
-      (fun (asmp, lhs, rhs) (EqTerm (asmp', e1, e2, t)) ->
-        (Assumption.union asmp asmp', e1 :: lhs, e2 :: rhs))
-      (Assumption.empty, [], [])
-      eqs
+  let rec check_endpoints check t1 t2 eq =
+    match t1, t2, eq with
+    | TT.NotAbstract t1, TT.NotAbstract t2, TT.NotAbstract eq ->
+       if not (check t1 t2 eq) then failwith "some error"
+    | TT.Abstract (_x1, u1, t1), TT.Abstract (_x2, u2, t2), TT.Abstract (_x', u', eq) ->
+       if TT.alpha_equal_type u1 u' || TT.alpha_equal_type u2 u' then
+         check_endpoints check t1 t2 eq
+       else
+         failwith "mismatch"
+    | _, _, _ -> failwith "wrong lengths"
+
   in
-  let e1 = form_is_term c lhs
-  and e2 = form_is_term c rhs in
-  let t = typeof e1 in
-  EqTerm (asmp, e1, e2, t)
+  let rec fold asmp_out lhs rhs = function
+
+    | [] -> (asmp_out, List.rev lhs, List.rev rhs)
+
+    | CongrIsType (t1, t2, eq) :: eqs ->
+       check_endpoints
+         (fun t1 t2 (TT.EqType (_, t1', t2')) ->
+           TT.alpha_equal_type t1 t1' && TT.alpha_equal_type t2 t2')
+         t1 t2 eq ;
+       let asmp_out = Assumption.union asmp_out (TT.assumptions_abstraction TT.assumptions_eq_type eq)
+       in fold asmp_out (PremiseIsType t1 :: lhs) (PremiseIsType t2 :: rhs) eqs
+
+    | CongrIsTerm (e1, e2, eq) :: eqs ->
+       check_endpoints
+         (fun e1 e2 (TT.EqTerm (_, e1', e2', _)) ->
+           TT.alpha_equal_term e1 e1' && TT.alpha_equal_term e2 e2')
+         e1 e2 eq ;
+       let asmp_out = Assumption.union asmp_out (TT.assumptions_abstraction TT.assumptions_eq_term eq)
+       in fold asmp_out (PremiseIsTerm e1 :: lhs) (PremiseIsTerm e2 :: rhs) eqs
+
+    | CongrEqType (eq1, eq2) :: eqs ->
+       let l = PremiseEqType eq1
+       and r = PremiseEqType eq2
+       in fold asmp_out (l :: lhs) (r :: rhs) eqs
+
+    | CongrEqTerm (eq1, eq2) :: eqs ->
+       let l = PremiseEqTerm eq1
+       and r = PremiseEqTerm eq2
+       in fold asmp_out (l :: lhs) (r :: rhs) eqs
+
+  in fold Assumption.empty [] [] args
 
 
-(** Given a list of (possibly abstracted) equations between arguments, create an equation
-   between [c] applied to the arguments of the left-hand sides and the right-hand sides,
-   respectively. *)
 let congruence_type_constructor sgn c eqs =
-  let (asmp, lhs, rhs) =
-    List.fold_left
-      (fun (asmp, lhs, rhs) (EqType (asmp', t1, t2)) ->
-        (Assumption.union asmp asmp', t1 :: lhs, t2 :: rhs))
-      (Assumption.empty, [], [])
-      eqs
-  in
-  let t1 = Rule.form_is_type sgn c (List.rev lhs)
-  and t2 = Rule.form_is_type sgn c (List.rev rhs)
-  in EqType (asmp, t1, t2)
+  let (asmp, lhs, rhs) = process_congruence_args eqs in
+  let t1 = form_is_type_rule sgn c lhs
+  and t2 = form_is_type_rule sgn c rhs
+  in TT.mk_eq_type asmp t1 t2
 
+let congruence_term_constructor sgn c eqs =
+  let (asmp, lhs, rhs) = process_congruence_args eqs in
+  let e1 = form_is_term_rule sgn c lhs
+  and e2 = form_is_term_rule sgn c rhs in
+  let t = type_of_term sgn e1
+  in TT.mk_eq_term asmp e1 e2 t
+
+
+
+(** Convenience functions *)
+
+let print_is_term ~penv ?max_level abstr ppf =
+  (* TODO: print invisible assumptions, or maybe the entire context *)
+  Print.print ?max_level ~at_level:Level.jdg ppf
+              "%s @[<hv>%t@]"
+              (Print.char_vdash ())
+              (TT.print_abstraction
+                 TT.occurs_term
+                 (fun ?max_level ~penv e ppf ->
+                   Print.print ppf "@[<hv>@[<hov>%t@]@;<1 -2>t@]"
+                               (TT.print_term ~max_level:Level.highest ~penv e)
+                               (* XXX print the type of the term also *)
+                  )
+                 ~max_level:Level.highest
+                 ~penv
+                 abstr)
+
+let print_is_type ~penv ?max_level abstr ppf =
+  (* TODO: print invisible assumptions, or maybe the entire context *)
+  Print.print ?max_level ~at_level:Level.jdg ppf
+              "%s @[<hv>%t@]"
+              (Print.char_vdash ())
+              (TT.print_abstraction
+                 TT.occurs_type
+                 (fun ?max_level ~penv t ppf ->
+                   Print.print ppf "@[<hv>@[<hov>%t@]@;<1 -2>: type@]"
+                               (TT.print_type ~max_level:Level.highest ~penv t)
+                 )
+                 ~max_level:Level.highest
+                 ~penv
+                 abstr)
+
+let print_eq_term ~penv ?max_level abstr ppf =
+  (* TODO: print invisible assumptions, or maybe the entire context *)
+  Print.print ?max_level ~at_level:Level.jdg ppf
+              "%s @[<hv>%t@]"
+              (Print.char_vdash ())
+              (TT.print_abstraction
+                 TT.occurs_eq_term
+                 (fun ?max_level ~penv (TT.EqTerm (_asmp, e1, e2, t)) ppf ->
+                   Print.print ppf "@[<hv>@[<hov>%t@]@ %s@ @[<hov>%t@]@ :@ @[<hov>%t@]@]"
+                               (TT.print_term ~penv e1)
+                               (Print.char_equal ())
+                               (TT.print_term ~penv e2)
+                               (TT.print_type ~penv t)
+                 )
+                 ~penv
+                 ~max_level:Level.highest
+                 abstr)
+
+let print_eq_type ~penv ?max_level abstr ppf =
+  (* TODO: print invisible assumptions, or maybe the entire context *)
+  Print.print ?max_level ~at_level:Level.jdg ppf
+              "%s @[<hv>%t@]"
+              (Print.char_vdash ())
+              (TT.print_abstraction
+                 TT.occurs_eq_type
+                 (fun ?max_level ~penv (TT.EqType (_asmp, t1, t2)) ppf ->
+                   Print.print ppf "@[<hv>@[<hov>%t@]@ %s@ @[<hov>%t@]@]"
+                               (TT.print_type ~penv t1)
+                               (Print.char_equal ())
+                               (TT.print_type ~penv t2)
+                 )
+                 ~penv
+                 ~max_level:Level.highest
+                 abstr)
+
+let print_error ~penv err ppf =
+  match err with
+
+  | InvalidConvert (t1, t2) ->
+     Format.fprintf ppf "Trying to convert something at@ %t@ using an equality on@ %t@."
+                    (TT.print_type ~penv t1) (TT.print_type ~penv t2)
+
+  | AlphaEqualTypeMismatch (t1, t2) ->
+     Format.fprintf ppf "The types@ %t@ and@ %t@ should be alpha equal."
+                    (TT.print_type ~penv t1) (TT.print_type ~penv t2)
+
+  | AlphaEqualTermMismatch (e1, e2) ->
+     Format.fprintf ppf "The terms@ %t@ and@ %t@ should be alpha equal."
+                    (TT.print_term ~penv e1) (TT.print_term ~penv e2)
 
 module Json =
   struct
@@ -696,10 +708,10 @@ module Json =
 
     let is_type t = Json.tag "IsType" [TT.Json.ty t]
 
-    let eq_term (EqTerm (asmp, e1, e2, t)) =
+    let eq_term (TT.EqTerm (asmp, e1, e2, t)) =
       Json.tag "EqTerm" [Assumption.Json.assumptions asmp; TT.Json.term e1; TT.Json.term e2; TT.Json.ty t]
 
-    let eq_type (EqType (asmp, t1, t2)) =
+    let eq_type (TT.EqType (asmp, t1, t2)) =
       Json.tag "EqType" [Assumption.Json.assumptions asmp; TT.Json.ty t1; TT.Json.ty t2]
 
   end

--- a/src/nucleus/jdg.ml
+++ b/src/nucleus/jdg.ml
@@ -12,6 +12,11 @@ type eq_type = TT.eq_type
 
 type eq_term = TT.eq_term
 
+type is_term_abstraction = is_term abstraction
+type is_type_abstraction = is_type abstraction
+type eq_type_abstraction = eq_type abstraction
+type eq_term_abstraction = eq_term abstraction
+
 (** Stumps (defined below) are used to construct and invert judgements. The
    [form_XYZ] functions below take a stump and construct a judgement from it,
    whereas the [invert_XYZ] functions do the opposite. We can think of stumps as

--- a/src/nucleus/jdg.ml
+++ b/src/nucleus/jdg.ml
@@ -285,6 +285,8 @@ and check_abstraction
   | _, _ -> failwith "TODO please reasonable error in Jdg.check_abstraction"
 
 
+let atom_name {TT.atom_name=n;_} = n
+
 (** [type_of_term sgn e] gives a type judgment [t], where [t] is the type of [e].
       Note that [t] itself gives no evidence that [e] actually has type [t].
       However, the assumptions of [e] are sufficient to show that [e] has
@@ -457,9 +459,22 @@ let form_is_term_convert sgn e (TT.EqType (asmp, t1, t2)) =
 
 let form_not_abstract u = TT.mk_not_abstract u
 
-let form_abstract abstr_u {TT.atom_name=x; atom_type=t} abstr =
-  let abstr = TT.abstract_abstraction abstr_u x abstr in
+let form_is_type_abstract {TT.atom_name=x; atom_type=t} abstr =
+  let abstr = TT.abstract_abstraction TT.abstract_type x abstr in
   TT.mk_abstract (Name.ident_of_atom x) t abstr
+
+let form_is_term_abstract {TT.atom_name=x; atom_type=t} abstr =
+  let abstr = TT.abstract_abstraction TT.abstract_term x abstr in
+  TT.mk_abstract (Name.ident_of_atom x) t abstr
+
+let form_eq_type_abstract {TT.atom_name=x; atom_type=t} abstr =
+  let abstr = TT.abstract_abstraction TT.abstract_eq_type x abstr in
+  TT.mk_abstract (Name.ident_of_atom x) t abstr
+
+let form_eq_term_abstract {TT.atom_name=x; atom_type=t} abstr =
+  let abstr = TT.abstract_abstraction TT.abstract_eq_term x abstr in
+  TT.mk_abstract (Name.ident_of_atom x) t abstr
+
 
 (** Destructors *)
 
@@ -692,8 +707,6 @@ let congruence_term_constructor sgn c eqs =
   and e2 = form_is_term_rule sgn c rhs in
   let t = type_of_term sgn e1
   in TT.mk_eq_term asmp e1 e2 t
-
-
 
 (** Printing functions *)
 

--- a/src/nucleus/jdg.ml
+++ b/src/nucleus/jdg.ml
@@ -8,9 +8,10 @@ type is_term = TT.term
 
 type is_type = TT.ty
 
-type eq_term = TT.assumption * TT.term * TT.term * TT.ty
+type eq_type = TT.eq_type
 
-type eq_type = TT.assumption * TT.ty * TT.ty
+type eq_term = TT.eq_term
+
 
 (** Shapes (defined below) are used to construct and invert judgements. The
    [form_XYZ] functions below take a shape and construct a judgement from it,
@@ -28,7 +29,6 @@ type shape_is_term =
   | TermAtom of is_atom
   | TermConstructor of Name.constructor * premise list
   | TermConvert of is_term * eq_type
-  | TermAbstract of is_atom * is_term
 
 and shape_is_type =
   | TypeConstructor of Name.constructor * premise list
@@ -447,7 +447,9 @@ let rec invert_is_term sgn = function
 
   | TT.TermConvert (e, asmp, t) ->
         let t' = natural_type e in
-        TermConvert (e, (asmp, t', t))
+        let e = TT.mk_not_abstract e in
+        let eq = TT.mk_not_abstract (TT.mk_eq_type asmp t' t) in
+        TermConvert (e, eq)
 
 and invert_is_type = function
   | TT.TypeConstructor (c, args) ->

--- a/src/nucleus/jdg.ml
+++ b/src/nucleus/jdg.ml
@@ -510,24 +510,25 @@ let invert_eq_type (TT.EqType (asmp, t1, t2)) = EqType (asmp, t1, t2)
 
 let invert_eq_term (TT.EqTerm (asmp, e1, e2, t)) = EqTerm (asmp, e1, e2, t)
 
-let invert_abstraction inst_v = function
+let invert_abstraction ?atom_name inst_v = function
   | TT.Abstract (x, t, abstr) ->
+     let x = (match atom_name with None -> x | Some y -> y) in
      let a = TT.fresh_atom x t in
      let abstr = TT.instantiate_abstraction inst_v (TT.mk_atom a) abstr in
      Abstract (a, abstr)
   | TT.NotAbstract v -> NotAbstract v
 
-let invert_is_type_abstraction t =
-  invert_abstraction TT.instantiate_type t
+let invert_is_type_abstraction ?atom_name t =
+  invert_abstraction ?atom_name TT.instantiate_type t
 
-let invert_is_term_abstraction e =
-  invert_abstraction TT.instantiate_term e
+let invert_is_term_abstraction ?atom_name e =
+  invert_abstraction ?atom_name TT.instantiate_term e
 
-let invert_eq_type_abstraction eq =
-  invert_abstraction TT.instantiate_eq_type eq
+let invert_eq_type_abstraction ?atom_name eq =
+  invert_abstraction ?atom_name TT.instantiate_eq_type eq
 
-let invert_eq_term_abstraction eq =
-  invert_abstraction TT.instantiate_eq_term eq
+let invert_eq_term_abstraction ?atom_name eq =
+  invert_abstraction ?atom_name TT.instantiate_eq_term eq
 
 let context_is_type_abstraction = TT.context_abstraction TT.assumptions_type
 let context_is_term_abstraction = TT.context_abstraction TT.assumptions_term
@@ -543,10 +544,27 @@ let occurs_is_term_abstraction = occurs_abstraction TT.assumptions_term
 let occurs_eq_type_abstraction = occurs_abstraction TT.assumptions_eq_type
 let occurs_eq_term_abstraction = occurs_abstraction TT.assumptions_eq_term
 
-(** Substitution *)
-let substitute_type e0 {TT.atom_name=a;_} t = TT.substitute_type e0 a t
 
-let substitute_term e0 {TT.atom_name=a;_} e = TT.substitute_term e0 a e
+let apply_abstraction inst_u sgn abstr e0 =
+  match abstr with
+  | TT.NotAbstract _ -> failwith "foo"
+  | TT.Abstract (x, t, abstr) ->
+     begin match TT.alpha_equal_type t (type_of_term sgn e0) with
+     | false -> failwith "bar"
+     | true ->  TT.instantiate_abstraction inst_u e0 abstr
+     end
+
+let apply_is_type_abstraction sgn abstr e0 =
+  apply_abstraction TT.instantiate_type sgn abstr e0
+
+let apply_is_term_abstraction sgn abstr e0 =
+  apply_abstraction TT.instantiate_term sgn abstr e0
+
+let apply_eq_type_abstraction sgn abstr e0 =
+  apply_abstraction TT.instantiate_eq_type sgn abstr e0
+
+let apply_eq_term_abstraction sgn abstr e0 =
+  apply_abstraction TT.instantiate_eq_term sgn abstr e0
 
 (** Conversion *)
 

--- a/src/nucleus/jdg.ml
+++ b/src/nucleus/jdg.ml
@@ -432,9 +432,12 @@ let form_is_term_convert sgn e (TT.EqType (asmp, t1, t2)) =
      else
        error (InvalidConvert (t0, t1))
 
-let rec form_abstraction = function
+let form_abstraction = function
+
   | NotAbstract u -> TT.mk_not_abstract u
-  | Abstract (x, u) -> TT.mk_abstract (Name.ident_of_atom x.atom_name) x.atom_type (form_abstraction u)
+
+  | Abstract ({TT.atom_name=x; atom_type=t}, u) ->
+     TT.mk_abstract (Name.ident_of_atom x) t u
 
 (** Destructors *)
 

--- a/src/nucleus/jdg.ml
+++ b/src/nucleus/jdg.ml
@@ -480,6 +480,12 @@ let invert_abstraction inst_v = function
      Abstract (a, abstr)
   | TT.NotAbstract v -> NotAbstract v
 
+let invert_is_type_abstraction t =
+  invert_abstraction TT.instantiate_type t
+
+let invert_is_term_abstraction t =
+  invert_abstraction TT.instantiate_term t
+
 (** Substitution *)
 let substitute_type e0 {TT.atom_name=a;_} t = TT.substitute_type e0 a t
 

--- a/src/nucleus/jdg.ml
+++ b/src/nucleus/jdg.ml
@@ -589,7 +589,11 @@ let mk_alpha_equal_term sgn e1 e2 =
 
 let rec mk_alpha_equal_abstraction equal_u abstr1 abstr2 =
   match abstr1, abstr2 with
-  | TT.NotAbstract u1, TT.NotAbstract u2 -> equal_u u1 u2
+  | TT.NotAbstract u1, TT.NotAbstract u2 ->
+     begin match equal_u u1 u2 with
+     | None -> None
+     | Some eq -> Some (TT.mk_not_abstract eq)
+     end
   | TT.Abstract (x1, t1, abstr1), TT.Abstract (_x2, t2, abstr2) ->
      begin match alpha_equal_type t1 t2 with
      | false -> None

--- a/src/nucleus/jdg.mli
+++ b/src/nucleus/jdg.mli
@@ -66,25 +66,32 @@ end
 val form_is_type_rule : Signature.t -> Name.constructor -> premise list -> is_type
 
 (** Given a term rule and a list of premises, match the rule against the given
-   premises, make sure they fit the rule, and return the list of arguments that the term
-   constructor should be applied to, together with the natural type of the resulting term.
- *)
+    premises, make sure they fit the rule, and return the list of arguments that
+    the term constructor should be applied to, together with the natural type of
+    the resulting term. *)
 val form_is_term_rule : Signature.t -> Name.constructor -> premise list -> is_term
 
 (** Convert atom judgement to term judgement *)
 val form_is_term_atom : is_atom -> is_term
 
+(** [fresh_atom x t] Create a fresh atom from name [x] with type [t] *)
+val fresh_atom : Name.ident -> is_type -> is_atom
+
 val form_is_term_convert : Signature.t -> is_term -> eq_type -> is_term
 
-(** Given an equality type rule and a list of premises, match the rule against the given
-   premises, make sure they fit the rule, and return the conclusion of the instance of the rule
-   so obtained. *)
+(** Given an equality type rule and a list of premises, match the rule against
+    the given premises, make sure they fit the rule, and return the conclusion
+    of the instance of the rule so obtained. *)
 val form_eq_type_rule : Signature.t -> Name.constructor -> premise list -> eq_type
 
 (** Given an terms equality type rule and a list of premises, match the rule
-   against the given premises, make sure they fit the rule, and return the conclusion of
-   the instance of the rule so obtained. *)
+    against the given premises, make sure they fit the rule, and return the
+    conclusion of the instance of the rule so obtained. *)
 val form_eq_term_rule : Signature.t -> Name.constructor -> premise list -> eq_term
+
+(** Consider something not abstracted as trivially abstracted *)
+val abstract_not_abstract : 'a -> 'a abstraction
+
 
 val invert_is_type : Signature.t -> is_type -> stump_is_type
 
@@ -143,6 +150,9 @@ val alpha_equal_is_term : is_term -> is_term -> bool
 
 (** Test whether types are alpha-equal. They may have different contexts. *)
 val alpha_equal_is_type : is_type -> is_type -> bool
+
+val alpha_equal_abstraction
+  : ('a -> 'a -> bool) -> 'a abstraction -> 'a abstraction -> bool
 
 (** If [e1 == e2 : A] then [e2 == e1 : A] *)
 val symmetry_term : eq_term -> eq_term

--- a/src/nucleus/jdg.mli
+++ b/src/nucleus/jdg.mli
@@ -225,8 +225,8 @@ val print_eq_type : penv:TT.print_env -> ?max_level:Level.t -> eq_type -> Format
 (* Inversion principles *)
 val invert_is_term : is_term -> shape_is_term
 val invert_is_type : is_type -> shape_is_type
-val invert_eq_type : eq_type -> is_type * is_type
-val invert_eq_term : eq_term -> is_term * is_term * is_type
+val invert_eq_type : eq_type -> TT.assumption * is_type * is_type
+val invert_eq_term : eq_term -> TT.assumption * is_term * is_term * is_type
 
 (** Deconstruct a type judgment into a type abstraction, if possible. *)
 val invert_abstract_ty : is_type -> (is_atom * is_type) option

--- a/src/nucleus/jdg.mli
+++ b/src/nucleus/jdg.mli
@@ -16,12 +16,19 @@ type eq_type
 (** Judgement that something is a term equality. *)
 type eq_term
 
+(** Shorthands for abstracted judgements. *)
+type is_term_abstraction = is_term abstraction
+type is_type_abstraction = is_type abstraction
+type eq_type_abstraction = eq_type abstraction
+type eq_term_abstraction = eq_term abstraction
+
+
 (** An argument to a term or type constructor *)
 type premise =
-  | PremiseIsType of is_type abstraction
-  | PremiseIsTerm of is_term abstraction
-  | PremiseEqType of eq_type abstraction
-  | PremiseEqTerm of eq_term abstraction
+  | PremiseIsType of is_type_abstraction
+  | PremiseIsTerm of is_term_abstraction
+  | PremiseEqType of eq_type_abstraction
+  | PremiseEqTerm of eq_term_abstraction
 
 (** A stump is obtained when we invert a judgement. *)
 
@@ -50,10 +57,10 @@ type 'a stump_abstraction =
    two endpoints with a path between them, except that no paths between equalities are
    needed. *)
 type congruence_premise =
-  | CongrIsType of is_type abstraction * is_type abstraction * eq_type abstraction
-  | CongrIsTerm of is_term abstraction * is_term abstraction * eq_term abstraction
-  | CongrEqType of eq_type abstraction * eq_type abstraction
-  | CongrEqTerm of eq_term abstraction * eq_term abstraction
+  | CongrIsType of is_type_abstraction * is_type_abstraction * eq_type_abstraction
+  | CongrIsTerm of is_term_abstraction * is_term_abstraction * eq_term_abstraction
+  | CongrEqType of eq_type_abstraction * eq_type_abstraction
+  | CongrEqTerm of eq_term_abstraction * eq_term_abstraction
 
 
 module Signature : sig
@@ -107,18 +114,18 @@ val invert_eq_type : eq_type -> stump_eq_type
 
 val invert_eq_term : eq_term -> stump_eq_term
 
-val invert_is_term_abstraction : is_term abstraction -> is_term stump_abstraction
+val invert_is_term_abstraction : is_term_abstraction -> is_term stump_abstraction
 
-val invert_is_type_abstraction : is_type abstraction -> is_type stump_abstraction
+val invert_is_type_abstraction : is_type_abstraction -> is_type stump_abstraction
 
-val invert_eq_type_abstraction : eq_type abstraction -> eq_type stump_abstraction
+val invert_eq_type_abstraction : eq_type_abstraction -> eq_type stump_abstraction
 
-val invert_eq_term_abstraction : eq_term abstraction -> eq_term stump_abstraction
+val invert_eq_term_abstraction : eq_term_abstraction -> eq_term stump_abstraction
 
-val context_is_type_abstraction : is_type abstraction -> is_atom list
-val context_is_term_abstraction : is_term abstraction -> is_atom list
-val context_eq_type_abstraction : eq_type abstraction -> is_atom list
-val context_eq_term_abstraction : eq_term abstraction -> is_atom list
+val context_is_type_abstraction : is_type_abstraction -> is_atom list
+val context_is_term_abstraction : is_term_abstraction -> is_atom list
+val context_eq_type_abstraction : eq_type_abstraction -> is_atom list
+val context_eq_term_abstraction : eq_term_abstraction -> is_atom list
 
 (** An error emitted by the nucleus *)
 type error
@@ -129,16 +136,16 @@ exception Error of error
 val type_of_term : Signature.t -> is_term -> is_type
 
 (** The type judgement of an abstracted term judgement. *)
-val type_of_term_abstraction : Signature.t -> is_term abstraction -> is_type abstraction
+val type_of_term_abstraction : Signature.t -> is_term_abstraction -> is_type_abstraction
 
 (** Typeof for atoms *)
 val type_of_atom : is_atom -> is_type
 
 (** Does this atom occur in this judgement? *)
-val occurs_is_type_abstraction : is_atom -> is_type abstraction -> bool
-val occurs_is_term_abstraction : is_atom -> is_term abstraction -> bool
-val occurs_eq_type_abstraction : is_atom -> eq_type abstraction -> bool
-val occurs_eq_term_abstraction : is_atom -> eq_term abstraction -> bool
+val occurs_is_type_abstraction : is_atom -> is_type_abstraction -> bool
+val occurs_is_term_abstraction : is_atom -> is_term_abstraction -> bool
+val occurs_eq_type_abstraction : is_atom -> eq_type_abstraction -> bool
+val occurs_eq_term_abstraction : is_atom -> eq_term_abstraction -> bool
 
 (** [substitute_type t a v] substitutes [v] for [a] in [t]. *)
 val substitute_type : is_term -> is_atom -> is_type -> is_type
@@ -212,16 +219,16 @@ val print_eq_type :
   ?max_level:Level.t -> penv:TT.print_env -> eq_type -> Format.formatter -> unit
 
 val print_is_term_abstraction :
-  ?max_level:Level.t -> penv:TT.print_env -> is_term abstraction -> Format.formatter -> unit
+  ?max_level:Level.t -> penv:TT.print_env -> is_term_abstraction -> Format.formatter -> unit
 
 val print_is_type_abstraction :
-  ?max_level:Level.t -> penv:TT.print_env -> is_type abstraction -> Format.formatter -> unit
+  ?max_level:Level.t -> penv:TT.print_env -> is_type_abstraction -> Format.formatter -> unit
 
 val print_eq_term_abstraction :
-  ?max_level:Level.t -> penv:TT.print_env -> eq_term abstraction -> Format.formatter -> unit
+  ?max_level:Level.t -> penv:TT.print_env -> eq_term_abstraction -> Format.formatter -> unit
 
 val print_eq_type_abstraction :
-  ?max_level:Level.t -> penv:TT.print_env -> eq_type abstraction -> Format.formatter -> unit
+  ?max_level:Level.t -> penv:TT.print_env -> eq_type_abstraction -> Format.formatter -> unit
 
 (** Print a nucleus error *)
 val print_error : penv:TT.print_env -> error -> Format.formatter -> unit

--- a/src/nucleus/jdg.mli
+++ b/src/nucleus/jdg.mli
@@ -74,7 +74,7 @@ val form_is_term_rule : Signature.t -> Name.constructor -> premise list -> is_te
 (** Convert atom judgement to term judgement *)
 val form_is_term_atom : is_atom -> is_term
 
-val form_is_term_convert : Signature.t -> TT.term -> TT.eq_type -> TT.term
+val form_is_term_convert : Signature.t -> is_term -> eq_type -> is_term
 
 (** Given an equality type rule and a list of premises, match the rule against the given
    premises, make sure they fit the rule, and return the conclusion of the instance of the rule
@@ -94,7 +94,7 @@ val invert_eq_type : Signature.t -> eq_type -> stump_eq_type
 
 val invert_eq_term : Signature.t -> eq_term -> stump_eq_term
 
-val invert_abstraction : (TT.term -> ?lvl:TT.bound -> 'a -> 'a) -> 'a TT.abstraction -> 'a stump_abstraction
+val invert_abstraction : (TT.term -> ?lvl:TT.bound -> 'a -> 'a) -> 'a abstraction -> 'a stump_abstraction
 
 (** An error emitted by the nucleus *)
 type error

--- a/src/nucleus/jdg.mli
+++ b/src/nucleus/jdg.mli
@@ -310,9 +310,6 @@ val congr_abstract_term : loc:Location.t -> eq_type -> is_atom -> is_atom -> eq_
 
 (** Derivable rules *)
 
-(** If [e : B] and [A] is the natural type of [e] then [A == B] *)
-val natural_eq_type : loc:Location.t -> Signature.t -> is_term -> eq_type
-
 module Json :
 sig
   val is_term : is_term -> Json.t

--- a/src/nucleus/jdg.mli
+++ b/src/nucleus/jdg.mli
@@ -100,7 +100,9 @@ val invert_eq_type : Signature.t -> eq_type -> stump_eq_type
 
 val invert_eq_term : Signature.t -> eq_term -> stump_eq_term
 
-val invert_abstraction : (TT.term -> ?lvl:TT.bound -> 'a -> 'a) -> 'a abstraction -> 'a stump_abstraction
+val invert_is_term_abstraction : is_term abstraction -> is_term stump_abstraction
+
+val invert_is_type_abstraction : is_type abstraction -> is_type stump_abstraction
 
 (** An error emitted by the nucleus *)
 type error

--- a/src/nucleus/jdg.mli
+++ b/src/nucleus/jdg.mli
@@ -40,20 +40,6 @@ type stump_eq_type =
 type stump_eq_term =
   | EqTerm of TT.assumption * is_term * is_term * is_type
 
-type ctx
-
-module Ctx : sig
-  (** The type of contexts. *)
-  type t = ctx
-
-  val add_fresh : loc:Location.t -> is_type -> Name.ident -> is_atom
-
-  (** [elements ctx] returns the elements of [ctx] sorted into a list so that all dependencies
-      point forward in the list, ie the first atom does not depend on any atom, etc. *)
-  val elements : t -> is_atom list
-
-end
-
 module Rule : sig
 
   module Schema : sig
@@ -197,9 +183,6 @@ exception Error of error Location.located
 (** Print a nucleus error *)
 val print_error : penv:TT.print_env -> error -> Format.formatter -> unit
 
-(** The jdugement that [Type] is a type. *)
-val ty_ty : is_type
-
 (** The type judgement of a term judgement. *)
 val typeof : is_term -> is_type
 
@@ -255,19 +238,9 @@ val substitute : loc:Location.t -> is_term -> is_atom -> is_term -> is_term
 (** Conversion *)
 
 (** Destructors *)
-type side = LEFT | RIGHT
-
-val eq_term_side : side -> eq_term -> is_term
-
-val eq_term_typeof : eq_term -> is_type
-
-val eq_type_side : side -> eq_type -> is_type
-
-(** The conversion rule: if [e : A] and [A == B] then [e : B] *)
-val convert : loc:Location.t -> is_term -> eq_type -> is_term
 
 (** If [e1 == e2 : A] and [A == B] then [e1 == e2 : B] *)
-val convert_eq : loc:Location.t -> eq_term -> eq_type -> eq_term
+val convert_eq_term : loc:Location.t -> eq_term -> eq_type -> eq_term
 
 (** Constructors *)
 

--- a/src/nucleus/jdg.mli
+++ b/src/nucleus/jdg.mli
@@ -89,9 +89,8 @@ val form_eq_type_rule : Signature.t -> Name.constructor -> premise list -> eq_ty
     conclusion of the instance of the rule so obtained. *)
 val form_eq_term_rule : Signature.t -> Name.constructor -> premise list -> eq_term
 
-(** Consider something not abstracted as trivially abstracted *)
-val abstract_not_abstract : 'a -> 'a abstraction
-
+(** Form an abstra *)
+val form_abstraction : 'a stump_abstraction -> 'a abstraction
 
 val invert_is_type : Signature.t -> is_type -> stump_is_type
 

--- a/src/nucleus/jdg.mli
+++ b/src/nucleus/jdg.mli
@@ -18,10 +18,10 @@ type eq_term
 
 (** An argument to a term or type constructor *)
 type premise =
-  | PremiseIsType of is_type
-  | PremiseIsTerm of is_term
-  | PremiseEqType of eq_type
-  | PremiseEqTerm of eq_term
+  | PremiseIsType of is_type abstraction
+  | PremiseIsTerm of is_term abstraction
+  | PremiseEqType of eq_type abstraction
+  | PremiseEqTerm of eq_term abstraction
 
 (** A stump is the data needed to form a judgement, or to invert it. Stumps of
    equations are special, because they allow only partial inversion. *)

--- a/src/nucleus/jdg.mli
+++ b/src/nucleus/jdg.mli
@@ -83,6 +83,8 @@ val form_is_term_rule : Signature.t -> Name.constructor -> premise list -> is_te
 (** Convert atom judgement to term judgement *)
 val form_is_term_atom : is_atom -> is_term
 
+val atom_name : is_atom -> Name.atom
+
 (** [fresh_atom x t] Create a fresh atom from name [x] with type [t] *)
 val fresh_atom : Name.ident -> is_type -> is_atom
 
@@ -102,9 +104,11 @@ val form_eq_term_rule : Signature.t -> Name.constructor -> premise list -> eq_te
 val form_not_abstract : 'a -> 'a abstraction
 
 (** Form an abstracted abstraction *)
-val form_abstract :
-  (Name.atom -> ?lvl:TT.bound -> 'a -> 'a) ->
-  TT.ty TT.atom -> 'a TT.abstraction -> 'a TT.abstraction
+val form_is_type_abstract : is_atom -> is_type_abstraction -> is_type_abstraction
+val form_is_term_abstract : is_atom -> is_term_abstraction -> is_term_abstraction
+val form_eq_type_abstract : is_atom -> eq_type_abstraction -> eq_type_abstraction
+val form_eq_term_abstract : is_atom -> eq_term_abstraction -> eq_term_abstraction
+
 
 val invert_is_type : is_type -> stump_is_type
 
@@ -205,6 +209,8 @@ val congruence_type_constructor :
 
 val congruence_term_constructor :
   Signature.t -> Name.constructor -> congruence_premise list -> eq_term
+
+(** Printing routines *)
 
 val print_is_term :
   ?max_level:Level.t -> penv:TT.print_env -> is_term -> Format.formatter -> unit

--- a/src/nucleus/jdg.mli
+++ b/src/nucleus/jdg.mli
@@ -1,5 +1,5 @@
 (** Judgements can be abstracted *)
-type 'a abstraction = 'a TT.abstraction
+type 'a abstraction
 
 (** Judgement that something is a term. *)
 type is_term
@@ -23,8 +23,7 @@ type premise =
   | PremiseEqType of eq_type abstraction
   | PremiseEqTerm of eq_term abstraction
 
-(** A stump is the data needed to form a judgement, or to invert it. Stumps of
-   equations are special, because they allow only partial inversion. *)
+(** A stump is obtained when we invert a judgement. *)
 
 type stump_is_type =
   | TypeConstructor of Name.constructor * premise list
@@ -40,133 +39,6 @@ type stump_eq_type =
 type stump_eq_term =
   | EqTerm of TT.assumption * is_term * is_term * is_type
 
-module Rule : sig
-
-  module Schema : sig
-    (** A rule concluding that something is a type. *)
-    type is_type
-
-    (** A rule concluding that something is a term. *)
-    type is_term
-
-    (** A rule concluding that two types are equal. *)
-    type eq_type
-
-    (** A rule concluding that two terms are equal. *)
-    type eq_term
-  end
-
-  (** Given a type formation rule and a list of premises, match the rule
-   against the given premises, make sure they fit the rule, and return the
-   judgement corresponding to the conclusion of the rule.
-
-      The head of the conclusion (the parts in square brackets) is not really
-   there because it is fully prescribed by the premises and the judgement
-   class; we just specify it here for readability.
-
-
-      Input:
-      ⊢ A type    x:A ⊢ B type
-      ————————————————————————
-      ⊢ [Π A B] type
-
-      Processed to schema:
-      ⊢ A type    {x : MV 0} ⊢ B type
-      ———————————————————————————————
-      ⊢ [Π A B] type
-
-      Instance:
-      Γ₁ ⊢ A₁ type    Γ₂ | {y:A₂} ⊢ B₁ type
-      ——————————————————————————————————— {Γ₁,Γ₂}↑Δ, A₁ =α= A₂
-      Δ ⊢ Π A B type
-
-
-      Input:
-      ⊢ A type    x:A ⊢ B type   y:A ⊢ s : B{y}
-      —————————————————————————————————————————
-      ⊢ [λ A B s] : Π A B
-
-      Processed to schema:
-      ⊢ A type    {x : MV 0} ⊢ B type   {y : MV 1} ⊢ s : (MV 0){y}
-      ————————————————————————————————————————————————————————————
-      ⊢ [λ A B s] : Π (MV 2) (MV 1)
-
-      Instance:
-      Γ₁ ⊢ A₁ type    Γ₂ | {x:A₂} ⊢ B₁ type   Γ₃ | {y:A₃} ⊢ s : B₂
-      ————————————————————————————————————————————————————————————
-      check: {Γ₁,Γ₂,Γ₃}↑Δ, A₁ =α= A₂ =α= A₃, B₁ =α= B₂
-      Δ ⊢ λ A₁ B₁ s : Π A₁ B₁
-
-      example: [A := nat, B := nat, s := Bound 0]
-         gives   [λ nat nat (Bound 0) : Π nat ({0:nat} nat)]
-
-
-      Input:
-      ⊢ A type   ⊢ u : A   ⊢ v : A
-      ————————————————————————————
-      ⊢ [Id A u v]  type
-
-      Processed to Schema:
-      ⊢ A type   ⊢ u : MV 0   ⊢ v : MV 1
-      ——————————————————————————————————
-      ⊢ [Id A u v]  type
-
-      Instance:
-      Γ₁ ⊢ A₁ type   Γ₂ ⊢ u : A₂   Γ₃ ⊢ v : A₃
-      ———————————————————————————————————————— {Γ₁, Γ₂, Γ₃} ↑ Δ, Α₁ =α= A₂, A₁ =α= A₃
-      Δ ⊢ Id A₁ u v  type
-
-
-      Input:
-      ⊢ A type    ⊢ u : A     x : A, p : Id A u x ⊢ C type
-      ⊢ w : C{u, refl A u}    ⊢ v : A     ⊢ p : Id A u v
-      ————————————————————————————————————————————————————
-      ⊢ [J A u C w v p] : C{v, p}
-
-      Schema:
-      ⊢ A type    ⊢ u : MV 0     {x : A, p : Id (MV 1) (MV 0) (Bound 0)} ⊢ C type
-      ⊢ w : C{u, refl A u}       ⊢ v : A     ⊢ p : Id A u v
-      ————————————————————————————————————————————————————————————————————————————
-      ⊢ [J A u C w v p] : C{v, p}
-
-      Instance:
-      ⊢ A₁ type    ⊢ u₁ : A₂     x : A₃, h : Id A u x ⊢ C type    ⊢ w : C{u, refl A u}
-      ⊢ v : A     ⊢ p : Id A u v
-      ————————————————————————————————————————————————————————————————————————————————
-      ⊢ [J A u C w v p] : C{v, p}
-
-
-  *)
-  val form_is_type : Schema.is_type -> premise list -> is_type
-
-  (** Given a term rule and a list of premises, match the rule against the given
-   premises, make sure they fit the rule, and return the list of arguments that the term
-   constructor should be applied to, together with the natural type of the resulting term.
-   *)
-  val form_is_term : Schema.is_term -> premise list -> TT.argument list * TT.ty
-
-  (** Given an equality type rule and a list of premises, match the rule against the given
-   premises, make sure they fit the rule, and return the conclusion of the instance of the rule
-   so obtained. *)
-  (* XXX TODO what about context joins and assumption sets? *)
-  val form_eq_type : Schema.eq_type -> premise list -> TT.ty * TT.ty
-
-  (** Given an terms equality type rule and a list of premises, match the rule
-   against the given premises, make sure they fit the rule, and return the conclusion of
-   the instance of the rule so obtained. *)
-  val form_eq_term : Schema.eq_term -> premise list -> TT.term * TT.term * TT.ty
-
-  (** Given a term judgment and the arguments of the corresponding term constructor, match
-   the arguments against the rule to invert them to the premises of the rule, as well as
-   to the natural type of the conclusion. *)
-  val invert_is_term : Schema.is_term -> TT.argument list -> premise list * TT.ty
-
-  (** Given a type judgment and the arguments of the corresponding term constructor, match
-   the arguments against the rule to invert them to the premises of the rule. *)
-  val invert_is_type : Schema.is_type -> TT.argument list -> premise list
-
-end
-
 module Signature : sig
   type t
 
@@ -174,6 +46,36 @@ module Signature : sig
 
   val add_constant : Name.constant -> is_type -> t -> t
 end
+
+(** Given a type formation rule and a list of premises, match the rule
+   against the given premises, make sure they fit the rule, and return the
+   judgement corresponding to the conclusion of the rule. *)
+val form_is_type : Rule.is_type -> premise list -> is_type
+
+(** Given a term rule and a list of premises, match the rule against the given
+   premises, make sure they fit the rule, and return the list of arguments that the term
+   constructor should be applied to, together with the natural type of the resulting term.
+ *)
+val form_is_term : Rule.is_term -> premise list -> TT.argument list * TT.ty
+
+(** Given an equality type rule and a list of premises, match the rule against the given
+   premises, make sure they fit the rule, and return the conclusion of the instance of the rule
+   so obtained. *)
+val form_eq_type : Rule.eq_type -> premise list -> TT.ty * TT.ty
+
+(** Given an terms equality type rule and a list of premises, match the rule
+   against the given premises, make sure they fit the rule, and return the conclusion of
+   the instance of the rule so obtained. *)
+val form_eq_term : Rule.eq_term -> premise list -> TT.term * TT.term * TT.ty
+
+(** Given a term judgment and the arguments of the corresponding term constructor, match
+   the arguments against the rule to invert them to the premises of the rule, as well as
+   to the natural type of the conclusion. *)
+val invert_is_term : Rule.is_term -> TT.argument list -> premise list * TT.ty
+
+(** Given a type judgment and the arguments of the corresponding term constructor, match
+   the arguments against the rule to invert them to the premises of the rule. *)
+val invert_is_type : Rule.is_type -> TT.argument list -> premise list
 
 (** An error emitted by the nucleus *)
 type error

--- a/src/nucleus/jdg.mli
+++ b/src/nucleus/jdg.mli
@@ -164,22 +164,29 @@ val congruence_type_constructor :
 val congruence_term_constructor :
   Signature.t -> Name.constructor -> congruence_premise list -> eq_term
 
-
-(** Print the judgement that something is a term. *)
 val print_is_term :
-  penv:TT.print_env -> ?max_level:Level.t -> is_term abstraction -> Format.formatter -> unit
+  ?max_level:Level.t -> penv:TT.print_env -> is_term -> Format.formatter -> unit
 
-(** Print the judgement that something is a type. *)
 val print_is_type :
-  penv:TT.print_env -> ?max_level:Level.t -> is_type abstraction -> Format.formatter -> unit
+  ?max_level:Level.t -> penv:TT.print_env -> is_type -> Format.formatter -> unit
 
-(** Print the judgement that terms are equal. *)
 val print_eq_term :
-  penv:TT.print_env -> ?max_level:Level.t -> eq_term abstraction -> Format.formatter -> unit
+  ?max_level:Level.t -> penv:TT.print_env -> eq_term -> Format.formatter -> unit
 
-(** Print the judgement that types are equal. *)
 val print_eq_type :
-  penv:TT.print_env -> ?max_level:Level.t -> eq_type abstraction -> Format.formatter -> unit
+  ?max_level:Level.t -> penv:TT.print_env -> eq_type -> Format.formatter -> unit
+
+val print_is_term_abstraction :
+  ?max_level:Level.t -> penv:TT.print_env -> is_term abstraction -> Format.formatter -> unit
+
+val print_is_type_abstraction :
+  ?max_level:Level.t -> penv:TT.print_env -> is_type abstraction -> Format.formatter -> unit
+
+val print_eq_term_abstraction :
+  ?max_level:Level.t -> penv:TT.print_env -> eq_term abstraction -> Format.formatter -> unit
+
+val print_eq_type_abstraction :
+  ?max_level:Level.t -> penv:TT.print_env -> eq_type abstraction -> Format.formatter -> unit
 
 (** Print a nucleus error *)
 val print_error : penv:TT.print_env -> error -> Format.formatter -> unit

--- a/src/nucleus/jdg.mli
+++ b/src/nucleus/jdg.mli
@@ -89,20 +89,24 @@ val form_eq_type_rule : Signature.t -> Name.constructor -> premise list -> eq_ty
     conclusion of the instance of the rule so obtained. *)
 val form_eq_term_rule : Signature.t -> Name.constructor -> premise list -> eq_term
 
-(** Form an abstra *)
+(** Form an abstraction *)
 val form_abstraction : 'a stump_abstraction -> 'a abstraction
 
-val invert_is_type : Signature.t -> is_type -> stump_is_type
+val invert_is_type : is_type -> stump_is_type
 
 val invert_is_term : Signature.t -> is_term -> stump_is_term
 
-val invert_eq_type : Signature.t -> eq_type -> stump_eq_type
+val invert_eq_type : eq_type -> stump_eq_type
 
-val invert_eq_term : Signature.t -> eq_term -> stump_eq_term
+val invert_eq_term : eq_term -> stump_eq_term
 
 val invert_is_term_abstraction : is_term abstraction -> is_term stump_abstraction
 
 val invert_is_type_abstraction : is_type abstraction -> is_type stump_abstraction
+
+val invert_eq_type_abstraction : eq_type abstraction -> eq_type stump_abstraction
+
+val invert_eq_term_abstraction : eq_term abstraction -> eq_term stump_abstraction
 
 (** An error emitted by the nucleus *)
 type error
@@ -111,6 +115,9 @@ exception Error of error
 
 (** The type judgement of a term judgement. *)
 val type_of_term : Signature.t -> is_term -> is_type
+
+(** The type judgement of an abstracted term judgement. *)
+val type_of_term_abstraction : Signature.t -> is_term abstraction -> is_type abstraction
 
 (** Typeof for atoms *)
 val type_of_atom : is_atom -> is_type

--- a/src/nucleus/jdg.mli
+++ b/src/nucleus/jdg.mli
@@ -39,105 +39,84 @@ type stump_eq_type =
 type stump_eq_term =
   | EqTerm of TT.assumption * is_term * is_term * is_type
 
+type 'a stump_abstraction =
+  | NotAbstract of 'a
+  | Abstract of is_atom * 'a abstraction
+
+
+(** An auxiliary type for providing arguments to a congruence rule. Each arguments is like
+   two endpoints with a path between them, except that no paths between equalities are
+   needed. *)
+type congruence_premise =
+  | CongrIsType of is_type abstraction * is_type abstraction * eq_type abstraction
+  | CongrIsTerm of is_term abstraction * is_term abstraction * eq_term abstraction
+  | CongrEqType of eq_type abstraction * eq_type abstraction
+  | CongrEqTerm of eq_term abstraction * eq_term abstraction
+
+
 module Signature : sig
   type t
 
   val empty : t
-
-  val add_constant : Name.constant -> is_type -> t -> t
 end
 
 (** Given a type formation rule and a list of premises, match the rule
    against the given premises, make sure they fit the rule, and return the
    judgement corresponding to the conclusion of the rule. *)
-val form_is_type : Rule.is_type -> premise list -> is_type
+val form_is_type_rule : Signature.t -> Name.constructor -> premise list -> is_type
 
 (** Given a term rule and a list of premises, match the rule against the given
    premises, make sure they fit the rule, and return the list of arguments that the term
    constructor should be applied to, together with the natural type of the resulting term.
  *)
-val form_is_term : Rule.is_term -> premise list -> TT.argument list * TT.ty
+val form_is_term_rule : Signature.t -> Name.constructor -> premise list -> is_term
+
+(** Convert atom judgement to term judgement *)
+val form_is_term_atom : is_atom -> is_term
+
+val form_is_term_convert : Signature.t -> TT.term -> TT.eq_type -> TT.term
 
 (** Given an equality type rule and a list of premises, match the rule against the given
    premises, make sure they fit the rule, and return the conclusion of the instance of the rule
    so obtained. *)
-val form_eq_type : Rule.eq_type -> premise list -> TT.ty * TT.ty
+val form_eq_type_rule : Signature.t -> Name.constructor -> premise list -> eq_type
 
 (** Given an terms equality type rule and a list of premises, match the rule
    against the given premises, make sure they fit the rule, and return the conclusion of
    the instance of the rule so obtained. *)
-val form_eq_term : Rule.eq_term -> premise list -> TT.term * TT.term * TT.ty
+val form_eq_term_rule : Signature.t -> Name.constructor -> premise list -> eq_term
 
-(** Given a term judgment and the arguments of the corresponding term constructor, match
-   the arguments against the rule to invert them to the premises of the rule, as well as
-   to the natural type of the conclusion. *)
-val invert_is_term : Rule.is_term -> TT.argument list -> premise list * TT.ty
+val invert_is_type : Signature.t -> is_type -> stump_is_type
 
-(** Given a type judgment and the arguments of the corresponding term constructor, match
-   the arguments against the rule to invert them to the premises of the rule. *)
-val invert_is_type : Rule.is_type -> TT.argument list -> premise list
+val invert_is_term : Signature.t -> is_term -> stump_is_term
+
+val invert_eq_type : Signature.t -> eq_type -> stump_eq_type
+
+val invert_eq_term : Signature.t -> eq_term -> stump_eq_term
+
+val invert_abstraction : (TT.term -> ?lvl:TT.bound -> 'a -> 'a) -> 'a TT.abstraction -> 'a stump_abstraction
 
 (** An error emitted by the nucleus *)
 type error
 
 exception Error of error
 
-(** Print a nucleus error *)
-val print_error : penv:TT.print_env -> error -> Format.formatter -> unit
-
 (** The type judgement of a term judgement. *)
-val typeof : is_term -> is_type
+val type_of_term : Signature.t -> is_term -> is_type
 
 (** Typeof for atoms *)
-val atom_is_type : is_atom -> is_type
-
-(** Convert atom judgement to term judgement *)
-val atom_is_term : is_atom -> is_term
+val type_of_atom : is_atom -> is_type
 
 (** Does this atom occur in this judgement, and if so with what type? *)
-val occurs : is_atom -> is_term -> is_atom option
-
-(** The context associated with a term judgement. *)
-val contextof : is_term -> is_atom list
-
-(** Print the judgement that something is a term. *)
-val print_is_term : penv:TT.print_env -> ?max_level:Level.t -> is_term -> Format.formatter -> unit
-
-(** Print the judgement that something is a type. *)
-val print_is_type : penv:TT.print_env -> ?max_level:Level.t -> is_type -> Format.formatter -> unit
-
-(** Print the judgement that terms are equal. *)
-val print_eq_term : penv:TT.print_env -> ?max_level:Level.t -> eq_term -> Format.formatter -> unit
-
-(** Print the judgement that types are equal. *)
-val print_eq_type : penv:TT.print_env -> ?max_level:Level.t -> eq_type -> Format.formatter -> unit
-
-(** Destructors *)
-
-(* Inversion principles *)
-val invert_is_term : is_term -> stump_is_term
-val invert_is_type : is_type -> stump_is_type
-val invert_eq_type : eq_type -> TT.assumption * is_type * is_type
-val invert_eq_term : eq_term -> TT.assumption * is_term * is_term * is_type
-
-(** Deconstruct a type judgment into a type abstraction, if possible. *)
-val invert_abstract_ty : is_type -> (is_atom * is_type) option
-
-(** Construct a term judgement using the appropriate formation rule. The type is the natural type. *)
-val form_is_term : Signature.t -> stump_is_term -> is_term
-
-(** Construct a type judgement using the appropriate formation rule. *)
-val form_is_type : Signature.t -> stump_is_type -> is_type
+(* XXX val occurs : is_atom -> is_term -> is_atom option *)
 
 (** Substitution *)
 
-(** [substitute_ty t a v] substitutes [a] with [v] in [t]. *)
-val substitute_ty : is_atom -> is_term -> is_type -> is_type
+(** [substitute_type t a v] substitutes [v] for [a] in [t]. *)
+val substitute_type : is_term -> is_atom -> is_type -> is_type
 
-(** [substitute e a v] substitutes [a] with [v] in [e]. *)
-val substitute : is_term -> is_atom -> is_term -> is_term
-
-(** Conversion *)
+(** [substitute_term e a v] substitutes [v] for [a] in [e]. *)
+val substitute_term : is_term -> is_atom -> is_term -> is_term
 
 (** Destructors *)
 
@@ -147,26 +126,23 @@ val convert_eq_term : eq_term -> eq_type -> eq_term
 (** Constructors *)
 
 (** Construct the judgment [e == e : A] from [e : A] *)
-val reflexivity : is_term -> eq_term
+val reflexivity_term : Signature.t -> is_term -> eq_term
 
 (** Construct the jdugment [A == A] from [A type] *)
-val reflexivity_ty : is_type -> eq_type
+val reflexivity_type : is_type -> eq_type
 
 (** Given two terms [e1 : A1] and [e2 : A2] construct [e1 == e2 : A1],
     provided [A1] and [A2] are alpha equal and [e1] and [e2] are alpha equal *)
-val mk_alpha_equal : is_term -> is_term -> eq_term option
+val mk_alpha_equal_term : Signature.t -> is_term -> is_term -> eq_term option
 
 (** Given two types [A] and [B] construct [A == B] provided the types are alpha equal *)
-val mk_alpha_equal_ty : is_type -> is_type -> eq_type option
+val mk_alpha_equal_type : is_type -> is_type -> eq_type option
 
 (** Test whether terms are alpha-equal. They may have different types and incompatible contexts even if [true] is returned. *)
 val alpha_equal_is_term : is_term -> is_term -> bool
 
 (** Test whether types are alpha-equal. They may have different contexts. *)
 val alpha_equal_is_type : is_type -> is_type -> bool
-
-(** Form an equality of two alpha-equal types. They must also have compatible contexts. *)
-val alpha_equal_eq_type : is_type -> is_type -> eq_type option
 
 (** If [e1 == e2 : A] then [e2 == e1 : A] *)
 val symmetry_term : eq_term -> eq_term
@@ -182,18 +158,36 @@ val transitivity_type : eq_type -> eq_type -> eq_type
 
 (** Congruence rules *)
 
-(** If [A1 == A2] and [B1 == B2] then [{x : A1} B1 == {x : A2} B2].
-    The first atom is used to abstract both sides. The second is used only for the name in the right hand side product. *)
-val congr_abstract_type : eq_type -> is_atom -> is_atom -> eq_type -> eq_type
+val congruence_type_constructor :
+  Signature.t -> Name.constructor -> congruence_premise list -> eq_type
 
-(** If [A1 == A2], [B1 == B2] and [e1 == e2 : B1] then [{x : A1} (e1 : B1) == {x : A2} (e2 : B2) : {x : A1} B1].
-    The first atom is used to abstract both sides. The second is used only for the name in the right hand side. *)
-val congr_abstract_term : eq_type -> is_atom -> is_atom -> eq_type -> eq_term -> eq_term
+val congruence_term_constructor :
+  Signature.t -> Name.constructor -> congruence_premise list -> eq_term
 
-(** Derivable rules *)
+
+(** Print the judgement that something is a term. *)
+val print_is_term :
+  penv:TT.print_env -> ?max_level:Level.t -> is_term abstraction -> Format.formatter -> unit
+
+(** Print the judgement that something is a type. *)
+val print_is_type :
+  penv:TT.print_env -> ?max_level:Level.t -> is_type abstraction -> Format.formatter -> unit
+
+(** Print the judgement that terms are equal. *)
+val print_eq_term :
+  penv:TT.print_env -> ?max_level:Level.t -> eq_term abstraction -> Format.formatter -> unit
+
+(** Print the judgement that types are equal. *)
+val print_eq_type :
+  penv:TT.print_env -> ?max_level:Level.t -> eq_type abstraction -> Format.formatter -> unit
+
+(** Print a nucleus error *)
+val print_error : penv:TT.print_env -> error -> Format.formatter -> unit
 
 module Json :
 sig
+  val abstraction : ('a -> Json.t) -> 'a abstraction -> Json.t
+
   val is_term : is_term -> Json.t
 
   val is_type : is_type -> Json.t

--- a/src/nucleus/jdg.mli
+++ b/src/nucleus/jdg.mli
@@ -247,7 +247,7 @@ val form_is_type : loc:Location.t -> Signature.t -> stump_is_type -> is_type
 (** Substitution *)
 
 (** [substitute_ty t a v] substitutes [a] with [v] in [t]. *)
-val substitute_ty : loc:Location.t -> is_type -> is_atom -> is_term -> is_type
+val substitute_ty : loc:Location.t -> is_atom -> is_term -> is_type -> is_type
 
 (** [substitute e a v] substitutes [a] with [v] in [e]. *)
 val substitute : loc:Location.t -> is_term -> is_atom -> is_term -> is_term

--- a/src/nucleus/jdg.mli
+++ b/src/nucleus/jdg.mli
@@ -171,8 +171,8 @@ val mk_alpha_equal_type : is_type -> is_type -> eq_type option
 
 (** Given two abstractions, construct an abstracted equality provided the abstracted entities are alpha equal. *)
 val mk_alpha_equal_abstraction :
-  ('a -> 'b -> 'c TT.abstraction option) ->
-  'a TT.abstraction -> 'b TT.abstraction -> 'c TT.abstraction option
+  ('a -> 'b -> 'c option) ->
+  'a abstraction -> 'b abstraction -> 'c abstraction option
 
 (** Test whether terms are alpha-equal. They may have different types and incompatible contexts even if [true] is returned. *)
 val alpha_equal_term : is_term -> is_term -> bool

--- a/src/nucleus/jdg.mli
+++ b/src/nucleus/jdg.mli
@@ -1,5 +1,5 @@
 (** Judgements can be abstracted *)
-type 'a abstraction = (TT.ty, 'a) TT.abstraction
+type 'a abstraction = 'a TT.abstraction
 
 (** Judgement that something is a term. *)
 type is_term
@@ -23,22 +23,22 @@ type premise =
   | PremiseEqType of eq_type
   | PremiseEqTerm of eq_term
 
-(** A shape is the data needed to form a judgement, or to invert it. Shapes of
+(** A stump is the data needed to form a judgement, or to invert it. Stumps of
    equations are special, because they allow only partial inversion. *)
 
-type shape_is_type =
+type stump_is_type =
   | TypeConstructor of Name.constructor * premise list
 
-and shape_is_term =
-  | TermAtom of Name.atom * TT.ty
+type stump_is_term =
+  | TermAtom of is_type TT.atom
   | TermConstructor of Name.constructor * premise list
   | TermConvert of is_term * eq_type
 
-and shape_eq_type =
-  | EqType of TT.eq_type * is_type * is_type
+type stump_eq_type =
+  | EqType of TT.assumption * is_type * is_type
 
-and shape_eq_term =
-  | EqTerm of TT.eq_term * is_term * is_term * is_type
+type stump_eq_term =
+  | EqTerm of TT.assumption * is_term * is_term * is_type
 
 type ctx
 
@@ -230,8 +230,8 @@ val print_eq_type : penv:TT.print_env -> ?max_level:Level.t -> eq_type -> Format
 (** Destructors *)
 
 (* Inversion principles *)
-val invert_is_term : is_term -> shape_is_term
-val invert_is_type : is_type -> shape_is_type
+val invert_is_term : is_term -> stump_is_term
+val invert_is_type : is_type -> stump_is_type
 val invert_eq_type : eq_type -> TT.assumption * is_type * is_type
 val invert_eq_term : eq_term -> TT.assumption * is_term * is_term * is_type
 
@@ -239,10 +239,10 @@ val invert_eq_term : eq_term -> TT.assumption * is_term * is_term * is_type
 val invert_abstract_ty : is_type -> (is_atom * is_type) option
 
 (** Construct a term judgement using the appropriate formation rule. The type is the natural type. *)
-val form_is_term : loc:Location.t -> Signature.t -> shape_is_term -> is_term
+val form_is_term : loc:Location.t -> Signature.t -> stump_is_term -> is_term
 
 (** Construct a type judgement using the appropriate formation rule. *)
-val form_is_type : loc:Location.t -> Signature.t -> shape_is_type -> is_type
+val form_is_type : loc:Location.t -> Signature.t -> stump_is_type -> is_type
 
 (** Substitution *)
 

--- a/src/nucleus/jdg.mli
+++ b/src/nucleus/jdg.mli
@@ -118,13 +118,17 @@ val invert_eq_type : eq_type -> stump_eq_type
 
 val invert_eq_term : eq_term -> stump_eq_term
 
-val invert_is_term_abstraction : is_term_abstraction -> is_term stump_abstraction
+val invert_is_term_abstraction :
+  ?atom_name:Name.ident -> is_term_abstraction -> is_term stump_abstraction
 
-val invert_is_type_abstraction : is_type_abstraction -> is_type stump_abstraction
+val invert_is_type_abstraction :
+  ?atom_name:Name.ident -> is_type_abstraction -> is_type stump_abstraction
 
-val invert_eq_type_abstraction : eq_type_abstraction -> eq_type stump_abstraction
+val invert_eq_type_abstraction :
+  ?atom_name:Name.ident -> eq_type_abstraction -> eq_type stump_abstraction
 
-val invert_eq_term_abstraction : eq_term_abstraction -> eq_term stump_abstraction
+val invert_eq_term_abstraction :
+  ?atom_name:Name.ident -> eq_term_abstraction -> eq_term stump_abstraction
 
 val context_is_type_abstraction : is_type_abstraction -> is_atom list
 val context_is_term_abstraction : is_term_abstraction -> is_atom list
@@ -151,11 +155,17 @@ val occurs_is_term_abstraction : is_atom -> is_term_abstraction -> bool
 val occurs_eq_type_abstraction : is_atom -> eq_type_abstraction -> bool
 val occurs_eq_term_abstraction : is_atom -> eq_term_abstraction -> bool
 
-(** [substitute_type t a v] substitutes [v] for [a] in [t]. *)
-val substitute_type : is_term -> is_atom -> is_type -> is_type
+val apply_is_type_abstraction :
+  Signature.t -> is_type_abstraction -> is_term -> is_type_abstraction
 
-(** [substitute_term e a v] substitutes [v] for [a] in [e]. *)
-val substitute_term : is_term -> is_atom -> is_term -> is_term
+val apply_is_term_abstraction :
+  Signature.t -> is_term_abstraction -> is_term -> is_term_abstraction
+
+val apply_eq_type_abstraction :
+  Signature.t -> eq_type_abstraction -> is_term -> eq_type_abstraction
+
+val apply_eq_term_abstraction :
+  Signature.t -> eq_term_abstraction -> is_term -> eq_term_abstraction
 
 (** If [e1 == e2 : A] and [A == B] then [e1 == e2 : B] *)
 val convert_eq_term : eq_term -> eq_type -> eq_term

--- a/src/nucleus/jdg.mli
+++ b/src/nucleus/jdg.mli
@@ -89,8 +89,13 @@ val form_eq_type_rule : Signature.t -> Name.constructor -> premise list -> eq_ty
     conclusion of the instance of the rule so obtained. *)
 val form_eq_term_rule : Signature.t -> Name.constructor -> premise list -> eq_term
 
-(** Form an abstraction *)
-val form_abstraction : 'a stump_abstraction -> 'a abstraction
+(** Form a non-abstracted abstraction *)
+val form_not_abstract : 'a -> 'a abstraction
+
+(** Form an abstracted abstraction *)
+val form_abstract :
+  (Name.atom -> ?lvl:TT.bound -> 'a -> 'a) ->
+  TT.ty TT.atom -> 'a TT.abstraction -> 'a TT.abstraction
 
 val invert_is_type : is_type -> stump_is_type
 
@@ -125,20 +130,14 @@ val type_of_atom : is_atom -> is_type
 (** Does this atom occur in this judgement, and if so with what type? *)
 (* XXX val occurs : is_atom -> is_term -> is_atom option *)
 
-(** Substitution *)
-
 (** [substitute_type t a v] substitutes [v] for [a] in [t]. *)
 val substitute_type : is_term -> is_atom -> is_type -> is_type
 
 (** [substitute_term e a v] substitutes [v] for [a] in [e]. *)
 val substitute_term : is_term -> is_atom -> is_term -> is_term
 
-(** Destructors *)
-
 (** If [e1 == e2 : A] and [A == B] then [e1 == e2 : B] *)
 val convert_eq_term : eq_term -> eq_type -> eq_term
-
-(** Constructors *)
 
 (** Construct the judgment [e == e : A] from [e : A] *)
 val reflexivity_term : Signature.t -> is_term -> eq_term
@@ -153,11 +152,16 @@ val mk_alpha_equal_term : Signature.t -> is_term -> is_term -> eq_term option
 (** Given two types [A] and [B] construct [A == B] provided the types are alpha equal *)
 val mk_alpha_equal_type : is_type -> is_type -> eq_type option
 
+(** Given two abstractions, construct an abstracted equality provided the abstracted entities are alpha equal. *)
+val mk_alpha_equal_abstraction :
+  ('a -> 'b -> 'c TT.abstraction option) ->
+  'a TT.abstraction -> 'b TT.abstraction -> 'c TT.abstraction option
+
 (** Test whether terms are alpha-equal. They may have different types and incompatible contexts even if [true] is returned. *)
-val alpha_equal_is_term : is_term -> is_term -> bool
+val alpha_equal_term : is_term -> is_term -> bool
 
 (** Test whether types are alpha-equal. They may have different contexts. *)
-val alpha_equal_is_type : is_type -> is_type -> bool
+val alpha_equal_type : is_type -> is_type -> bool
 
 val alpha_equal_abstraction
   : ('a -> 'a -> bool) -> 'a abstraction -> 'a abstraction -> bool

--- a/src/nucleus/jdg.mli
+++ b/src/nucleus/jdg.mli
@@ -1,21 +1,20 @@
-(** A judgement context. *)
-type ctx
+(** Judgements can be abstracted *)
+type 'a abstraction = (TT.ty, 'a) TT.abstraction
 
-(** Possibly abstracted judgement that something is a term, i.e.,
-    [ctx |- e : t] or [ctx |- {x1 : t1} .... {xn : tn} (e : t)] *)
+(** Judgement that something is a term. *)
 type is_term
 
-(** Judgement [(x : t) in ctx] *)
+(** Judgement that somethin is an atom. *)
 type is_atom
 
-(** Possibly abstracted judgement [ctx |- t type] *)
+(** Judgement that something is a type. *)
 type is_type
 
-(** Possibly abstracted judgement [ctx |- e1 == e2 : t] *)
-type eq_term
-
-(** Possibly abstracted judgement [ctx |- t1 == t2] *)
+(** Judgement that something is a type equality. *)
 type eq_type
+
+(** Judgement that something is a term equality. *)
+type eq_term
 
 (** An argument to a term or type constructor *)
 type premise =
@@ -24,16 +23,24 @@ type premise =
   | PremiseEqType of eq_type
   | PremiseEqTerm of eq_term
 
-(** Contains enough information to construct a new judgement *)
-type shape_is_term =
-  | Atom of is_atom
+(** A shape is the data needed to form a judgement, or to invert it. Shapes of
+   equations are special, because they allow only partial inversion. *)
+
+type shape_is_type =
+  | TypeConstructor of Name.constructor * premise list
+
+and shape_is_term =
+  | TermAtom of Name.atom * TT.ty
   | TermConstructor of Name.constructor * premise list
   | TermConvert of is_term * eq_type
-  | TermAbstract of is_atom * is_term
 
-and shape_is_type =
-  | TypeConstructor of Name.constructor * premise list
-  | TypeAbstract of is_atom * is_type
+and shape_eq_type =
+  | EqType of TT.eq_type * is_type * is_type
+
+and shape_eq_term =
+  | EqTerm of TT.eq_term * is_term * is_term * is_type
+
+type ctx
 
 module Ctx : sig
   (** The type of contexts. *)

--- a/src/nucleus/jdg.mli
+++ b/src/nucleus/jdg.mli
@@ -4,7 +4,7 @@ type 'a abstraction = 'a TT.abstraction
 (** Judgement that something is a term. *)
 type is_term
 
-(** Judgement that somethin is an atom. *)
+(** Judgement that something is an atom. *)
 type is_atom
 
 (** Judgement that something is a type. *)
@@ -196,7 +196,7 @@ val atom_is_term : loc:Location.t -> is_atom -> is_term
 val occurs : is_atom -> is_term -> is_atom option
 
 (** The context associated with a term judgement. *)
-val contextof : is_term -> Ctx.t
+val contextof : is_term -> is_atom list
 
 (** Print the judgement that something is a term. *)
 val print_is_term : penv:TT.print_env -> ?max_level:Level.t -> is_term -> Format.formatter -> unit

--- a/src/nucleus/jdg.mli
+++ b/src/nucleus/jdg.mli
@@ -80,7 +80,7 @@ val invert_is_type : Rule.is_type -> TT.argument list -> premise list
 (** An error emitted by the nucleus *)
 type error
 
-exception Error of error Location.located
+exception Error of error
 
 (** Print a nucleus error *)
 val print_error : penv:TT.print_env -> error -> Format.formatter -> unit
@@ -92,7 +92,7 @@ val typeof : is_term -> is_type
 val atom_is_type : is_atom -> is_type
 
 (** Convert atom judgement to term judgement *)
-val atom_is_term : loc:Location.t -> is_atom -> is_term
+val atom_is_term : is_atom -> is_term
 
 (** Does this atom occur in this judgement, and if so with what type? *)
 val occurs : is_atom -> is_term -> is_atom option
@@ -124,25 +124,25 @@ val invert_eq_term : eq_term -> TT.assumption * is_term * is_term * is_type
 val invert_abstract_ty : is_type -> (is_atom * is_type) option
 
 (** Construct a term judgement using the appropriate formation rule. The type is the natural type. *)
-val form_is_term : loc:Location.t -> Signature.t -> stump_is_term -> is_term
+val form_is_term : Signature.t -> stump_is_term -> is_term
 
 (** Construct a type judgement using the appropriate formation rule. *)
-val form_is_type : loc:Location.t -> Signature.t -> stump_is_type -> is_type
+val form_is_type : Signature.t -> stump_is_type -> is_type
 
 (** Substitution *)
 
 (** [substitute_ty t a v] substitutes [a] with [v] in [t]. *)
-val substitute_ty : loc:Location.t -> is_atom -> is_term -> is_type -> is_type
+val substitute_ty : is_atom -> is_term -> is_type -> is_type
 
 (** [substitute e a v] substitutes [a] with [v] in [e]. *)
-val substitute : loc:Location.t -> is_term -> is_atom -> is_term -> is_term
+val substitute : is_term -> is_atom -> is_term -> is_term
 
 (** Conversion *)
 
 (** Destructors *)
 
 (** If [e1 == e2 : A] and [A == B] then [e1 == e2 : B] *)
-val convert_eq_term : loc:Location.t -> eq_term -> eq_type -> eq_term
+val convert_eq_term : eq_term -> eq_type -> eq_term
 
 (** Constructors *)
 
@@ -154,10 +154,10 @@ val reflexivity_ty : is_type -> eq_type
 
 (** Given two terms [e1 : A1] and [e2 : A2] construct [e1 == e2 : A1],
     provided [A1] and [A2] are alpha equal and [e1] and [e2] are alpha equal *)
-val mk_alpha_equal : loc:Location.t -> is_term -> is_term -> eq_term option
+val mk_alpha_equal : is_term -> is_term -> eq_term option
 
 (** Given two types [A] and [B] construct [A == B] provided the types are alpha equal *)
-val mk_alpha_equal_ty : loc:Location.t -> is_type -> is_type -> eq_type option
+val mk_alpha_equal_ty : is_type -> is_type -> eq_type option
 
 (** Test whether terms are alpha-equal. They may have different types and incompatible contexts even if [true] is returned. *)
 val alpha_equal_is_term : is_term -> is_term -> bool
@@ -166,7 +166,7 @@ val alpha_equal_is_term : is_term -> is_term -> bool
 val alpha_equal_is_type : is_type -> is_type -> bool
 
 (** Form an equality of two alpha-equal types. They must also have compatible contexts. *)
-val alpha_equal_eq_type : loc:Location.t -> is_type -> is_type -> eq_type option
+val alpha_equal_eq_type : is_type -> is_type -> eq_type option
 
 (** If [e1 == e2 : A] then [e2 == e1 : A] *)
 val symmetry_term : eq_term -> eq_term
@@ -175,20 +175,20 @@ val symmetry_term : eq_term -> eq_term
 val symmetry_type : eq_type -> eq_type
 
 (** If [e1 == e2 : A] and [e2 == e3 : A] then [e1 == e2 : A] *)
-val transitivity_term : loc:Location.t -> eq_term -> eq_term -> eq_term
+val transitivity_term : eq_term -> eq_term -> eq_term
 
 (** If [A == B] and [B == C] then [A == C] *)
-val transitivity_type : loc:Location.t -> eq_type -> eq_type -> eq_type
+val transitivity_type : eq_type -> eq_type -> eq_type
 
 (** Congruence rules *)
 
 (** If [A1 == A2] and [B1 == B2] then [{x : A1} B1 == {x : A2} B2].
     The first atom is used to abstract both sides. The second is used only for the name in the right hand side product. *)
-val congr_abstract_type : loc:Location.t -> eq_type -> is_atom -> is_atom -> eq_type -> eq_type
+val congr_abstract_type : eq_type -> is_atom -> is_atom -> eq_type -> eq_type
 
 (** If [A1 == A2], [B1 == B2] and [e1 == e2 : B1] then [{x : A1} (e1 : B1) == {x : A2} (e2 : B2) : {x : A1} B1].
     The first atom is used to abstract both sides. The second is used only for the name in the right hand side. *)
-val congr_abstract_term : loc:Location.t -> eq_type -> is_atom -> is_atom -> eq_type -> eq_term -> eq_term
+val congr_abstract_term : eq_type -> is_atom -> is_atom -> eq_type -> eq_term -> eq_term
 
 (** Derivable rules *)
 

--- a/src/nucleus/jdg.mli
+++ b/src/nucleus/jdg.mli
@@ -25,19 +25,21 @@ type premise =
 
 (** A stump is obtained when we invert a judgement. *)
 
+type assumption = is_type Assumption.t
+
 type stump_is_type =
   | TypeConstructor of Name.constructor * premise list
 
 type stump_is_term =
-  | TermAtom of is_type TT.atom
+  | TermAtom of is_atom
   | TermConstructor of Name.constructor * premise list
   | TermConvert of is_term * eq_type
 
 type stump_eq_type =
-  | EqType of TT.assumption * is_type * is_type
+  | EqType of assumption * is_type * is_type
 
 type stump_eq_term =
-  | EqTerm of TT.assumption * is_term * is_term * is_type
+  | EqTerm of assumption * is_term * is_term * is_type
 
 type 'a stump_abstraction =
   | NotAbstract of 'a
@@ -113,6 +115,11 @@ val invert_eq_type_abstraction : eq_type abstraction -> eq_type stump_abstractio
 
 val invert_eq_term_abstraction : eq_term abstraction -> eq_term stump_abstraction
 
+val context_is_type_abstraction : is_type abstraction -> is_atom list
+val context_is_term_abstraction : is_term abstraction -> is_atom list
+val context_eq_type_abstraction : eq_type abstraction -> is_atom list
+val context_eq_term_abstraction : eq_term abstraction -> is_atom list
+
 (** An error emitted by the nucleus *)
 type error
 
@@ -127,8 +134,11 @@ val type_of_term_abstraction : Signature.t -> is_term abstraction -> is_type abs
 (** Typeof for atoms *)
 val type_of_atom : is_atom -> is_type
 
-(** Does this atom occur in this judgement, and if so with what type? *)
-(* XXX val occurs : is_atom -> is_term -> is_atom option *)
+(** Does this atom occur in this judgement? *)
+val occurs_is_type_abstraction : is_atom -> is_type abstraction -> bool
+val occurs_is_term_abstraction : is_atom -> is_term abstraction -> bool
+val occurs_eq_type_abstraction : is_atom -> eq_type abstraction -> bool
+val occurs_eq_term_abstraction : is_atom -> eq_term abstraction -> bool
 
 (** [substitute_type t a v] substitutes [v] for [a] in [t]. *)
 val substitute_type : is_term -> is_atom -> is_type -> is_type
@@ -177,6 +187,9 @@ val transitivity_term : eq_term -> eq_term -> eq_term
 
 (** If [A == B] and [B == C] then [A == C] *)
 val transitivity_type : eq_type -> eq_type -> eq_type
+
+(** Given [e : A], compute the natural type of [e] as [B], return [B == A] *)
+val natural_type_eq : Signature.t -> is_term -> eq_type
 
 (** Congruence rules *)
 

--- a/src/nucleus/rule.ml
+++ b/src/nucleus/rule.ml
@@ -1,0 +1,120 @@
+(** The datatypes for describing the user-definable rules of type theory. *)
+
+type meta = int  (* meta-variables appearing in rules *)
+type bound = TT.bound
+
+type term =
+  | TermBound of bound
+  | TermConstructor of Name.constructor * argument list
+  | TermMeta of meta * term list
+
+and ty =
+  | TypeConstructor of Name.constructor * argument list
+  | TypeMeta of meta * term list
+
+and eq_type = EqType of assumption * ty * ty
+
+and eq_term = EqTerm of assumption * term * term * ty
+
+and argument =
+  | ArgIsType of ty abstraction
+  | ArgIsTerm of term abstraction
+  | ArgEqType of eq_type abstraction
+  | ArgEqTerm of eq_term abstraction
+
+and 'a abstraction =
+  | NotAbstract of 'a
+  | Abstract of Name.ident * ty * 'a abstraction
+
+and assumption = ()
+
+type premise =
+  | PremiseIsType of Name.ident * unit abstraction
+  | PremiseIsTerm of Name.ident * ty abstraction
+  | PremiseEqType of (ty * ty) abstraction
+  | PremiseEqTerm of (term * term * ty) abstraction
+
+type is_type_rule = premise list
+type is_term_rule = premise list * ty
+type eq_type_rule = premise list * (ty * ty)
+type eq_term_rule = premise list * (term * term * ty)
+
+(** Examples of rules that can be formulated using the above.
+
+   The head of the conclusion (the parts in square brackets) is not really
+   there because it is fully prescribed by the premises and the judgement
+   class; we just specify it here for readability.
+
+
+      Input:
+      ⊢ A type    x:A ⊢ B type
+      ————————————————————————
+      ⊢ [Π A B] type
+
+      Processed to schema:
+      ⊢ A type    {x : MV 0} ⊢ B type
+      ———————————————————————————————
+      ⊢ [Π A B] type
+
+      Instance:
+      Γ₁ ⊢ A₁ type    Γ₂ | {y:A₂} ⊢ B₁ type
+      ——————————————————————————————————— {Γ₁,Γ₂}↑Δ, A₁ =α= A₂
+      Δ ⊢ Π A B type
+
+
+      Input:
+      ⊢ A type    x:A ⊢ B type   y:A ⊢ s : B{y}
+      —————————————————————————————————————————
+      ⊢ [λ A B s] : Π A B
+
+      Processed to schema:
+      ⊢ A type    {x : MV 0} ⊢ B type   {y : MV 1} ⊢ s : (MV 0){y}
+      ————————————————————————————————————————————————————————————
+      ⊢ [λ A B s] : Π (MV 2) (MV 1)
+
+      Instance:
+      Γ₁ ⊢ A₁ type    Γ₂ | {x:A₂} ⊢ B₁ type   Γ₃ | {y:A₃} ⊢ s : B₂
+      ————————————————————————————————————————————————————————————
+      check: {Γ₁,Γ₂,Γ₃}↑Δ, A₁ =α= A₂ =α= A₃, B₁ =α= B₂
+      Δ ⊢ λ A₁ B₁ s : Π A₁ B₁
+
+      example: [A := nat, B := nat, s := Bound 0]
+         gives   [λ nat nat (Bound 0) : Π nat ({0:nat} nat)]
+
+
+      Input:
+      ⊢ A type   ⊢ u : A   ⊢ v : A
+      ————————————————————————————
+      ⊢ [Id A u v]  type
+
+      Processed to Schema:
+      ⊢ A type   ⊢ u : MV 0   ⊢ v : MV 1
+      ——————————————————————————————————
+      ⊢ [Id A u v]  type
+
+      Instance:
+      Γ₁ ⊢ A₁ type   Γ₂ ⊢ u : A₂   Γ₃ ⊢ v : A₃
+      ———————————————————————————————————————— {Γ₁, Γ₂, Γ₃} ↑ Δ, Α₁ =α= A₂, A₁ =α= A₃
+      Δ ⊢ Id A₁ u v  type
+
+
+      Input:
+      ⊢ A type    ⊢ u : A     x : A, p : Id A u x ⊢ C type
+      ⊢ w : C{u, refl A u}    ⊢ v : A     ⊢ p : Id A u v
+      ————————————————————————————————————————————————————
+      ⊢ [J A u C w v p] : C{v, p}
+
+      Schema:
+      ⊢ A type    ⊢ u : MV 0     {x : A, p : Id (MV 1) (MV 0) (Bound 0)} ⊢ C type
+      ⊢ w : C{u, refl A u}       ⊢ v : A     ⊢ p : Id A u v
+      ————————————————————————————————————————————————————————————————————————————
+      ⊢ [J A u C w v p] : C{v, p}
+
+      Instance:
+      ⊢ A₁ type    ⊢ u₁ : A₂     x : A₃, h : Id A u x ⊢ C type    ⊢ w : C{u, refl A u}
+      ⊢ v : A     ⊢ p : Id A u v
+      ————————————————————————————————————————————————————————————————————————————————
+      ⊢ [J A u C w v p] : C{v, p}
+
+
+*)

--- a/src/parser/desugar.ml
+++ b/src/parser/desugar.ml
@@ -300,8 +300,8 @@ let rec tt_pattern ctx {Location.thing=p';loc} =
               match xopt with
               | Some x ->
                  let ctx = Ctx.add_variable x ctx in
-                 ctx, x
-              | None -> ctx, Name.anonymous ()
+                 ctx, Some x
+              | None -> ctx, None
             end
           in
           let ctx, p = fold ctx abstr in

--- a/src/parser/desugar.ml
+++ b/src/parser/desugar.ml
@@ -143,6 +143,10 @@ end (* module Ctx *)
 
 let locate = Location.locate
 
+let rec mlty_abstraction = function
+  | Input.ML_NotAbstract -> Dsyntax.ML_NotAbstract
+  | Input.ML_Abstract abstr -> Dsyntax.ML_Abstract (mlty_abstraction abstr)
+
 let mlty ctx params ty =
   let rec mlty ({Location.thing=ty';loc}) =
     let ty' =
@@ -197,13 +201,21 @@ let mlty ctx params ty =
       | Input.ML_Anonymous ->
          Dsyntax.ML_Anonymous
 
-      | Input.ML_IsType -> Dsyntax.ML_IsType
+      | Input.ML_IsType abstr ->
+         let abstr = mlty_abstraction abstr
+         in Dsyntax.ML_IsType abstr
 
-      | Input.ML_IsTerm -> Dsyntax.ML_IsTerm
+      | Input.ML_IsTerm abstr ->
+         let abstr = mlty_abstraction abstr
+         in Dsyntax.ML_IsTerm abstr
 
-      | Input.ML_EqType -> Dsyntax.ML_EqType
+      | Input.ML_EqType abstr ->
+         let abstr = mlty_abstraction abstr
+         in Dsyntax.ML_EqType abstr
 
-      | Input.ML_EqTerm -> Dsyntax.ML_EqTerm
+      | Input.ML_EqTerm abstr ->
+         let abstr = mlty_abstraction abstr
+         in Dsyntax.ML_EqTerm abstr
 
       | Input.ML_String -> Dsyntax.ML_String
       end

--- a/src/parser/desugar.ml
+++ b/src/parser/desugar.ml
@@ -159,13 +159,12 @@ let rec mlty_judgement = function
 let rec mlty_abstracted_judgement = function
 
   | Input.ML_NotAbstract frm ->
-     let frm = mlty_judgement frm
-     in Dsyntax.ML_NotAbstract frm
+     let frm = mlty_judgement frm in
+     Dsyntax.ML_NotAbstract frm
 
-  | Input.ML_Abstract (frm, abstr) ->
-     let frm = mlty_judgement frm
-     and abstr = mlty_abstracted_judgement abstr
-     in Dsyntax.ML_Abstract (frm, abstr)
+  | Input.ML_Abstract abstr ->
+     let abstr = mlty_abstracted_judgement abstr in
+     Dsyntax.ML_Abstract abstr
 
 let mlty ctx params ty =
   let rec mlty ({Location.thing=ty';loc}) =
@@ -279,6 +278,10 @@ let rec tt_pattern ctx {Location.thing=p';loc} =
      let ctx, p = tt_pattern ctx p in
      ctx, locate (Dsyntax.Patt_TT_GenAtom p) loc
 
+  | Input.Patt_TT_IsType p ->
+     let ctx, p = tt_pattern ctx p in
+     ctx, locate (Dsyntax.Patt_TT_IsType p) loc
+
   | Input.Patt_TT_IsTerm (p1, p2) ->
      let ctx, p1 = tt_pattern ctx p1 in
      let ctx, p2 = tt_pattern ctx p2 in
@@ -301,7 +304,7 @@ let rec tt_pattern ctx {Location.thing=p';loc} =
        | (xopt, popt) :: abstr ->
           let ctx, popt =
             match popt with
-            | None -> ctx, Dsyntax.Patt_TT_Anonymous
+            | None -> ctx, locate Dsyntax.Patt_TT_Anonymous loc
             | Some p ->
                let ctx, p = tt_pattern ctx p in
                ctx, p
@@ -445,6 +448,9 @@ let rec check_linear_tt forbidden {Location.thing=p';loc} =
      List.fold_left check_linear_tt forbidden ps
 
   | Input.Patt_TT_GenAtom p ->
+     check_linear_tt forbidden p
+
+  | Input.Patt_TT_IsType p ->
      check_linear_tt forbidden p
 
   | Input.Patt_TT_EqTerm (p1, p2, p3) ->

--- a/src/parser/desugar.ml
+++ b/src/parser/desugar.ml
@@ -27,7 +27,6 @@ type error =
   | InvalidPatternName : Name.ident * 'a info -> error
   | InvalidAppliedPatternName : Name.ident * 'a info -> error
   | NonlinearPattern : Name.ident -> error
-  | TermPatternExpected
   | ArityMismatch of Name.ident * int * int
   | UnboundYield
   | ParallelShadowing of Name.ident
@@ -44,7 +43,6 @@ let print_error err ppf = match err with
   | InvalidPatternName (x, info) -> Format.fprintf ppf "%t cannot be used in a pattern as it is %t." (Name.print_ident x) (print_info info)
   | InvalidAppliedPatternName (x, info) -> Format.fprintf ppf "%t cannot be applied in a pattern as it is %t." (Name.print_ident x) (print_info info)
   | NonlinearPattern x -> Format.fprintf ppf "non-linear pattern variable %t is not allowed (but you may interpolate it)." (Name.print_ident x)
-  | TermPatternExpected -> Format.fprintf ppf "This pattern should match terms but it matches types."
   | ArityMismatch (x, used, expected) -> Format.fprintf ppf "%t expects %d arguments but is used with %d." (Name.print_ident x) expected used
   | UnboundYield -> Format.fprintf ppf "yield may only appear in a handler's operation cases."
   | ParallelShadowing x -> Format.fprintf ppf "%t is bound more than once." (Name.print_ident x)
@@ -150,7 +148,7 @@ end (* module Ctx *)
 
 let locate = Location.locate
 
-let rec mlty_judgement = function
+let mlty_judgement = function
   | Input.ML_IsType -> Dsyntax.ML_IsType
   | Input.ML_IsTerm -> Dsyntax.ML_IsTerm
   | Input.ML_EqType -> Dsyntax.ML_EqType

--- a/src/parser/desugar.ml
+++ b/src/parser/desugar.ml
@@ -301,10 +301,10 @@ let rec tt_pattern ctx {Location.thing=p';loc} =
        | (xopt, popt) :: abstr ->
           let ctx, popt =
             match popt with
-            | None -> ctx, None
+            | None -> ctx, Dsyntax.Patt_TT_Anonymous
             | Some p ->
                let ctx, p = tt_pattern ctx p in
-               ctx, Some p
+               ctx, p
           in
           let ctx, xopt =
             begin

--- a/src/parser/desugar.ml
+++ b/src/parser/desugar.ml
@@ -21,7 +21,6 @@ type error =
   | UnknownTypeName of Name.ident
   | OperationExpected : Name.ident * 'a info -> error
   | OperationAlreadyDeclared of Name.ident
-  | TTConstructorAlreadyDeclared of Name.ident
   | AMLConstructorAlreadyDeclared of Name.ident
   | InvalidTermPatternName : Name.ident * 'a info -> error
   | InvalidPatternName : Name.ident * 'a info -> error
@@ -37,7 +36,6 @@ let print_error err ppf = match err with
   | UnknownTypeName x -> Format.fprintf ppf "Unknown type name %t." (Name.print_ident x)
   | OperationExpected (x, info) -> Format.fprintf ppf "%t should be an operation, but is %t." (Name.print_ident x) (print_info info)
   | OperationAlreadyDeclared x -> Format.fprintf ppf "An operation %t is already declared." (Name.print_ident x)
-  | TTConstructorAlreadyDeclared x -> Format.fprintf ppf "The constructor %t is already declared." (Name.print_ident x)
   | AMLConstructorAlreadyDeclared x -> Format.fprintf ppf "The AML constructor %t is already declared." (Name.print_ident x)
   | InvalidTermPatternName (x, info) -> Format.fprintf ppf "%t cannot be used in a term pattern as it is %t." (Name.print_ident x) (print_info info)
   | InvalidPatternName (x, info) -> Format.fprintf ppf "%t cannot be used in a pattern as it is %t." (Name.print_ident x) (print_info info)
@@ -112,13 +110,6 @@ module Ctx = struct
       error ~loc (AMLConstructorAlreadyDeclared c)
     else
       { ctx with bound = (c, AMLConstructor k) :: ctx.bound }
-
-  let add_tt_constructor ~loc c k ctx =
-    if List.exists (function (c', TTConstructor _) -> Name.eq_ident c c' | _ -> false) ctx.bound
-    then
-      error ~loc (TTConstructorAlreadyDeclared c)
-    else
-      { ctx with bound = (c, TTConstructor k) :: ctx.bound }
 
 
   (* Add to the context the fact that [ty] is a type constructor with

--- a/src/parser/desugar.ml
+++ b/src/parser/desugar.ml
@@ -583,7 +583,7 @@ let rec comp ~yield ctx {Location.thing=c';loc} =
         if k = 0 then locate (Dsyntax.TT_Constructor (x, [])) loc
         else error ~loc (ArityMismatch (x, 0, k))
      | AMLConstructor k ->
-        if k = 0 then locate (Dsyntax.AML_Constructor (x, [])) loc
+        if k = 0 then locate (Dsyntax.AMLConstructor (x, [])) loc
         else error ~loc (ArityMismatch (x, 0, k))
      | Operation k ->
         if k = 0 then locate (Dsyntax.Operation (x, [])) loc
@@ -614,11 +614,11 @@ let rec comp ~yield ctx {Location.thing=c';loc} =
 
   | Input.List cs ->
      let rec fold ~loc = function
-       | [] -> locate (Dsyntax.AML_Constructor (Name.Predefined.nil, [])) loc
+       | [] -> locate (Dsyntax.AMLConstructor (Name.Predefined.nil, [])) loc
        | c :: cs ->
           let c = comp ~yield ctx c in
           let cs = fold ~loc:(c.Location.loc) cs in
-          locate (Dsyntax.AML_Constructor (Name.Predefined.cons, [c ; cs])) loc
+          locate (Dsyntax.AMLConstructor (Name.Predefined.cons, [c ; cs])) loc
      in
      fold ~loc cs
 
@@ -861,7 +861,7 @@ and match_op_case ~yield ctx (ps, pt, c) =
 
 and aml_constructor ~loc ~yield ctx x cs =
   let cs = List.map (comp ~yield ctx) cs in
-  locate (Dsyntax.AML_Constructor (x, cs)) loc
+  locate (Dsyntax.AMLConstructor (x, cs)) loc
 
 and tt_constructor ~loc ~yield ctx x cs =
   let cs = List.map (comp ~yield ctx) cs in

--- a/src/parser/desugar.ml
+++ b/src/parser/desugar.ml
@@ -311,8 +311,8 @@ let rec tt_pattern ctx {Location.thing=p';loc} =
               match xopt with
               | Some x ->
                  let ctx = Ctx.add_variable x ctx in
-                 ctx, xopt
-              | None -> ctx, xopt
+                 ctx, x
+              | None -> ctx, Name.anonymous ()
             end
           in
           let ctx, p = fold ctx abstr in

--- a/src/parser/desugar.ml
+++ b/src/parser/desugar.ml
@@ -239,9 +239,9 @@ let rec tt_pattern ctx vars n {Location.thing=p';loc} =
   | Input.Patt_TT_Var x ->
      begin match Name.assoc_ident x vars with
      | Some i ->
-        (locate (Dsyntax.Patt_TT_EqVar i) loc), vars, n
+        (locate (Dsyntax.Patt_TT_EquVar i) loc), vars, n
      | None ->
-        (locate (Dsyntax.Patt_TT_NewVar n) loc), vars, (n+1)
+        (locate (Dsyntax.Patt_TT_NewVar n) loc), (x,n)::vars, (n+1)
      end
 
   | Input.Patt_TT_Interpolate x ->

--- a/src/parser/desugar.ml
+++ b/src/parser/desugar.ml
@@ -143,9 +143,22 @@ end (* module Ctx *)
 
 let locate = Location.locate
 
-let rec mlty_abstraction = function
-  | Input.ML_NotAbstract -> Dsyntax.ML_NotAbstract
-  | Input.ML_Abstract abstr -> Dsyntax.ML_Abstract (mlty_abstraction abstr)
+let rec mlty_judgement = function
+  | Input.ML_IsType -> Dsyntax.ML_IsType
+  | Input.ML_IsTerm -> Dsyntax.ML_IsTerm
+  | Input.ML_EqType -> Dsyntax.ML_EqType
+  | Input.ML_EqTerm -> Dsyntax.ML_EqTerm
+
+let rec mlty_abstracted_judgement = function
+
+  | Input.ML_NotAbstract frm ->
+     let frm = mlty_judgement frm
+     in Dsyntax.ML_NotAbstract frm
+
+  | Input.ML_Abstract (frm, abstr) ->
+     let frm = mlty_judgement frm
+     and abstr = mlty_abstracted_judgement abstr
+     in Dsyntax.ML_Abstract (frm, abstr)
 
 let mlty ctx params ty =
   let rec mlty ({Location.thing=ty';loc}) =
@@ -201,21 +214,9 @@ let mlty ctx params ty =
       | Input.ML_Anonymous ->
          Dsyntax.ML_Anonymous
 
-      | Input.ML_IsType abstr ->
-         let abstr = mlty_abstraction abstr
-         in Dsyntax.ML_IsType abstr
-
-      | Input.ML_IsTerm abstr ->
-         let abstr = mlty_abstraction abstr
-         in Dsyntax.ML_IsTerm abstr
-
-      | Input.ML_EqType abstr ->
-         let abstr = mlty_abstraction abstr
-         in Dsyntax.ML_EqType abstr
-
-      | Input.ML_EqTerm abstr ->
-         let abstr = mlty_abstraction abstr
-         in Dsyntax.ML_EqTerm abstr
+      | Input.ML_Judgement abstr ->
+         let abstr = mlty_abstracted_judgement abstr
+         in Dsyntax.ML_Judgement abstr
 
       | Input.ML_String -> Dsyntax.ML_String
       end

--- a/src/parser/input.mli
+++ b/src/parser/input.mli
@@ -10,9 +10,15 @@ type 'a located = 'a Location.located
 (** Bound variables are de Bruijn indices *)
 type bound = int
 
-type ml_abstraction =
-  | ML_NotAbstract
-  | ML_Abstract of ml_abstraction
+type ml_judgement =
+  | ML_IsType
+  | ML_IsTerm
+  | ML_EqType
+  | ML_EqTerm
+
+type ml_abstracted_judgement =
+  | ML_NotAbstract of ml_judgement
+  | ML_Abstract of ml_judgement * ml_abstracted_judgement
 
 type ml_ty = ml_ty' located
 and ml_ty' =
@@ -22,10 +28,7 @@ and ml_ty' =
   | ML_Handler of ml_ty * ml_ty
   | ML_Ref of ml_ty
   | ML_Dynamic of ml_ty
-  | ML_IsType of ml_abstraction
-  | ML_IsTerm of ml_abstraction
-  | ML_EqType of ml_abstraction
-  | ML_EqTerm of ml_abstraction
+  | ML_Judgement of ml_abstracted_judgement
   | ML_String
   | ML_Anonymous
 

--- a/src/parser/input.mli
+++ b/src/parser/input.mli
@@ -53,7 +53,6 @@ type tt_pattern = tt_pattern' located
 and tt_pattern' =
   | Patt_TT_Anonymous
   | Patt_TT_Var of Name.ident (* pattern variable *)
-  | Patt_TT_Interpolate of Name.ident (* interpolated value *)
   | Patt_TT_As of tt_pattern * tt_pattern
   | Patt_TT_Constructor of Name.ident * tt_pattern list
   | Patt_TT_GenAtom of tt_pattern
@@ -67,7 +66,6 @@ type pattern = pattern' located
 and pattern' =
   | Patt_Anonymous
   | Patt_Var of Name.ident
-  | Patt_Interpolate of Name.ident
   | Patt_As of pattern * pattern
   | Patt_Judgement of tt_pattern
   | Patt_Constr of Name.ident * pattern list
@@ -99,14 +97,6 @@ and term' =
   | Abstract of (Name.ident * comp option) list * comp
   | Spine of comp * comp list
   | Yield of comp
-  | CongrAbstractTy of comp * comp * comp
-  | CongrAbstract of comp * comp * comp * comp
-  | Reflexivity_type of comp
-  | Symmetry_type of comp
-  | Transitivity_type of comp * comp
-  | Reflexivity_term of comp
-  | Symmetry_term of comp
-  | Transitivity_term of comp * comp
   | String of string
   | Context of comp
   | Occurs of comp * comp
@@ -126,7 +116,8 @@ and let_clause =
   | Let_clause_tt of Name.ident * ty * comp
   | Let_clause_patt of pattern * let_annotation * comp
 
-
+(* XXX we should be able to destruct the first argument of a recursive function with an
+   (irrefutable) pattern. Thus, [ml_arg] should be defined using patterns in place of variable names. *)
 and letrec_clause = Name.ident * ml_arg * ml_arg list * let_annotation * comp
 
 (** Handle cases *)

--- a/src/parser/input.mli
+++ b/src/parser/input.mli
@@ -48,12 +48,6 @@ type let_annotation =
 (* An argument of a function or a let-clause *)
 type ml_arg = Name.ident * arg_annotation
 
-(** A binder in a pattern may or may not bind the bound variable
-    as a pattern variable. *)
-type tt_variable =
-  | PattVar of Name.ident
-  | NonPattVar of Name.ident
-
 (** Sugared term patterns *)
 type tt_pattern = tt_pattern' located
 and tt_pattern' =
@@ -66,7 +60,7 @@ and tt_pattern' =
   | Patt_TT_IsTerm of tt_pattern * tt_pattern
   | Patt_TT_EqType of tt_pattern * tt_pattern
   | Patt_TT_EqTerm of tt_pattern * tt_pattern * tt_pattern
-  | Patt_TT_Abstraction of (tt_variable * tt_pattern option) list * tt_pattern
+  | Patt_TT_Abstraction of (Name.ident option * tt_pattern option) list * tt_pattern
 
 type pattern = pattern' located
 and pattern' =

--- a/src/parser/input.mli
+++ b/src/parser/input.mli
@@ -95,7 +95,6 @@ and term' =
   | Ref of comp
   | Sequence of comp * comp
   | Assume of (Name.ident * comp) * comp
-  | Where of comp * expr * comp
   | Ascribe of comp * ty
   | Abstract of (Name.ident * comp option) list * comp
   | Spine of comp * comp list
@@ -138,7 +137,7 @@ and handle_case =
 
 and match_case = pattern * comp
 
-and match_op_case = pattern list * pattern option * comp
+and match_op_case = pattern list * tt_pattern option * comp
 
 type top_op_case = Name.ident option list * Name.ident option * comp
 

--- a/src/parser/input.mli
+++ b/src/parser/input.mli
@@ -18,7 +18,7 @@ type ml_judgement =
 
 type ml_abstracted_judgement =
   | ML_NotAbstract of ml_judgement
-  | ML_Abstract of ml_judgement * ml_abstracted_judgement
+  | ML_Abstract of ml_abstracted_judgement
 
 type ml_ty = ml_ty' located
 and ml_ty' =
@@ -57,6 +57,7 @@ and tt_pattern' =
   | Patt_TT_As of tt_pattern * tt_pattern
   | Patt_TT_Constructor of Name.ident * tt_pattern list
   | Patt_TT_GenAtom of tt_pattern
+  | Patt_TT_IsType of tt_pattern
   | Patt_TT_IsTerm of tt_pattern * tt_pattern
   | Patt_TT_EqType of tt_pattern * tt_pattern
   | Patt_TT_EqTerm of tt_pattern * tt_pattern * tt_pattern

--- a/src/parser/lexer.ml
+++ b/src/parser/lexer.ml
@@ -44,6 +44,7 @@ let reserved = [
   ("reflexivity_term", REFLEXIVITY_TERM) ;
   ("symmetry_term", SYMMETRY_TERM) ;
   ("transitivity_term", TRANSITIVITY_TERM) ;
+  ("type", TYPE) ;
   ("require", REQUIRE) ;
   ("val", VAL) ;
   ("verbosity", VERBOSITY) ;

--- a/src/parser/lexer.ml
+++ b/src/parser/lexer.ml
@@ -48,7 +48,6 @@ let reserved = [
   ("require", REQUIRE) ;
   ("val", VAL) ;
   ("verbosity", VERBOSITY) ;
-  ("where", WHERE) ;
   ("with", WITH) ;
   ("yield", YIELD) ;
   ("Π", PROD) ;

--- a/src/parser/lexer.ml
+++ b/src/parser/lexer.ml
@@ -13,7 +13,6 @@ let reserved = [
   ("assume", ASSUME) ;
   ("congr_abstract", CONGR_ABSTRACT) ;
   ("congr_abstract_ty", CONGR_ABSTRACT_TY) ;
-  ("constant", CONSTANT) ;
   ("context", CONTEXT) ;
   ("current", CURRENT) ;
   ("do", DO) ;
@@ -46,7 +45,6 @@ let reserved = [
   ("symmetry_term", SYMMETRY_TERM) ;
   ("transitivity_term", TRANSITIVITY_TERM) ;
   ("require", REQUIRE) ;
-  ("type", TYPE) ;
   ("val", VAL) ;
   ("verbosity", VERBOSITY) ;
   ("where", WHERE) ;

--- a/src/parser/lexer.ml
+++ b/src/parser/lexer.ml
@@ -2,15 +2,12 @@
 open Parser
 
 let reserved = [
-  ("Type", TYPE) ;
-  ("El", EL) ;
   ("is_type", MLISTYPE) ;
   ("is_term", MLISTERM) ;
   ("eq_type", MLEQTYPE) ;
   ("eq_term", MLEQTERM) ;
   ("_", UNDERSCORE) ;
   ("_atom", UATOM) ;
-  ("_constant", UCONSTANT) ;
   ("and", AND) ;
   ("as", AS) ;
   ("assume", ASSUME) ;
@@ -49,6 +46,7 @@ let reserved = [
   ("symmetry_term", SYMMETRY_TERM) ;
   ("transitivity_term", TRANSITIVITY_TERM) ;
   ("require", REQUIRE) ;
+  ("type", TYPE) ;
   ("val", VAL) ;
   ("verbosity", VERBOSITY) ;
   ("where", WHERE) ;

--- a/src/parser/lexer.ml
+++ b/src/parser/lexer.ml
@@ -11,8 +11,6 @@ let reserved = [
   ("and", AND) ;
   ("as", AS) ;
   ("assume", ASSUME) ;
-  ("congr_abstract", CONGR_ABSTRACT) ;
-  ("congr_abstract_ty", CONGR_ABSTRACT_TY) ;
   ("context", CONTEXT) ;
   ("current", CURRENT) ;
   ("do", DO) ;
@@ -38,12 +36,6 @@ let reserved = [
   ("operation", OPERATION) ;
   ("rec", REC) ;
   ("ref", REF) ;
-  ("reflexivity_type", REFLEXIVITY_TYPE) ;
-  ("symmetry_type", SYMMETRY_TYPE) ;
-  ("transitivity_type", TRANSITIVITY_TYPE) ;
-  ("reflexivity_term", REFLEXIVITY_TERM) ;
-  ("symmetry_term", SYMMETRY_TERM) ;
-  ("transitivity_term", TRANSITIVITY_TERM) ;
   ("type", TYPE) ;
   ("require", REQUIRE) ;
   ("val", VAL) ;
@@ -123,9 +115,6 @@ and token_aux ({ Ulexbuf.stream;_ } as lexbuf) =
   | ':'                      -> f (); COLON
   | ":>"                     -> f (); COLONGT
   | ','                      -> f (); COMMA
-  | '?', name                -> f (); PATTVAR (let s = Ulexbuf.lexeme lexbuf in
-                                               let s = String.sub s 1 (String.length s - 1) in
-                                               Name.make s)
   | "|-"                     -> f (); VDASH
   | '|'                      -> f (); BAR
   | "->" | 8594 | 10230      -> f (); ARROW
@@ -134,7 +123,8 @@ and token_aux ({ Ulexbuf.stream;_ } as lexbuf) =
   | '!'                      -> f (); BANG
   | ":="                     -> f (); COLONEQ
   | ';'                      -> f (); SEMICOLON
-  (* Comes before prefixop because it also matches prefixop *)
+  (* Comes before prefixop because it also matches prefixop. It's a hack to allow
+     '?' as an identifier, which may not be so smart. *)
   | '?'                      -> f (); NAME (Name.make ~fixity:Name.Word "?")
   (* We record the location of operators here because menhir cannot handle %infix and
      mark_location simultaneously, it seems. *)

--- a/src/parser/parser.mly
+++ b/src/parser/parser.mly
@@ -334,7 +334,7 @@ plain_prefix_pattern:
       Patt_Constr (op, [e])
     }
 
-simple_pattern: mark_location(plain_simple_pattern) { $1 }
+(* simple_pattern: mark_location(plain_simple_pattern) { $1 } *)
 plain_simple_pattern:
   | UNDERSCORE                     { Patt_Anonymous }
   | x=patt_var                     { Patt_Var x }

--- a/src/parser/parser.mly
+++ b/src/parser/parser.mly
@@ -65,9 +65,6 @@
 (* Assumptions *)
 %token ASSUME CONTEXT OCCURS
 
-(* Substitution *)
-%token WHERE
-
 (* Toplevel directives *)
 %token VERBOSITY
 %token <string> QUOTED_STRING
@@ -137,7 +134,6 @@ plain_term:
   | NOW x=term EQ c1=term IN c2=term                             { Now (x,c1,c2) }
   | CURRENT c=term                                               { Current c }
   | ASSUME x=var_name COLON t=ty_term IN c=term                  { Assume ((x, t), c) }
-  | c1=binop_term WHERE e=simple_term EQ c2=term                 { Where (c1, e, c2) }
   | MATCH e=term WITH lst=match_cases END                        { Match (e, lst) }
   | HANDLE c=term WITH hcs=handler_cases END                     { Handle (c, hcs) }
   | WITH h=term HANDLE c=term                                    { With (h, c) }
@@ -190,7 +186,7 @@ plain_prefix_term:
   | NATURAL t=prefix_term                      { Natural t }
   | YIELD e=prefix_term                        { Yield e }
 
-simple_term: mark_location(plain_simple_term) { $1 }
+(* simple_term: mark_location(plain_simple_term) { $1 } *)
 plain_simple_term:
   | x=var_name                                          { Var x }
   | s=QUOTED_STRING                                     { String s }
@@ -271,8 +267,8 @@ handler_case:
   | FINALLY p=pattern DARROW t=term                             { CaseFinally (p, t) }
 
 handler_checking:
-  |                    { None }
-  | COLON pt=pattern { Some pt }
+  |                     { None }
+  | COLON pt=tt_pattern { Some pt }
 
 top_handler_cases:
   | BAR lst=separated_nonempty_list(BAR, top_handler_case)  { lst }

--- a/src/parser/parser.mly
+++ b/src/parser/parser.mly
@@ -33,7 +33,7 @@
 %token OPERATION
 %token <Name.ident> PATTVAR
 %token MATCH
-%token AS
+%token AS TYPE
 %token VDASH EQEQ
 
 %token HANDLE WITH HANDLER BAR VAL FINALLY END YIELD
@@ -356,6 +356,7 @@ tt_pattern: mark_location(plain_tt_pattern) { $1 }
 plain_tt_pattern:
   | p1=binop_tt_pattern AS p2=binop_tt_pattern                        { Patt_TT_As (p1, p2) }
   | p=plain_binop_tt_pattern                                          { p }
+  | p=binop_tt_pattern TYPE                                           { Patt_TT_IsType p }
   | p1=binop_tt_pattern COLON p2=binop_tt_pattern                     { Patt_TT_IsTerm (p1, p2) }
   | p1=binop_tt_pattern EQEQ  p2=binop_tt_pattern                     { Patt_TT_EqType (p1, p2) }
   | p1=binop_tt_pattern EQEQ  p2=binop_tt_pattern COLON p3=tt_pattern { Patt_TT_EqTerm (p1, p2, p3) }
@@ -467,8 +468,7 @@ mlty_judgement:
 
 mlty_abstracted_judgement:
   | frm=mlty_judgement                                      { ML_NotAbstract frm }
-  | LBRACE frm=mlty_judgement RBRACE abstr=mlty_abstracted_judgement
-                                                            { ML_Abstract (frm, abstr) }
+  | LBRACE RBRACE abstr=mlty_abstracted_judgement           { ML_Abstract abstr }
 
 mlty_defs:
   | lst=separated_nonempty_list(AND, mlty_def) { lst }

--- a/src/parser/parser.mly
+++ b/src/parser/parser.mly
@@ -390,9 +390,8 @@ plain_simple_tt_pattern:
   | LPAREN p=plain_abstracted_tt_pattern RPAREN  { p }
 
 tt_name:
-  | x=var_name      { NonPattVar x }
-  | UNDERSCORE      { PattVar (Name.anonymous ()) }
-  | x=PATTVAR       { PattVar x }
+  | UNDERSCORE      { None }
+  | x=PATTVAR       { Some x }
 
 patt_var:
   | x=PATTVAR                    { x }

--- a/src/parser/parser.mly
+++ b/src/parser/parser.mly
@@ -31,18 +31,12 @@
 
 (* Meta-level programming *)
 %token OPERATION
-%token <Name.ident> PATTVAR
 %token MATCH
 %token AS TYPE
 %token VDASH EQEQ
 
 %token HANDLE WITH HANDLER BAR VAL FINALLY END YIELD
 %token SEMICOLON
-
-%token CONGR_ABSTRACT_TY CONGR_ABSTRACT
-%token REFLEXIVITY_TERM REFLEXIVITY_TYPE
-%token SYMMETRY_TERM SYMMETRY_TYPE
-%token TRANSITIVITY_TERM TRANSITIVITY_TYPE
 
 %token NATURAL
 
@@ -163,15 +157,6 @@ app_term: mark_location(plain_app_term) { $1 }
 plain_app_term:
   | e=plain_prefix_term                             { e }
   | e=prefix_term es=nonempty_list(prefix_term)     { Spine (e, es) }
-  | REFLEXIVITY_TYPE e=prefix_term                  { Reflexivity_type e }
-  | SYMMETRY_TYPE e=prefix_term                     { Symmetry_type e }
-  | TRANSITIVITY_TYPE e1=prefix_term e2=prefix_term { Transitivity_type (e1, e2) }
-  | REFLEXIVITY_TERM e=prefix_term                  { Reflexivity_term e }
-  | SYMMETRY_TERM e=prefix_term                     { Symmetry_term e }
-  | TRANSITIVITY_TERM e1=prefix_term e2=prefix_term { Transitivity_term (e1, e2) }
-  | CONGR_ABSTRACT_TY e1=prefix_term e2=prefix_term e3=prefix_term { CongrAbstractTy (e1, e2, e3) }
-  | CONGR_ABSTRACT e1=prefix_term e2=prefix_term e3=prefix_term e4=prefix_term
-    { CongrAbstract (e1, e2, e3, e4) }
 
 prefix_term: mark_location(plain_prefix_term) { $1 }
 plain_prefix_term:
@@ -287,7 +272,7 @@ top_handler_case:
       (op, ([x1;x2], y, t)) }
 
 top_patt_maybe_var:
-  | x=patt_var                   { Some x }
+  | x=var_name                   { Some x }
   | UNDERSCORE                   { None }
 
 top_handler_checking:
@@ -333,8 +318,7 @@ plain_prefix_pattern:
 (* simple_pattern: mark_location(plain_simple_pattern) { $1 } *)
 plain_simple_pattern:
   | UNDERSCORE                     { Patt_Anonymous }
-  | x=patt_var                     { Patt_Var x }
-  | x=var_name                     { Patt_Interpolate x }
+  | x=var_name                     { Patt_Var x }
   | LPAREN ps=separated_list(COMMA, pattern) RPAREN
     { match ps with
       | [{Location.thing=p;loc=_}] -> p
@@ -382,16 +366,12 @@ plain_prefix_tt_pattern:
 (* simple_tt_pattern: mark_location(plain_simple_tt_pattern) { $1 } *)
 plain_simple_tt_pattern:
   | UNDERSCORE                        { Patt_TT_Anonymous }
-  | x=patt_var                        { Patt_TT_Var x }
-  | x=var_name                        { Patt_TT_Interpolate x }
+  | x=var_name                        { Patt_TT_Var x }
   | LPAREN p=plain_abstracted_tt_pattern RPAREN  { p }
 
 tt_name:
-  | UNDERSCORE      { None }
-  | x=PATTVAR       { Some x }
-
-patt_var:
-  | x=PATTVAR                    { x }
+  | UNDERSCORE       { None }
+  | x=var_name       { Some x }
 
 let_pattern: mark_location(plain_let_pattern) { $1 }
 plain_let_pattern:

--- a/src/parser/parser.mly
+++ b/src/parser/parser.mly
@@ -330,6 +330,7 @@ plain_simple_pattern:
 
 abstracted_tt_pattern: mark_location(plain_abstracted_tt_pattern) { $1 }
 plain_abstracted_tt_pattern:
+  | p=plain_tt_pattern                                            { p }
   | abstr=tt_abstraction p=tt_pattern                             { Patt_TT_Abstraction (abstr, p) }
 
 tt_pattern: mark_location(plain_tt_pattern) { $1 }

--- a/src/parser/parser.mly
+++ b/src/parser/parser.mly
@@ -455,17 +455,21 @@ simple_mlty: mark_location(plain_simple_mlty) { $1 }
 plain_simple_mlty:
   | LPAREN t=plain_mlty RPAREN          { t }
   | c=var_name                          { ML_TyApply (c, []) }
-  | abstr=mlty_abstraction MLISTYPE     { ML_IsType abstr }
-  | abstr=mlty_abstraction MLISTERM     { ML_IsTerm abstr }
-  | abstr=mlty_abstraction MLEQTYPE     { ML_IsType abstr }
-  | abstr=mlty_abstraction MLEQTERM     { ML_IsTerm abstr }
+  | abstr=mlty_abstracted_judgement     { ML_Judgement abstr }
   | MLUNIT                              { ML_Prod [] }
   | MLSTRING                            { ML_String }
   | UNDERSCORE                          { ML_Anonymous }
 
-mlty_abstraction:
-  |                                      { ML_NotAbstract }
-  | LBRACE RBRACE abstr=mlty_abstraction { ML_Abstract abstr }
+mlty_judgement:
+  | MLISTYPE { ML_IsType }
+  | MLISTERM { ML_IsTerm }
+  | MLEQTYPE { ML_EqType }
+  | MLEQTERM { ML_EqTerm }
+
+mlty_abstracted_judgement:
+  | frm=mlty_judgement                                      { ML_NotAbstract frm }
+  | LBRACE frm=mlty_judgement RBRACE abstr=mlty_abstracted_judgement
+                                                            { ML_Abstract (frm, abstr) }
 
 mlty_defs:
   | lst=separated_nonempty_list(AND, mlty_def) { lst }

--- a/src/pattern.mli
+++ b/src/pattern.mli
@@ -9,7 +9,8 @@ type bound = int
 type is_type = is_type' located
 and is_type' =
   | Type_Anonymous
-  | Type_Var of bound
+  | Type_NewVar of bound
+  | Type_EquVar of bound
   | Type_Interpolate of bound
   | Type_As of is_type * is_type
   | Type_Constructor of Name.constructor * argument list
@@ -18,7 +19,8 @@ and is_type' =
 and is_term = is_term' located
 and is_term' =
   | Term_Anonymous
-  | Term_Var of bound
+  | Term_NewVar of bound
+  | Term_Equar of bound
   | Term_Interpolate of bound
   | Term_As of is_term * is_term
   | Term_Constructor of Name.constructor * argument list
@@ -28,7 +30,8 @@ and is_term' =
 and eq_term = eq_term' located
 and eq_term' =
   | EqTerm_Anonymous
-  | EqTerm_Var of bound
+  | EqTerm_NewVar of bound
+  | EqTerm_EquVar of bound
   | EqTerm_Interpolate of bound
   | EqTerm_As of eq_term * eq_term
   | EqTerm_Eq of is_term * is_term * is_type
@@ -37,7 +40,8 @@ and eq_term' =
 and eq_type = eq_type' located
 and eq_type' =
   | EqType_Anonymous
-  | EqType_Var of bound
+  | EqType_NewVar of bound
+  | EqType_EquVar of bound
   | EqType_Interpolate of bound
   | EqType_As of eq_type * eq_type
   | EqType_Eq of is_type * is_type
@@ -58,9 +62,11 @@ and 'a abstraction =
 type aml = aml' located
 and aml' =
   | Anonymous
-  | As of aml * bound
-  | Bound of bound
-  | IsTerm of (is_term * is_type) abstraction
+  | NewVar of bound
+  | EquVar of bound
+  | Interpolate of bound
+  | As of aml * aml
+  | IsTerm of is_term abstraction
   | IsType of is_type abstraction
   | EqTerm of (is_term * is_term * is_type) abstraction
   | EqType of (is_type * is_type) abstraction

--- a/src/pattern.mli
+++ b/src/pattern.mli
@@ -10,7 +10,7 @@ type judgement = judgement' located
 and judgement' =
   | TTAnonymous
   | TTVar of Name.ident    (* XXX are the idents used anywhere? *)
-  | TTInterpolate of bound
+(*   | TTInterpolate of bound *)
   | TTAs of judgement * judgement
   | TTConstructor of Name.constructor * argument list
   | TTGenAtom of is_term
@@ -28,7 +28,7 @@ type aml = aml' located
 and aml' =
   | Anonymous
   | Var of Name.ident
-  | Interpolate of bound
+(*   | Interpolate of bound *)
   | As of aml * aml
   | Judgement of judgement
   | AMLConstructor of Name.ident * aml list

--- a/src/pattern.mli
+++ b/src/pattern.mli
@@ -9,8 +9,7 @@ type bound = int
 type is_type = is_type' located
 and is_type' =
   | IsType_Anonymous
-  | IsType_NewVar of bound
-  | IsType_EquVar of bound
+  | IsType_Var of Name.ident    (* XXX are the idents used anywhere? *)
   | IsType_Interpolate of bound
   | IsType_As of is_type * is_type
   | IsType_Constructor of Name.constructor * argument list
@@ -19,8 +18,7 @@ and is_type' =
 and is_term = is_term' located
 and is_term' =
   | IsTerm_Anonymous
-  | IsTerm_NewVar of bound
-  | IsTerm_EquVar of bound
+  | IsTerm_Var of Name.ident
   | IsTerm_Interpolate of bound
   | IsTerm_As of is_term * is_term
   | IsTerm_Constructor of Name.constructor * argument list
@@ -30,8 +28,7 @@ and is_term' =
 and eq_term = eq_term' located
 and eq_term' =
   | EqTerm_Anonymous
-  | EqTerm_NewVar of bound
-  | EqTerm_EquVar of bound
+  | EqTerm_Var of Name.ident
   | EqTerm_Interpolate of bound
   | EqTerm_As of eq_term * eq_term
   | EqTerm_Eq of is_term * is_term * is_type
@@ -40,8 +37,7 @@ and eq_term' =
 and eq_type = eq_type' located
 and eq_type' =
   | EqType_Anonymous
-  | EqType_NewVar of bound
-  | EqType_EquVar of bound
+  | EqType_Var of Name.ident
   | EqType_Interpolate of bound
   | EqType_As of eq_type * eq_type
   | EqType_Eq of is_type * is_type
@@ -63,7 +59,6 @@ type aml = aml' located
 and aml' =
   | Anonymous
   | NewVar of bound
-  | EquVar of bound
   | Interpolate of bound
   | As of aml * aml
   | IsTerm of is_term abstraction

--- a/src/pattern.mli
+++ b/src/pattern.mli
@@ -23,7 +23,6 @@ and is_term' =
   | Term_As of is_term * is_term
   | Term_Constructor of Name.constructor * argument list
   | Term_GenAtom of is_term
-  | Term_GenConstant of is_term
 
 (** Term equality pattern *)
 and eq_term = eq_term' located
@@ -36,7 +35,6 @@ and eq_term' =
 
 (** Type equality pattern *)
 and eq_type = eq_type' located
-
 and eq_type' =
   | EqType_Anonymous
   | EqType_Var of bound

--- a/src/pattern.mli
+++ b/src/pattern.mli
@@ -8,23 +8,23 @@ type bound = int
 (** Type pattern *)
 type is_type = is_type' located
 and is_type' =
-  | Type_Anonymous
-  | Type_NewVar of bound
-  | Type_EquVar of bound
-  | Type_Interpolate of bound
-  | Type_As of is_type * is_type
-  | Type_Constructor of Name.constructor * argument list
+  | IsType_Anonymous
+  | IsType_NewVar of bound
+  | IsType_EquVar of bound
+  | IsType_Interpolate of bound
+  | IsType_As of is_type * is_type
+  | IsType_Constructor of Name.constructor * argument list
 
 (** Term pattern *)
 and is_term = is_term' located
 and is_term' =
-  | Term_Anonymous
-  | Term_NewVar of bound
-  | Term_Equar of bound
-  | Term_Interpolate of bound
-  | Term_As of is_term * is_term
-  | Term_Constructor of Name.constructor * argument list
-  | Term_GenAtom of is_term
+  | IsTerm_Anonymous
+  | IsTerm_NewVar of bound
+  | IsTerm_Equar of bound
+  | IsTerm_Interpolate of bound
+  | IsTerm_As of is_term * is_term
+  | IsTerm_Constructor of Name.constructor * argument list
+  | IsTerm_GenAtom of is_term
 
 (** Term equality pattern *)
 and eq_term = eq_term' located

--- a/src/pattern.mli
+++ b/src/pattern.mli
@@ -10,14 +10,14 @@ type judgement = judgement' located
 and judgement' =
   | TTAnonymous
   | TTVar of Name.ident    (* XXX are the idents used anywhere? *)
-(*   | TTInterpolate of bound *)
   | TTAs of judgement * judgement
   | TTConstructor of Name.constructor * argument list
   | TTGenAtom of is_term
+  | TTIsType of is_type
   | TTIsTerm of is_term * is_type
   | TTEqType of is_type * is_type
   | TTEqTerm of is_term * is_term * is_type
-  | TTAbstract of Name.ident * is_type * judgement
+  | TTAbstract of Name.ident option * is_type * judgement
 
 and is_type = judgement
 and is_term = judgement
@@ -28,7 +28,6 @@ type aml = aml' located
 and aml' =
   | Anonymous
   | Var of Name.ident
-(*   | Interpolate of bound *)
   | As of aml * aml
   | Judgement of judgement
   | AMLConstructor of Name.ident * aml list

--- a/src/pattern.mli
+++ b/src/pattern.mli
@@ -52,7 +52,7 @@ and argument =
 (** An abstracted pattern *)
 and 'a abstraction =
   | NotAbstract of 'a
-  | Abstract of Name.ident * bound option * is_type * 'a abstraction
+  | Abstract of Name.ident * is_type * 'a abstraction
 
 (** AML pattern *)
 type aml = aml' located
@@ -61,7 +61,7 @@ and aml' =
   | NewVar of bound
   | Interpolate of bound
   | As of aml * aml
-  | IsTerm of is_term abstraction
+  | IsTerm of is_term abstraction (* XXX should these be abstractions? *)
   | IsType of is_type abstraction
   | EqTerm of (is_term * is_term * is_type) abstraction
   | EqType of (is_type * is_type) abstraction

--- a/src/pattern.mli
+++ b/src/pattern.mli
@@ -5,26 +5,56 @@ type 'a located = 'a Location.located
 (** Bound variables are de Bruijn indices *)
 type bound = int
 
+(** Type pattern *)
+type is_type = is_type' located
+and is_type' =
+  | Type_Anonymous
+  | Type_Var of bound
+  | Type_Interpolate of bound
+  | Type_As of is_type * is_type
+  | Type_Constructor of Name.constructor * argument list
+
 (** Term pattern *)
-type is_term = is_term' located
+and is_term = is_term' located
 and is_term' =
   | Term_Anonymous
-  | Term_As of is_term * bound
-  | Term_Bound of bound
-  | Term_Constant of Name.ident
-  | Term_Abstract of Name.ident * bound option * is_type option * is_term
+  | Term_Var of bound
+  | Term_Interpolate of bound
+  | Term_As of is_term * is_term
+  | Term_Constructor of Name.constructor * argument list
   | Term_GenAtom of is_term
   | Term_GenConstant of is_term
 
-(** Type pattern *)
-and is_type = is_type' located
-and is_type' =
-  | Type_Anonymous
-  | Type_As of is_type * bound
-  | Type_Bound of bound
-  | Type_Type
-  | Type_AbstractTy of Name.ident * bound option * is_type option * is_type
-  | Type_El of is_term
+(** Term equality pattern *)
+and eq_term = eq_term' located
+and eq_term' =
+  | EqTerm_Anonymous
+  | EqTerm_Var of bound
+  | EqTerm_Interpolate of bound
+  | EqTerm_As of eq_term * eq_term
+  | EqTerm_Eq of is_term * is_term * is_type
+
+(** Type equality pattern *)
+and eq_type = eq_type' located
+
+and eq_type' =
+  | EqType_Anonymous
+  | EqType_Var of bound
+  | EqType_Interpolate of bound
+  | EqType_As of eq_type * eq_type
+  | EqType_Eq of is_type * is_type
+
+(** Patterns for constructor arguments *)
+and argument =
+  | ArgIsType of is_type abstraction
+  | ArgIsTerm of is_term abstraction
+  | ArgEqType of eq_type abstraction
+  | ArgEqTerm of eq_term abstraction
+
+(** An abstracted pattern *)
+and 'a abstraction =
+  | NotAbstract of 'a
+  | Abstract of Name.ident * bound option * is_type option * 'a
 
 (** AML pattern *)
 type aml = aml' located
@@ -32,9 +62,9 @@ and aml' =
   | Anonymous
   | As of aml * bound
   | Bound of bound
-  | IsTerm of is_term * is_type
-  | IsType of is_type
-  | EqTerm of is_term * is_term * is_type
-  | EqType of is_type * is_type
+  | IsTerm of (is_term * is_type) abstraction
+  | IsType of is_type abstraction
+  | EqTerm of (is_term * is_term * is_type) abstraction
+  | EqType of (is_type * is_type) abstraction
   | Constructor of Name.ident * aml list
   | Tuple of aml list

--- a/src/pattern.mli
+++ b/src/pattern.mli
@@ -5,65 +5,31 @@ type 'a located = 'a Location.located
 (** Bound variables are de Bruijn indices *)
 type bound = int
 
-(** Type pattern *)
-type is_type = is_type' located
-and is_type' =
-  | IsType_Anonymous
-  | IsType_Var of Name.ident    (* XXX are the idents used anywhere? *)
-  | IsType_Interpolate of bound
-  | IsType_As of is_type * is_type
-  | IsType_Constructor of Name.constructor * argument list
+(** Judgement pattern. *)
+type judgement = judgement' located
+and judgement' =
+  | TTAnonymous
+  | TTVar of Name.ident    (* XXX are the idents used anywhere? *)
+  | TTInterpolate of bound
+  | TTAs of judgement * judgement
+  | TTConstructor of Name.constructor * argument list
+  | TTGenAtom of is_term
+  | TTIsTerm of is_term * is_type
+  | TTEqType of is_type * is_type
+  | TTEqTerm of is_term * is_term * is_type
+  | TTAbstract of Name.ident * is_type * judgement
 
-(** Term pattern *)
-and is_term = is_term' located
-and is_term' =
-  | IsTerm_Anonymous
-  | IsTerm_Var of Name.ident
-  | IsTerm_Interpolate of bound
-  | IsTerm_As of is_term * is_term
-  | IsTerm_Constructor of Name.constructor * argument list
-  | IsTerm_GenAtom of is_term
-
-(** Term equality pattern *)
-and eq_term = eq_term' located
-and eq_term' =
-  | EqTerm_Anonymous
-  | EqTerm_Var of Name.ident
-  | EqTerm_Interpolate of bound
-  | EqTerm_As of eq_term * eq_term
-  | EqTerm_Eq of is_term * is_term * is_type
-
-(** Type equality pattern *)
-and eq_type = eq_type' located
-and eq_type' =
-  | EqType_Anonymous
-  | EqType_Var of Name.ident
-  | EqType_Interpolate of bound
-  | EqType_As of eq_type * eq_type
-  | EqType_Eq of is_type * is_type
-
-(** Patterns for constructor arguments *)
-and argument =
-  | ArgIsType of is_type abstraction
-  | ArgIsTerm of is_term abstraction
-  | ArgEqType of eq_type abstraction
-  | ArgEqTerm of eq_term abstraction
-
-(** An abstracted pattern *)
-and 'a abstraction =
-  | NotAbstract of 'a
-  | Abstract of Name.ident * is_type * 'a abstraction
+and is_type = judgement
+and is_term = judgement
+and argument = judgement
 
 (** AML pattern *)
 type aml = aml' located
 and aml' =
   | Anonymous
-  | NewVar of bound
+  | Var of Name.ident
   | Interpolate of bound
   | As of aml * aml
-  | IsTerm of is_term abstraction (* XXX should these be abstractions? *)
-  | IsType of is_type abstraction
-  | EqTerm of (is_term * is_term * is_type) abstraction
-  | EqType of (is_type * is_type) abstraction
-  | Constructor of Name.ident * aml list
+  | Judgement of judgement
+  | AMLConstructor of Name.ident * aml list
   | Tuple of aml list

--- a/src/pattern.mli
+++ b/src/pattern.mli
@@ -52,7 +52,7 @@ and argument =
 (** An abstracted pattern *)
 and 'a abstraction =
   | NotAbstract of 'a
-  | Abstract of Name.ident * bound option * is_type option * 'a
+  | Abstract of Name.ident * bound option * is_type * 'a abstraction
 
 (** AML pattern *)
 type aml = aml' located

--- a/src/pattern.mli
+++ b/src/pattern.mli
@@ -20,7 +20,7 @@ and is_term = is_term' located
 and is_term' =
   | IsTerm_Anonymous
   | IsTerm_NewVar of bound
-  | IsTerm_Equar of bound
+  | IsTerm_EquVar of bound
   | IsTerm_Interpolate of bound
   | IsTerm_As of is_term * is_term
   | IsTerm_Constructor of Name.constructor * argument list

--- a/src/rsyntax.mli
+++ b/src/rsyntax.mli
@@ -73,10 +73,10 @@ and handler = {
   handler_finally : match_case list;
 }
 
-and match_case = Name.ident list * Pattern.aml * comp
+and match_case = Pattern.aml * comp
 
 (** Match multiple patterns at once, with shared pattern variables *)
-and match_op_case = Name.ident list * Pattern.aml list * Pattern.aml option * comp
+and match_op_case = Pattern.aml list * Pattern.aml option * comp
 
 type top_op_case = Name.ident list * Name.ident option * comp
 

--- a/src/rsyntax.mli
+++ b/src/rsyntax.mli
@@ -26,7 +26,7 @@ and comp' =
   | Bound of bound
   | Function of Name.ident * comp
   | Handler of handler
-  | AML_Constructor of Name.ident * comp list
+  | AMLConstructor of Name.ident * comp list
   | Tuple of comp list
   | Operation of Name.ident * comp list
   | With of comp * comp
@@ -41,7 +41,10 @@ and comp' =
   | Assume of (Name.ident * comp) * comp
   | Match of comp * match_case list
   | Ascribe of comp * comp
-  | TT_Constructor of Name.ident * comp list
+  | IsTypeConstructor of Name.ident * comp list
+  | IsTermConstructor of Name.ident * comp list
+  | EqTypeConstructor of Name.ident * comp list
+  | EqTermConstructor of Name.ident * comp list
   | Apply of comp * comp
   | Abstract of Name.ident * comp option * comp
   | Yield of comp

--- a/src/rsyntax.mli
+++ b/src/rsyntax.mli
@@ -59,11 +59,8 @@ and comp' =
   | Context of comp
   | Natural of comp
 
-(* XXX the variable name is only used for printing toplevel let's *)
-(* TODO: remove Let_clause_ML and compile it into Let_clause_patt instead *)
 and let_clause =
-  | Let_clause_ML of Name.ident * ml_schema * comp
-  | Let_clause_patt of (Name.ident * ml_schema) list * Pattern.aml * comp
+  | Let_clause of Pattern.aml * ml_schema * comp
 
 and letrec_clause = Name.ident * Name.ident * ml_schema * comp
 

--- a/src/rsyntax.mli
+++ b/src/rsyntax.mli
@@ -41,15 +41,18 @@ and comp' =
   | Assume of (Name.ident * comp) * comp
   | Match of comp * match_case list
   | Ascribe of comp * comp
-  | IsTypeConstructor of Name.ident * comp list
-  | IsTermConstructor of Name.ident * comp list
-  | EqTypeConstructor of Name.ident * comp list
-  | EqTermConstructor of Name.ident * comp list
+  | IsTypeConstructor of Name.constructor * comp list
+  | IsTermConstructor of Name.constructor * comp list
+  | EqTypeConstructor of Name.constructor * comp list
+  | EqTermConstructor of Name.constructor * comp list
   | Apply of comp * comp
   | Abstract of Name.ident * comp option * comp
   | Yield of comp
   | String of string
-  | Occurs of comp * comp
+  | OccursIsTypeAbstraction of comp * comp
+  | OccursIsTermAbstraction of comp * comp
+  | OccursEqTypeAbstraction of comp * comp
+  | OccursEqTermAbstraction of comp * comp
   | Context of comp
   | Natural of comp
 

--- a/src/rsyntax.mli
+++ b/src/rsyntax.mli
@@ -79,7 +79,6 @@ and toplevel' =
   | DefMLType of (Name.ty * (Name.ty list * ml_tydef)) list
   | DefMLTypeRec of (Name.ty * (Name.ty list * ml_tydef)) list
   | DeclOperation of Name.operation * (ml_ty list * ml_ty)
-  | DeclConstants of Name.constant list * comp
   | DeclExternal of Name.ident * ml_schema * string
   | TopHandle of (Name.operation * top_op_case) list
   | TopLet of let_clause list

--- a/src/rsyntax.mli
+++ b/src/rsyntax.mli
@@ -39,21 +39,12 @@ and comp' =
   | Ref of comp
   | Sequence of comp * comp
   | Assume of (Name.ident * comp) * comp
-  | Where of comp * comp * comp
   | Match of comp * match_case list
   | Ascribe of comp * comp
   | TT_Constructor of Name.ident * comp list
   | Apply of comp * comp
   | Abstract of Name.ident * comp option * comp
   | Yield of comp
-  | CongrAbstractTy of comp * comp * comp
-  | CongrAbstract of comp * comp * comp * comp
-  | Reflexivity_type of comp
-  | Symmetry_type of comp
-  | Transitivity_type of comp * comp
-  | Reflexivity_term of comp
-  | Symmetry_term of comp
-  | Transitivity_term of comp * comp
   | String of string
   | Occurs of comp * comp
   | Context of comp

--- a/src/rsyntax.mli
+++ b/src/rsyntax.mli
@@ -59,6 +59,8 @@ and comp' =
   | Context of comp
   | Natural of comp
 
+(* XXX the variable name is only used for printing toplevel let's *)
+(* TODO: remove Let_clause_ML and compile it into Let_clause_patt instead *)
 and let_clause =
   | Let_clause_ML of Name.ident * ml_schema * comp
   | Let_clause_patt of (Name.ident * ml_schema) list * Pattern.aml * comp

--- a/src/rsyntax.mli
+++ b/src/rsyntax.mli
@@ -73,7 +73,7 @@ and handler = {
 and match_case = Pattern.aml * comp
 
 (** Match multiple patterns at once, with shared pattern variables *)
-and match_op_case = Pattern.aml list * Pattern.aml option * comp
+and match_op_case = Pattern.aml list * Pattern.judgement option * comp
 
 type top_op_case = Name.ident list * Name.ident option * comp
 

--- a/src/rsyntax.mli
+++ b/src/rsyntax.mli
@@ -60,9 +60,10 @@ and comp' =
   | Natural of comp
 
 and let_clause =
-  | Let_clause of Pattern.aml * ml_schema * comp
+  | Let_clause of (Name.ident * Mlty.ty_schema) list * Pattern.aml * comp
 
-and letrec_clause = Name.ident * Name.ident * ml_schema * comp
+and letrec_clause =
+  | Letrec_clause of Name.ident * Name.ident * ml_schema * comp
 
 and handler = {
   handler_val: match_case list;

--- a/src/rsyntax.mli
+++ b/src/rsyntax.mli
@@ -23,12 +23,10 @@ type let_annotation =
 (** Computations *)
 type comp = comp' located
 and comp' =
-  | Type
-  | El of comp
   | Bound of bound
   | Function of Name.ident * comp
   | Handler of handler
-  | Constructor of Name.ident * comp list
+  | AML_Constructor of Name.ident * comp list
   | Tuple of comp list
   | Operation of Name.ident * comp list
   | With of comp * comp
@@ -44,7 +42,7 @@ and comp' =
   | Where of comp * comp * comp
   | Match of comp * match_case list
   | Ascribe of comp * comp
-  | Constant of Name.ident
+  | TT_Constructor of Name.ident * comp list
   | Apply of comp * comp
   | Abstract of Name.ident * comp option * comp
   | Yield of comp

--- a/src/runtime/equal.ml
+++ b/src/runtime/equal.ml
@@ -67,7 +67,7 @@ let equal_ty ~loc j1 j2 =
 
 let coerce ~loc je jt =
   let je_ty = Jdg.typeof je in
-  match Jdg.alpha_equal_eq_type ~loc je_ty jt with
+  match Jdg.mk_equal_eq_type ~loc je_ty jt with
 
   | Some _ ->
      Opt.return je
@@ -82,8 +82,8 @@ let coerce ~loc je jt =
           let eq_lhs = Jdg.eq_type_side Jdg.LEFT eq
           and eq_rhs = Jdg.eq_type_side Jdg.RIGHT eq in
           begin
-            match Jdg.alpha_equal_eq_type ~loc je_ty eq_lhs,
-                  Jdg.alpha_equal_eq_type ~loc jt eq_rhs
+            match Jdg.mk_equal_eq_type ~loc je_ty eq_lhs,
+                  Jdg.mk_equal_eq_type ~loc jt eq_rhs
             with
             | Some _, Some _ ->
                Opt.return (Jdg.convert ~loc je eq)
@@ -93,7 +93,7 @@ let coerce ~loc je jt =
 
        | Predefined.Coercible je ->
           begin
-            match Jdg.alpha_equal_eq_type ~loc (Jdg.typeof je) jt with
+            match Jdg.mk_alpha_equal_type ~loc (Jdg.typeof je) jt with
             | Some _ ->
                Opt.return je
             | None ->

--- a/src/runtime/equal.ml
+++ b/src/runtime/equal.ml
@@ -50,7 +50,7 @@ let equal ~loc j1 j2 =
 
 (** Compare two types *)
 let equal_ty ~loc j1 j2 =
-  match Jdg.mk_alpha_equal_ty ~loc j1 j2 with
+  match Jdg.mk_alpha_equal_type j1 j2 with
     | Some eq -> Opt.return eq
     | None ->
       Predefined.operation_equal_type ~loc j1 j2 >!=

--- a/src/runtime/equal.ml
+++ b/src/runtime/equal.ml
@@ -66,12 +66,11 @@ let equal_type ~loc t1 t2 =
 
 let coerce ~loc sgn e t =
   let t' = Jdg.type_of_term sgn e in
-  match Jdg.mk_alpha_equal_type t' t with
+  match Jdg.alpha_equal_type t' t with
 
-  | Some _ ->
-     Opt.return e
+  | true -> Opt.return e
 
-  | None ->
+  | false ->
      Predefined.operation_coerce ~loc e t >!=
        begin function
 
@@ -94,6 +93,7 @@ let coerce ~loc sgn e t =
             | false -> Runtime.(error ~loc (InvalidCoerce (t, e')))
           end
        end
+
 end
 
 (** Expose without the monad stuff *)

--- a/src/runtime/equal.ml
+++ b/src/runtime/equal.ml
@@ -65,8 +65,8 @@ let equal_type ~loc t1 t2 =
         end
 
 let coerce ~loc sgn e t =
-  let t' = Jdg.type_of_term sgn e in
-  match Jdg.alpha_equal_type t' t with
+  let t' = Jdg.type_of_term_abstraction sgn e in
+  match Jdg.alpha_equal_abstraction Jdg.alpha_equal_type t' t with
 
   | true -> Opt.return e
 
@@ -77,18 +77,21 @@ let coerce ~loc sgn e t =
        | Predefined.NotCoercible -> Opt.fail
 
        | Predefined.Convertible eq ->
+          failwith "TODO: convert e along eq if possible"
+          (*
           let (Jdg.EqType (_asmp, u', u)) = Jdg.invert_eq_type eq in
           begin match Jdg.alpha_equal_type t' u' && Jdg.alpha_equal_type t u with
             | true ->
-               Opt.return (Jdg.form_is_term_convert sgn e eq)
+               Opt.return (Jdg.form_is_term_abstraction_convert sgn e eq)
             | false ->
                Runtime.(error ~loc (InvalidConvertible (t', t, eq)))
           end
+          *)
 
        | Predefined.Coercible e' ->
           begin
-            let u = Jdg.type_of_term sgn e' in
-            match Jdg.alpha_equal_type t u with
+            let u = Jdg.type_of_term_abstraction sgn e' in
+            match Jdg.alpha_equal_abstraction Jdg.alpha_equal_type t u with
             | true -> Opt.return e'
             | false -> Runtime.(error ~loc (InvalidCoerce (t, e')))
           end

--- a/src/runtime/equal.mli
+++ b/src/runtime/equal.mli
@@ -11,5 +11,5 @@ val equal_type :
 
 (** Coerce the given term to the given type, if possible *)
 val coerce :
-  loc:Location.t -> Jdg.Signature.t -> Jdg.is_term -> Jdg.is_type ->
-  Jdg.is_term option Runtime.comp
+  loc:Location.t -> Jdg.Signature.t -> Jdg.is_term_abstraction -> Jdg.is_type_abstraction ->
+  Jdg.is_term_abstraction option Runtime.comp

--- a/src/runtime/equal.mli
+++ b/src/runtime/equal.mli
@@ -1,10 +1,15 @@
 (** Equality checking *)
 
 (** Compares two terms at alpha-equivalent types *)
-val equal : loc:Location.t -> Jdg.is_term -> Jdg.is_term -> Jdg.eq_term option Runtime.comp
+val equal :
+  loc:Location.t -> Jdg.Signature.t ->
+  Jdg.is_term -> Jdg.is_term -> Jdg.eq_term option Runtime.comp
 
-(** Compare two types. *)
-val equal_ty : loc:Location.t -> Jdg.is_type -> Jdg.is_type -> Jdg.eq_type option Runtime.comp
+(** Compare two type abstractions. *)
+val equal_type :
+  loc:Location.t -> Jdg.is_type -> Jdg.is_type -> Jdg.eq_type option Runtime.comp
 
 (** Coerce the given term to the given type, if possible *)
-val coerce : loc:Location.t -> Jdg.is_term -> Jdg.is_type -> Jdg.is_term option Runtime.comp
+val coerce :
+  loc:Location.t -> Jdg.Signature.t -> Jdg.is_term -> Jdg.is_type ->
+  Jdg.is_term option Runtime.comp

--- a/src/runtime/equal.mli
+++ b/src/runtime/equal.mli
@@ -11,5 +11,5 @@ val equal_type :
 
 (** Coerce the given term to the given type, if possible *)
 val coerce :
-  loc:Location.t -> Jdg.Signature.t -> Jdg.is_term -> Jdg.is_type ->
-  Jdg.is_term option Runtime.comp
+  loc:Location.t -> Jdg.Signature.t -> Jdg.is_term_abstraction ->
+  Jdg.is_type_abstraction -> Jdg.is_term option Runtime.comp

--- a/src/runtime/equal.mli
+++ b/src/runtime/equal.mli
@@ -3,6 +3,7 @@
 (** Compares two terms at alpha-equivalent types *)
 val equal : loc:Location.t -> Jdg.is_term -> Jdg.is_term -> Jdg.eq_term option Runtime.comp
 
+(** Compare two types. *)
 val equal_ty : loc:Location.t -> Jdg.is_type -> Jdg.is_type -> Jdg.eq_type option Runtime.comp
 
 (** Coerce the given term to the given type, if possible *)

--- a/src/runtime/equal.mli
+++ b/src/runtime/equal.mli
@@ -11,5 +11,5 @@ val equal_type :
 
 (** Coerce the given term to the given type, if possible *)
 val coerce :
-  loc:Location.t -> Jdg.Signature.t -> Jdg.is_term_abstraction ->
-  Jdg.is_type_abstraction -> Jdg.is_term option Runtime.comp
+  loc:Location.t -> Jdg.Signature.t -> Jdg.is_term -> Jdg.is_type ->
+  Jdg.is_term option Runtime.comp

--- a/src/runtime/eval.ml
+++ b/src/runtime/eval.ml
@@ -285,28 +285,6 @@ and check_default ~loc v t_check =
       | Some e -> return e
     end
 
-and check_premises premises t_premises =
-
-  let rec fold ps_out ps ts =
-    match ps, ts with
-
-    | [], [] ->
-       let ps_out = List.rev ps_out in
-       return ps_out
-
-    | p :: ps, t :: ts ->
-       check_premise p t >>= fun p ->
-       fold (p :: ps_out) ps ts
-
-    | [], _::_ | _::_, [] ->
-       (* desugar made sure this cannot happen *)
-       assert false
-  in
-  fold [] premises t_premises
-
-and check_premise c t =
-  check c t >>= fun e -> as_premise (Runtime.mk_is_term e)
-
 and as_premise = function
   | Runtime.IsType t -> return (Jdg.PremiseIsType t)
   | Runtime.IsTerm e -> return (Jdg.PremiseIsTerm e)
@@ -585,11 +563,6 @@ and check_atom c =
 let comp_value c =
   let r = infer c in
   Runtime.top_handle ~loc:c.Location.loc r
-
-(* comp_ty: 'a Rsyntax.comp -> Jdg.is_type Runtime.toplevel *)
-let comp_ty c =
-  let r = check_is_type c in
-  Runtime.top_handle ~loc:(c.Location.loc) r
 
 let comp_handle (xs,y,c) =
   Runtime.top_return_closure (fun (vs,checking) ->

--- a/src/runtime/eval.ml
+++ b/src/runtime/eval.ml
@@ -182,19 +182,6 @@ let rec infer {Location.thing=c'; loc} =
      Runtime.add_free ~loc x t (fun _ ->
        infer c2)
 
-  | Rsyntax.Where (c1, c2, c3) ->
-    check_atom c2 >>= fun a ->
-    check_is_term c1 >>= fun je ->
-    begin match Jdg.occurs a je with
-    | None ->
-       check c3 (Jdg.type_of_atom a) >>= fun _ ->
-       Runtime.return_is_term je
-    | Some a ->
-       check c3 (Jdg.type_of_atom a) >>= fun js ->
-       let j = Jdg.substitute ~loc je a js in
-       Runtime.return_is_term j
-    end
-
   | Rsyntax.Match (c, cases) ->
      infer c >>=
      match_cases ~loc cases infer
@@ -238,54 +225,6 @@ let rec infer {Location.thing=c'; loc} =
         Runtime.Ref _ | Runtime.Dyn _ | Runtime.String _ as h ->
         Runtime.(error ~loc (Inapplicable h))
     end
-
-  | Rsyntax.CongrAbstractTy (c1, c2, c3) ->
-    check_atom c1 >>= fun x ->
-    check_eq_type c2 >>= fun eqa ->
-    check_eq_type c3 >>= fun eqb ->
-    let eq = Jdg.congr_abstract_type ~loc eqa x x eqb in
-    Runtime.return_eq_type eq
-
-  | Rsyntax.CongrAbstract (c1, c2, c3, c4) ->
-    check_atom c1 >>= fun x ->
-    check_eq_type c2 >>= fun eqa ->
-    check_eq_type c3 >>= fun eqb ->
-    check_eq_term c4 >>= fun eqbody ->
-    let eq = Jdg.congr_abstract_term ~loc eqa x x eqb eqbody in
-    Runtime.return_eq_term eq
-
-  | Rsyntax.Reflexivity_term c ->
-     check_is_term c >>= fun je ->
-     let eq = Jdg.reflexivity je in
-     Runtime.return_eq_term eq
-
-  | Rsyntax.Symmetry_term c ->
-     check_eq_term c >>= fun jeq ->
-     let eq = Jdg.symmetry_term jeq in
-     Runtime.return_eq_term eq
-
-  | Rsyntax.Transitivity_term (c1, c2) ->
-     check_eq_term c1 >>= fun jeq1 ->
-     check_eq_term c2 >>= fun jeq2 ->
-     let eq = Jdg.transitivity_term ~loc jeq1 jeq2 in
-     Runtime.return_eq_term eq
-
-
-  | Rsyntax.Reflexivity_type c ->
-     check_is_type c >>= fun jt ->
-     let eq = Jdg.reflexivity_ty jt in
-     Runtime.return_eq_type eq
-
-  | Rsyntax.Symmetry_type c ->
-     check_eq_type c >>= fun jeq ->
-     let eq = Jdg.symmetry_type jeq in
-     Runtime.return_eq_type eq
-
-  | Rsyntax.Transitivity_type (c1, c2) ->
-     check_eq_type c1 >>= fun jeq1 ->
-     check_eq_type c2 >>= fun jeq2 ->
-     let eq = Jdg.transitivity_type ~loc jeq1 jeq2 in
-     Runtime.return_eq_type eq
 
   | Rsyntax.String s ->
     Runtime.return (Runtime.mk_string s)

--- a/src/runtime/eval.ml
+++ b/src/runtime/eval.ml
@@ -187,10 +187,10 @@ let rec infer {Location.thing=c'; loc} =
     check_is_term c1 >>= fun je ->
     begin match Jdg.occurs a je with
     | None ->
-       check c3 (Jdg.atom_is_type a) >>= fun _ ->
+       check c3 (Jdg.type_of_atom a) >>= fun _ ->
        Runtime.return_is_term je
     | Some a ->
-       check c3 (Jdg.atom_is_type a) >>= fun js ->
+       check c3 (Jdg.type_of_atom a) >>= fun js ->
        let j = Jdg.substitute ~loc je a js in
        Runtime.return_is_term j
     end
@@ -295,7 +295,7 @@ let rec infer {Location.thing=c'; loc} =
     check_is_term c2 >>= fun j ->
     begin match Jdg.occurs a j with
       | Some jx ->
-        let j = Jdg.atom_is_type jx in
+        let j = Jdg.type_of_atom jx in
         Runtime.return (Predefined.from_option (Some (Runtime.mk_is_type j)))
       | None ->
         Runtime.return (Predefined.from_option None)
@@ -407,14 +407,14 @@ and check_abstract ~loc t_check x u c =
      begin match u with
      | Some u ->
         check_is_type u >>= fun ju ->
-        Equal.equal_ty ~loc:(u.Location.loc) ju (Jdg.atom_is_type a) >>=
+        Equal.equal_ty ~loc:(u.Location.loc) ju (Jdg.type_of_atom a) >>=
           begin function
             | Some equ -> Runtime.return (ju, equ)
             | None ->
-               Runtime.(error ~loc:(u.Location.loc) (AnnotationMismatch (ju, (Jdg.atom_is_type a))))
+               Runtime.(error ~loc:(u.Location.loc) (AnnotationMismatch (ju, (Jdg.type_of_atom a))))
           end
      | None ->
-        let ju = Jdg.atom_is_type a in
+        let ju = Jdg.type_of_atom a in
         let equ = Jdg.reflexivity_ty ju in
         Runtime.return (ju, equ)
      end >>= fun (ju, equ) -> (* equ : ju == typeof a *)

--- a/src/runtime/eval.ml
+++ b/src/runtime/eval.ml
@@ -26,6 +26,8 @@ let as_dyn ~loc v =
   let e = Runtime.as_dyn ~loc v in
   return e
 
+let form_not_abstract j = Jdg.form_abstraction (Jdg.NotAbstract j)
+
 (** Evaluate a computation -- infer mode. *)
 (*   infer : Rsyntax.comp -> Runtime.value Runtime.comp *)
 let rec infer {Location.thing=c'; loc} =
@@ -54,11 +56,32 @@ let rec infer {Location.thing=c'; loc} =
        return v
 
     | Rsyntax.IsTypeConstructor (c, cs) ->
+       (* XXX premises should really be run in checking mode!!! *)
+       infer_premises [] cs >>= fun premises ->
        Runtime.lookup_signature >>= fun sgn ->
-       let (ts, _) = Jdg.lookup_constructor_somehow_XXX sgn c in
-       check_premises cs ts >>= fun premises ->
        let e = Jdg.form_is_type_rule sgn c premises in
-       let v = Runtime.mk_is_type e in
+       let v = Runtime.mk_is_type (form_not_abstract e) in
+       return v
+
+    | Rsyntax.IsTermConstructor (c, cs) ->
+       infer_premises [] cs >>= fun premises ->
+       Runtime.lookup_signature >>= fun sgn ->
+       let e = Jdg.form_is_term_rule sgn c premises in
+       let v = Runtime.mk_is_term (form_not_abstract e) in
+       return v
+
+    | Rsyntax.EqTypeConstructor (c, cs) ->
+       infer_premises [] cs >>= fun premises ->
+       Runtime.lookup_signature >>= fun sgn ->
+       let e = Jdg.form_eq_type_rule sgn c premises in
+       let v = Runtime.mk_eq_type (form_not_abstract e) in
+       return v
+
+    | Rsyntax.EqTermConstructor (c, cs) ->
+       infer_premises [] cs >>= fun premises ->
+       Runtime.lookup_signature >>= fun sgn ->
+       let e = Jdg.form_eq_term_rule sgn c premises in
+       let v = Runtime.mk_eq_term (form_not_abstract e) in
        return v
 
     | Rsyntax.Tuple cs ->
@@ -155,7 +178,7 @@ let rec infer {Location.thing=c'; loc} =
      match_cases ~loc cases infer
 
   | Rsyntax.Ascribe (c1, c2) ->
-     check_is_type c2 >>= fun t ->
+     check_is_type_abstraction c2 >>= fun t ->
      check c1 t >>=
      Runtime.return_is_term
 
@@ -166,14 +189,28 @@ let rec infer {Location.thing=c'; loc} =
      check_is_type u >>= fun ju ->
      Runtime.add_free x ju (fun jy ->
          let vy = Jdg.form_is_term_atom jy in
-         Predefined.add_abstracting vy
-      (infer c >>= function
-       | Runtime.IsTerm je -> form_is_term ~loc (Jdg.Abstract (jy, je)) >>= Runtime.return_is_term
-       | Runtime.IsType jt -> form_is_type ~loc (Jdg.AbstractTy (jy, jt)) >>= Runtime.return_is_type
-       | (Runtime.EqTerm _ | Runtime.EqType _ | Runtime.Closure _ | Runtime.Handler _ |
-          Runtime.Tag _ | Runtime.Tuple _ | Runtime.Ref _ | Runtime.Dyn _ | Runtime.String _) as v ->
-          Runtime.(error ~loc (IsTypeOrTermExpected v))
-      ))
+         let vy = Jdg.form_abstraction (Jdg.NotAbstract vy) in
+         let abstract j = Jdg.form_abstraction (Jdg.Abstract (jy, j)) in
+
+         Predefined.add_abstracting
+           vy
+           begin infer c >>=
+             function
+
+             | Runtime.IsType jdg -> Runtime.return_is_type (abstract jdg)
+
+             | Runtime.IsTerm jdg -> Runtime.return_is_term (abstract jdg)
+
+             | Runtime.EqType jdg -> Runtime.return_eq_type (abstract jdg)
+
+             | Runtime.EqTerm jdg -> Runtime.return_eq_term (abstract jdg)
+
+             | (Runtime.Closure _ | Runtime.Handler _ | Runtime.Tag _ |
+                Runtime.Tuple _ | Runtime.Ref _ | Runtime.Dyn _ |
+                Runtime.String _) as v ->
+                Runtime.(error ~loc (JudgementExpected v))
+
+           end)
 
   | Rsyntax.Yield c ->
     infer c >>= fun v ->
@@ -193,32 +230,59 @@ let rec infer {Location.thing=c'; loc} =
   | Rsyntax.String s ->
     return (Runtime.mk_string s)
 
-  | Rsyntax.Occurs (c1,c2) ->
-    check_atom c1 >>= fun a ->
-    check_is_term c2 >>= fun j ->
-    begin match Jdg.occurs a j with
-      | Some jx ->
-        let j = Jdg.type_of_atom jx in
-        return (Predefined.from_option (Some (Runtime.mk_is_type j)))
-      | None ->
-        return (Predefined.from_option None)
-    end
+  | Rsyntax.OccursIsTypeAbstraction (c1, c2) ->
+     check_is_type_abstraction c2 >>= fun abstr ->
+     occurs Jdg.occurs_is_type_abstraction c1 abstr
+
+  | Rsyntax.OccursIsTermAbstraction (c1,c2) ->
+     check_is_term_abstraction c2 >>= fun abstr ->
+     occurs Jdg.occurs_is_term_abstraction c1 abstr
+
+  | Rsyntax.OccursEqTypeAbstraction (c1, c2) ->
+     check_eq_type_abstraction c2 >>= fun abstr ->
+     occurs Jdg.occurs_eq_type_abstraction c1 abstr
+
+  | Rsyntax.OccursEqTermAbstraction (c1, c2) ->
+     check_eq_term_abstraction c2 >>= fun abstr ->
+     occurs Jdg.occurs_eq_term_abstraction c1 abstr
+
 
   | Rsyntax.Context c ->
-    check_is_term c >>= fun j ->
-    let ctx = Jdg.contextof j in
-    let xts = Jdg.Ctx.elements ctx in
-    let js = List.map (fun j -> Runtime.mk_is_term (Jdg.atom_is_term ~loc j)) xts in
+    check_is_term_abstraction c >>= fun j ->
+    let xts = Jdg.context_is_term_abstraction j in
+    let js = List.map (fun j -> Runtime.mk_is_term
+                          (form_not_abstract (Jdg.form_is_term_atom j))) xts in
     return (Predefined.mk_list js)
 
   | Rsyntax.Natural c ->
     check_is_term c >>= fun j ->
     Runtime.lookup_signature >>= fun signature ->
-    let eq = Jdg.natural_eq_type ~loc signature j in
-    Runtime.return_eq_type eq
+    let eq = Jdg.natural_type_eq signature j in
+    Runtime.return_eq_type (form_not_abstract eq)
+
+(* XXX premises should really be run in checking mode!!! *)
+and infer_premises ps_out = function
+  | [] -> return (List.rev ps_out)
+  | p :: ps -> infer p >>= as_premise >>= fun p ->
+     infer_premises (p :: ps_out) ps
+
+and occurs
+  : 'a . (Jdg.is_atom -> 'a Jdg.abstraction -> bool)
+    -> Rsyntax.comp
+    -> 'a Jdg.abstraction -> Runtime.value Runtime.comp
+  = fun occurs_abstr c1 abstr ->
+  check_atom c1 >>= fun a ->
+  begin match occurs_abstr a abstr with
+  | true ->
+     let t = Jdg.type_of_atom a in
+     let t = Runtime.mk_is_type (Jdg.form_abstraction (Jdg.NotAbstract t)) in
+     return (Predefined.from_option (Some t))
+  | false ->
+     return (Predefined.from_option None)
+  end
 
 and check_default ~loc v t_check =
-  as_is_term ~loc v >>= fun je ->
+  let je = as_is_term_abstraction ~loc v in
   Equal.coerce ~loc je t_check >>=
     begin function
       | Some je -> return je
@@ -239,20 +303,23 @@ and check_premises premises t_premises =
        fold (p :: ps_out) ps ts
 
     | [], _::_ | _::_, [] ->
-       (** desugar made sure this cannot happen *)
+       (* desugar made sure this cannot happen *)
        assert false
   in
   fold [] premises t_premises
 
 and check_premise c t =
-  check c t >>= function
+  check c t >>= fun e -> as_premise (Runtime.mk_is_term e)
+
+and as_premise = function
   | Runtime.IsType t -> return (Jdg.PremiseIsType t)
   | Runtime.IsTerm e -> return (Jdg.PremiseIsTerm e)
   | Runtime.EqType eq -> return (Jdg.PremiseEqType eq)
   | Runtime.EqTerm eq -> return (Jdg.PremiseEqTerm eq)
   | (Runtime.Closure _ | Runtime.Handler _ | Runtime.Tag _ | Runtime.Tuple _ |
-    Runtime.Ref _| Runtime.Dyn _| Runtime.String _) ->
+     Runtime.Ref _| Runtime.Dyn _| Runtime.String _) ->
      assert false
+
 
 (* Rsyntax.comp -> Jdg.is_type -> Jdg.is_term Runtime.comp *)
 and check ({Location.thing=c';loc} as c) t_check =
@@ -277,7 +344,10 @@ and check ({Location.thing=c';loc} as c) t_check =
   | Rsyntax.Update _
   | Rsyntax.Current _
   | Rsyntax.String _
-  | Rsyntax.Occurs _
+  | Rsyntax.OccursIsTypeAbstraction _
+  | Rsyntax.OccursIsTermAbstraction _
+  | Rsyntax.OccursEqTypeAbstraction _
+  | Rsyntax.OccursEqTermAbstraction _
   | Rsyntax.Context _
   | Rsyntax.Natural _ ->
     infer c >>= fun v ->
@@ -325,7 +395,8 @@ and check ({Location.thing=c';loc} as c) t_check =
     check_abstract ~loc t_check x u c
 
 and check_abstract ~loc t_check x u c =
-  match Jdg.invert_is_type t_check with
+  Runtime.lookup_signature >>= fun sgn ->
+  match Jdg.invert_is_type sgn t_check with
 
   | Jdg.TypeConstructor _ ->
      Runtime.(error ~loc (AbstractTyExpected t_check))
@@ -439,13 +510,25 @@ and match_op_cases ~loc op cases vs checking =
   fold cases
 
 and check_is_type c : Jdg.is_type Runtime.comp =
-  infer c >>= as_is_type ~loc:(c.Location.loc)
+  infer c >>= fun v -> return (as_is_type ~loc:c.Location.loc v)
+
+and check_is_type_abstraction c =
+  infer c >>= fun v -> return (as_is_type_abstraction ~loc:c.Location.loc v)
 
 and check_is_term c =
-  infer c >>= as_is_term ~loc:c.Location.loc
+  infer c >>= fun v -> return (as_is_term ~loc:c.Location.loc v)
+
+and check_is_term_abstraction c =
+  infer c >>= fun v -> return (as_is_term_abstraction ~loc:c.Location.loc v)
+
+and check_eq_type_abstraction c =
+  infer c >>= fun v -> return (as_eq_type_abstraction ~loc:c.Location.loc v)
+
+and check_eq_term_abstraction c =
+  infer c >>= fun v -> return (as_eq_term_abstraction ~loc:c.Location.loc v)
 
 and check_atom c =
-  infer c >>= as_atom ~loc:c.Location.loc
+  infer c >>= fun v -> (as_atom ~loc:c.Location.loc v)
 
 (** Move to toplevel monad *)
 

--- a/src/runtime/eval.ml
+++ b/src/runtime/eval.ml
@@ -625,7 +625,7 @@ let print_error err ppf =
     | JdgError (penv, err) -> Jdg.print_error ~penv err ppf
 
 let rec toplevel ~quiet ~print_annot {Location.thing=c;loc} =
-  Runtime.catch (lazy (match c with
+  Runtime.catch ~loc (lazy (match c with
 
     | Rsyntax.DefMLType lst
 
@@ -702,7 +702,7 @@ let rec toplevel ~quiet ~print_annot {Location.thing=c;loc} =
         return ())
 
     | Rsyntax.TopFail c ->
-       Runtime.catch (lazy (comp_value c)) >>= begin function
+       Runtime.catch ~loc (lazy (comp_value c)) >>= begin function
 
        | Runtime.CaughtRuntime {Location.thing=err; loc}  ->
          Runtime.top_lookup_penv >>= fun penv ->

--- a/src/runtime/eval.ml
+++ b/src/runtime/eval.ml
@@ -5,28 +5,9 @@ let (>>=) = Runtime.bind
 
 let return = Runtime.return
 
-let as_is_term_abstraction ~loc v =
-  Runtime.as_is_term ~loc v
-
-let as_is_term ~loc v =
-  let e = Runtime.as_is_term ~loc v in
-  match Jdg.invert_is_term_abstraction e with
-  | Jdg.NotAbstract e -> e
-  | Jdg.Abstract _ -> Runtime.(error ~loc (IsTermExpected v))
-
-let as_is_type_abstraction ~loc v =
-  let e = Runtime.as_is_type ~loc v in
-    return e
-
-let as_is_type ~loc v =
-  let t = Runtime.as_is_type ~loc v in
-  match Jdg.invert_is_type_abstraction t with
-  | Jdg.NotAbstract t -> t
-  | Jdg.Abstract _ -> Runtime.(error ~loc (IsTypeExpected v))
-
 let as_atom ~loc v =
   Runtime.lookup_signature >>= fun sgn ->
-  let j = as_is_term ~loc v in
+  let j = Runtime.as_is_term ~loc v in
   match Jdg.invert_is_term sgn j with
     | Jdg.TermAtom x -> return x
     | (Jdg.TermConstructor _ | Jdg.TermConvert _) -> Runtime.(error ~loc (ExpectedAtom j))

--- a/src/runtime/matching.ml
+++ b/src/runtime/matching.ml
@@ -12,6 +12,9 @@ let add_var x (v : Runtime.value) xvs = v :: xvs
    but this seems to be the price to pay for the discrepancy between the
    syntax of patterns and the structure of runtime values. *)
 
+(* Collect the values of the matched bound variables and return them in a list. The head
+   of the list is the *last* variable found, which means that probably the list should be
+   reversed before we actually put the values onto the environment. *)
 let rec collect_is_term env xvs {Location.thing=p';loc} v =
   match p' with
   (* patterns that are generic for all judgement forms *)

--- a/src/runtime/matching.ml
+++ b/src/runtime/matching.ml
@@ -6,172 +6,264 @@ let return = Runtime.return
 
 exception Match_fail
 
-let update k v xvs =
-  try
-    let v' = List.assoc k xvs in
-    if Runtime.equal_value v v'
-    then xvs
-    else raise Match_fail
-  with
-    Not_found ->
-      (k,v) :: xvs
+let add_var x (v : Runtime.value) xvs = (x, v) :: xvs
 
-let rec collect_is_term env xvs p j =
-  let loc = p.Location.loc in
-  match p.Location.thing, Jdg.invert_is_term j with
-  | Pattern.Term_Anonymous, _ -> xvs
+(* There is a lot of repetition in the [collect_is_XYZ] functions below,
+   but this seems to be the price to pay for the discrepancy between the
+   syntax of patterns and the structure of runtime values. *)
 
-  | Pattern.Term_As (p,k), _ ->
-     let v = Runtime.mk_is_term j in
-     let xvs = update k v xvs in
-     collect_is_term env xvs p j
+let rec collect_is_term env xvs {Location.thing=p';loc} v =
+  match p' with
+  (* patterns that are generic for all judgement forms *)
+  | Pattern.TTAnonymous -> xvs
 
-  | Pattern.Term_Bound k, _ ->
-     let v' = Runtime.get_bound ~loc k env in
-     if Runtime.equal_value (Runtime.mk_is_term j) v'
-     then xvs
-     else raise Match_fail
+  | Pattern.TTVar x ->
+     add_var x (Runtime.mk_is_term v) xvs
 
-  | Pattern.Term_Constant x, Jdg.Constant y ->
-     if Name.eq_ident x y
-     then xvs
-     else raise Match_fail
+  | Pattern.TTAs (p1, p2) ->
+     let xvs = collect_is_term env xvs p1 v in
+     collect_is_term env xvs p2 v
 
-  | Pattern.Term_Abstract (x,bopt,popt,p), Jdg.Abstract (jy,je) ->
-     let xvs = begin match popt with
-       | Some pt -> collect_is_type env xvs pt (Jdg.type_of_atom jy)
-       | None -> xvs
-     end in
-     let yt = Runtime.mk_is_term (Jdg.atom_is_term ~loc jy) in
-     let env = Runtime.push_bound yt env in
-     let xvs = match bopt with
-       | None -> xvs
-       | Some k -> update k yt xvs
-     in
-     collect_is_term env xvs p je
+  (* patterns specific to terms *)
+  | Pattern.TTConstructor (c, ps) ->
+     begin match Jdg.invert_is_term_abstraction v with
+     | Jdg.Abstract _ -> raise Match_fail
+     | Jdg.NotAbstract e ->
+        let sgn = Runtime.get_signature env in
+        begin match Jdg.invert_is_term sgn e with
+        | Jdg.TermConstructor (c', args) when Name.eq_ident c c' ->
+           collect_args env xvs ps args
+        | (Jdg.TermConstructor _ | Jdg.TermAtom _ | Jdg.TermConvert _) ->
+           raise Match_fail
+        end
+     end
 
-  | Pattern.Term_GenAtom p, Jdg.Atom x ->
-    let j = Jdg.atom_is_term ~loc x in
-    collect_is_term env xvs p j
+  | Pattern.TTGenAtom p ->
+     begin match Jdg.invert_is_term_abstraction v with
+     | Jdg.Abstract _ -> raise Match_fail
+     | Jdg.NotAbstract e ->
+        let sgn = Runtime.get_signature env in
+        begin match Jdg.invert_is_term sgn e with
+        | Jdg.TermAtom a ->
+           collect_is_term env xvs p v
+        | (Jdg.TermConstructor  _ | Jdg.TermConvert _) ->
+           raise Match_fail
+        end
+     end
 
-  | Pattern.Term_GenConstant p, Jdg.Constant c ->
-    let signature = Runtime.get_typing_signature env in
-    let j = Jdg.form_is_term ~loc signature (Jdg.Constant c) in
-    collect_is_term env xvs p j
+  | Pattern.TTIsTerm (p1, p2) ->
+     let xvs = collect_is_term env xvs p1 v in
+     (* TODO optimize for the case when [p2] is [Pattern.TTAnonymous]
+        because it allows us to avoid calculating the type of [v]. *)
+     let sgn = Runtime.get_signature env in
+     let t = Jdg.type_of_term_abstraction sgn v in
+     collect_is_type env xvs p2 t
 
-  | (Pattern.Term_Constant _ | Pattern.Term_Abstract _ |
-     Pattern.Term_GenAtom _ | Pattern.Term_GenConstant _) , _ ->
+  | Pattern.TTAbstract (xopt, p1, p2) ->
+     begin match Jdg.invert_is_term_abstraction v with
+     | Jdg.NotAbstract _ -> raise Match_fail
+     | Jdg.Abstract (a, v2) ->
+        let v1 = Jdg.form_abstraction (Jdg.NotAbstract (Jdg.type_of_atom a)) in
+        let xvs = collect_is_type env xvs p1 v1 in
+        let xvs =
+          match xopt with
+          | None -> xvs
+          | Some x ->
+             let e = Jdg.form_abstraction (Jdg.NotAbstract (Jdg.form_is_term_atom a)) in
+             add_var x (Runtime.mk_is_term e) xvs
+        in
+        collect_is_term env xvs p2 v
+     end
+
+  | (Pattern.TTEqType _ | Pattern.TTEqTerm _ | Pattern.TTIsType _) ->
      raise Match_fail
 
-and collect_is_type env xvs p j =
-  let loc = p.Location.loc in
-  match p.Location.thing, Jdg.invert_is_type j with
+and collect_is_type env xvs {Location.thing=p';loc} v =
+  match p' with
+  (* patterns that are generic for all judgement forms *)
+  | Pattern.TTAnonymous -> xvs
 
-  | Pattern.Type_Anonymous, _ -> xvs
+  | Pattern.TTVar x ->
+     add_var x (Runtime.mk_is_type v) xvs
 
-  | Pattern.Type_As (p,k), _ ->
-     let v = Runtime.mk_is_type j in
-     let xvs = update k v xvs in
-     collect_is_type env xvs p j
+  | Pattern.TTAs (p1, p2) ->
+     let xvs = collect_is_type env xvs p1 v in
+     collect_is_type env xvs p2 v
 
-  | Pattern.Type_Bound k, _ ->
-     let v' = Runtime.get_bound ~loc k env in
-     if Runtime.equal_value (Runtime.mk_is_type j) v'
-     then xvs
-     else raise Match_fail
+  (* patterns specific to types *)
+  | Pattern.TTConstructor (c, ps) ->
+     begin match Jdg.invert_is_type_abstraction v with
+     | Jdg.Abstract _ -> raise Match_fail
+     | Jdg.NotAbstract t ->
+        begin match Jdg.invert_is_type t with
+        | Jdg.TypeConstructor (c', args) ->
+           if Name.eq_ident c c' then
+             collect_args env xvs ps args
+           else
+             raise Match_fail
+        end
+     end
 
-  | Pattern.Type_Type, Jdg.Type ->
-     xvs
+  | Pattern.TTAbstract (xopt, p1, p2) ->
+     begin match Jdg.invert_is_type_abstraction v with
+     | Jdg.NotAbstract _ -> raise Match_fail
+     | Jdg.Abstract (a, v2) ->
+        let v1 = Jdg.form_abstraction (Jdg.NotAbstract (Jdg.type_of_atom a)) in
+        let xvs = collect_is_type env xvs p1 v1 in
+        let xvs =
+          match xopt with
+          | None -> xvs
+          | Some x ->
+             let e = Jdg.form_abstraction (Jdg.NotAbstract (Jdg.form_is_term_atom a)) in
+             add_var x (Runtime.mk_is_term e) xvs
+        in
+        collect_is_type env xvs p2 v
+     end
 
-  | Pattern.Type_AbstractTy (x,bopt,popt,p), Jdg.AbstractTy (jy,jb) ->
-     let xvs = begin match popt with
-       | Some pt -> collect_is_type env xvs pt (Jdg.type_of_atom jy)
-       | None -> xvs
-     end in
-     let yt = Runtime.mk_is_term (Jdg.atom_is_term ~loc jy) in
-     let env = Runtime.push_bound yt env in
-     let xvs = match bopt with
-       | None -> xvs
-       | Some k -> update k yt xvs
-     in
-     collect_is_type env xvs p jb
-
-  | Pattern.Type_El p, Jdg.El j ->
-     collect_is_term env xvs p j
-
-  | (Pattern.Type_Type | Pattern.Type_AbstractTy _ | Pattern.Type_El _), _ ->
+  | (Pattern.TTIsTerm _ | Pattern.TTGenAtom _ | Pattern.TTEqType _ |
+     Pattern.TTEqTerm _ | Pattern.TTIsType _) ->
      raise Match_fail
 
-and collect_eq_type env xvs pt1 pt2 jeq =
-  let (t1, t2) = Jdg.invert_eq_type jeq in
-  let xvs = collect_is_type env xvs pt1 t1 in
-  let xvs = collect_is_type env xvs pt2 t2 in
-  xvs
+and collect_eq_type env xvs {Location.thing=p';loc} v =
+  match p' with
+  (* patterns that are generic for all judgement forms *)
+  | Pattern.TTAnonymous -> xvs
 
-and collect_eq_term env xvs p1 p2 pt jeq =
-  let (e1, e2, t) = Jdg.invert_eq_term jeq in
-  let xvs = collect_is_term env xvs p1 e1 in
-  let xvs = collect_is_term env xvs p2 e2 in
-  let xvs = collect_is_type env xvs pt t in
-  xvs
+  | Pattern.TTVar x ->
+     add_var x (Runtime.mk_eq_type v) xvs
 
-and collect_pattern env xvs {Location.thing=p;loc} v =
-  match p, v with
+  | Pattern.TTAs (p1, p2) ->
+     let xvs = collect_eq_type env xvs p1 v in
+     collect_eq_type env xvs p2 v
+
+  (* patterns specific to type equations *)
+  | Pattern.TTAbstract (xopt, p1, p2) ->
+     begin match Jdg.invert_eq_type_abstraction v with
+     | Jdg.NotAbstract _ -> raise Match_fail
+     | Jdg.Abstract (a, v2) ->
+        let v1 = Jdg.form_abstraction (Jdg.NotAbstract (Jdg.type_of_atom a)) in
+        let xvs = collect_is_type env xvs p1 v1 in
+        let xvs =
+          match xopt with
+          | None -> xvs
+          | Some x ->
+             let e = Jdg.form_abstraction (Jdg.NotAbstract (Jdg.form_is_term_atom a)) in
+             add_var x (Runtime.mk_is_term e) xvs
+        in
+        collect_eq_type env xvs p2 v
+     end
+
+  | Pattern.TTEqType (p1, p2) ->
+     begin match Jdg.invert_eq_type_abstraction v with
+     | Jdg.Abstract _ -> raise Match_fail
+     | Jdg.NotAbstract eq ->
+        let (Jdg.EqType (_asmp, t1, t2)) = Jdg.invert_eq_type eq in
+        let xvs = collect_is_type env xvs p1 (Jdg.form_abstraction (Jdg.NotAbstract t1)) in
+        collect_is_type env xvs p2 (Jdg.form_abstraction (Jdg.NotAbstract t2))
+     end
+
+  | (Pattern.TTIsTerm _ | Pattern.TTGenAtom _ | Pattern.TTEqTerm _ | Pattern.TTIsType _ |
+     Pattern.TTConstructor _) ->
+     raise Match_fail
+
+and collect_eq_term env xvs {Location.thing=p';loc} v =
+  match p' with
+  (* patterns that are generic for all judgement forms *)
+  | Pattern.TTAnonymous -> xvs
+
+  | Pattern.TTVar x ->
+     add_var x (Runtime.mk_eq_term v) xvs
+
+  | Pattern.TTAs (p1, p2) ->
+     let xvs = collect_eq_term env xvs p1 v in
+     collect_eq_term env xvs p2 v
+
+  (* patterns specific to term equations *)
+  | Pattern.TTAbstract (xopt, p1, p2) ->
+     begin match Jdg.invert_eq_term_abstraction v with
+     | Jdg.NotAbstract _ -> raise Match_fail
+     | Jdg.Abstract (a, v2) ->
+        let v1 = Jdg.form_abstraction (Jdg.NotAbstract (Jdg.type_of_atom a)) in
+        let xvs = collect_is_type env xvs p1 v1 in
+        let xvs =
+          match xopt with
+          | None -> xvs
+          | Some x ->
+             let e = Jdg.form_abstraction (Jdg.NotAbstract (Jdg.form_is_term_atom a)) in
+             add_var x (Runtime.mk_is_term e) xvs
+        in
+        collect_eq_term env xvs p2 v
+     end
+
+  | Pattern.TTEqTerm (p1, p2, p3) ->
+     begin match Jdg.invert_eq_term_abstraction v with
+     | Jdg.Abstract _ -> raise Match_fail
+     | Jdg.NotAbstract eq ->
+        let (Jdg.EqTerm (_asmp, e1, e2, t)) = Jdg.invert_eq_term eq in
+        let xvs = collect_is_term env xvs p1 (Jdg.form_abstraction (Jdg.NotAbstract e1)) in
+        let xvs = collect_is_term env xvs p2 (Jdg.form_abstraction (Jdg.NotAbstract e2)) in
+        collect_is_type env xvs p2 (Jdg.form_abstraction (Jdg.NotAbstract t))
+     end
+
+  | (Pattern.TTIsTerm _ | Pattern.TTGenAtom _ | Pattern.TTEqType _ | Pattern.TTIsType _ |
+     Pattern.TTConstructor _) ->
+     raise Match_fail
+
+and collect_args env xvs ps vs =
+  match ps, vs with
+
+  | [], [] -> xvs
+
+  | p::ps, v::vs ->
+     let xvs =
+       begin match v with
+       | Jdg.PremiseIsType t -> collect_is_type env xvs p t
+       | Jdg.PremiseIsTerm e -> collect_is_term env xvs p e
+       | Jdg.PremiseEqType eq -> collect_eq_type env xvs p eq
+       | Jdg.PremiseEqTerm eq -> collect_eq_term env xvs p eq
+     end in
+     collect_args env xvs ps vs
+
+  | [], _::_ | _::_, [] -> assert false
+
+and collect_pattern env xvs {Location.thing=p';loc} v =
+  match p', v with
   | Pattern.Anonymous, _ -> xvs
 
-  | Pattern.As (p,k), v ->
-     let xvs = update k v xvs in
-     collect_pattern env xvs p v
+  | Pattern.Var x, v ->
+     add_var x v xvs
 
-  | Pattern.Bound k, v ->
-     let v' = Runtime.get_bound ~loc k env in
-     if Runtime.equal_value v v'
-     then xvs
-     else raise Match_fail
+  | Pattern.As (p1, p2), v ->
+     let xvs = collect_pattern env xvs p1 v in
+     collect_pattern env xvs p2 v
 
-  | Pattern.IsType pt, Runtime.IsType j ->
-     collect_is_type env xvs pt j
+  | Pattern.Judgement p, Runtime.IsType t ->
+     collect_is_type env xvs p t
 
-  | Pattern.IsTerm (pe, pt), Runtime.IsTerm j ->
-     let xvs = collect_is_type env xvs pt (Jdg.typeof j) in
-     collect_is_term env xvs pe j
+  | Pattern.Judgement p, Runtime.IsTerm e ->
+     collect_is_term env xvs p e
 
-  | Pattern.EqType (pt1, pt2), Runtime.EqType j ->
-     collect_eq_type env xvs pt1 pt2 j
+  | Pattern.Judgement p, Runtime.EqType eq ->
+     collect_eq_type env xvs p eq
 
-  | Pattern.EqTerm (p1, p2, pt), Runtime.EqTerm j ->
-     collect_eq_term env xvs p1 p2 pt j
+  | Pattern.Judgement p, Runtime.EqTerm eq ->
+     collect_eq_term env xvs p eq
 
-  | Pattern.Constructor (tag, ps), Runtime.Tag (tag', vs) when Name.eq_ident tag tag' ->
+  | Pattern.AMLConstructor (tag, ps), Runtime.Tag (tag', vs) when Name.eq_ident tag tag' ->
     multicollect_pattern env xvs ps vs
 
   | Pattern.Tuple ps, Runtime.Tuple vs ->
     multicollect_pattern env xvs ps vs
 
-  | Pattern.IsTerm _, (Runtime.IsType _ | Runtime.EqTerm _ | Runtime.EqType _ |
-                       Runtime.Closure _ | Runtime.Handler _ |
-                       Runtime.Tag _ | Runtime.Ref _ | Runtime.Dyn _|
-                       Runtime.Tuple _ | Runtime.String _)
+  (* mismatches *)
+  | Pattern.Judgement _, (Runtime.Closure _ | Runtime.Handler _ | Runtime.Tag _ |
+                          Runtime.Ref _ | Runtime.Dyn _ |
+                          Runtime.Tuple _ | Runtime.String _)
 
-  | Pattern.IsType _, (Runtime.IsTerm _ | Runtime.EqTerm _ | Runtime.EqType _ |
-                       Runtime.Closure _ | Runtime.Handler _ |
-                       Runtime.Tag _ | Runtime.Ref _ | Runtime.Dyn _|
-                       Runtime.Tuple _ | Runtime.String _)
-
-  | Pattern.EqTerm _, (Runtime.IsTerm _ | Runtime.IsType _ | Runtime.EqType _ |
-                       Runtime.Closure _ | Runtime.Handler _ |
-                       Runtime.Tag _ | Runtime.Ref _ | Runtime.Dyn _|
-                       Runtime.Tuple _ | Runtime.String _)
-
-  | Pattern.EqType _, (Runtime.IsTerm _ | Runtime.IsType _ | Runtime.EqTerm _ |
-                       Runtime.Closure _ | Runtime.Handler _ |
-                       Runtime.Tag _ | Runtime.Ref _ | Runtime.Dyn _|
-                       Runtime.Tuple _ | Runtime.String _)
-
-  | Pattern.Constructor _, (Runtime.IsTerm _ | Runtime.IsType _ | Runtime.EqTerm _ | Runtime.EqType _ |
-                            Runtime.Closure _ | Runtime.Handler _ | Runtime.Tag _ |
-                            Runtime.Ref _ | Runtime.Dyn _ |
-                            Runtime.Tuple _ | Runtime.String _)
+  | Pattern.AMLConstructor _, (Runtime.IsTerm _ | Runtime.IsType _ | Runtime.EqTerm _ | Runtime.EqType _ |
+                               Runtime.Closure _ | Runtime.Handler _ | Runtime.Tag _ |
+                               Runtime.Ref _ | Runtime.Dyn _ |
+                               Runtime.Tuple _ | Runtime.String _)
 
   | Pattern.Tuple _, (Runtime.IsTerm _ | Runtime.IsType _ | Runtime.EqTerm _ | Runtime.EqType _ |
                       Runtime.Closure _ | Runtime.Handler _ | Runtime.Tag _ |

--- a/src/runtime/matching.ml
+++ b/src/runtime/matching.ml
@@ -6,7 +6,7 @@ let return = Runtime.return
 
 exception Match_fail
 
-let add_var x (v : Runtime.value) xvs = (x, v) :: xvs
+let add_var x (v : Runtime.value) xvs = v :: xvs
 
 (* There is a lot of repetition in the [collect_is_XYZ] functions below,
    but this seems to be the price to pay for the discrepancy between the
@@ -284,9 +284,6 @@ and multicollect_pattern env xvs ps vs =
 let match_pattern_env p v env =
   try
     let xvs = collect_pattern env [] p v in
-    (* return in decreasing de bruijn order: ready to fold with add_bound *)
-    let xvs = List.sort (fun (k,_) (k',_) -> compare k k') xvs in
-    let xvs = List.rev_map snd xvs in
     Some xvs
   with
     Match_fail -> None

--- a/src/runtime/matching.ml
+++ b/src/runtime/matching.ml
@@ -39,7 +39,7 @@ let rec collect_is_term env xvs p j =
 
   | Pattern.Term_Abstract (x,bopt,popt,p), Jdg.Abstract (jy,je) ->
      let xvs = begin match popt with
-       | Some pt -> collect_is_type env xvs pt (Jdg.atom_is_type jy)
+       | Some pt -> collect_is_type env xvs pt (Jdg.type_of_atom jy)
        | None -> xvs
      end in
      let yt = Runtime.mk_is_term (Jdg.atom_is_term ~loc jy) in
@@ -85,7 +85,7 @@ and collect_is_type env xvs p j =
 
   | Pattern.Type_AbstractTy (x,bopt,popt,p), Jdg.AbstractTy (jy,jb) ->
      let xvs = begin match popt with
-       | Some pt -> collect_is_type env xvs pt (Jdg.atom_is_type jy)
+       | Some pt -> collect_is_type env xvs pt (Jdg.type_of_atom jy)
        | None -> xvs
      end in
      let yt = Runtime.mk_is_term (Jdg.atom_is_term ~loc jy) in

--- a/src/runtime/matching.mli
+++ b/src/runtime/matching.mli
@@ -10,4 +10,4 @@ val top_match_pattern : Pattern.aml -> Runtime.value -> Runtime.value list optio
 val match_op_pattern :
   Pattern.aml list -> Pattern.is_type option ->
   Runtime.value list -> Jdg.is_type_abstraction option ->
-  (Name.ident * Runtime.value) list option Runtime.comp
+  Runtime.value list option Runtime.comp

--- a/src/runtime/matching.mli
+++ b/src/runtime/matching.mli
@@ -5,7 +5,9 @@ val match_pattern : Pattern.aml -> Runtime.value -> Runtime.value list option Ru
 (** Match a value against a pattern. Matches are returned in the order of decreasing de Bruijn index. *)
 val top_match_pattern : Pattern.aml -> Runtime.value -> Runtime.value list option Runtime.toplevel
 
+(** [match_op_pattern ps p_out vs t_out] matches patterns [ps] against values [vs] and
+    the optional pattern [p_out] against the optional type [t_out]. *)
 val match_op_pattern :
-  Pattern.aml list -> Pattern.judgement option ->
-  Runtime.value list -> Jdg.is_type option ->
-  Runtime.value list option Runtime.comp
+  Pattern.aml list -> Pattern.is_type option ->
+  Runtime.value list -> Runtime.is_type_abstraction option ->
+  (Name.ident * Runtime.value) list option Runtime.comp

--- a/src/runtime/matching.mli
+++ b/src/runtime/matching.mli
@@ -9,5 +9,5 @@ val top_match_pattern : Pattern.aml -> Runtime.value -> Runtime.value list optio
     the optional pattern [p_out] against the optional type [t_out]. *)
 val match_op_pattern :
   Pattern.aml list -> Pattern.is_type option ->
-  Runtime.value list -> Runtime.is_type_abstraction option ->
+  Runtime.value list -> Jdg.is_type_abstraction option ->
   (Name.ident * Runtime.value) list option Runtime.comp

--- a/src/runtime/matching.mli
+++ b/src/runtime/matching.mli
@@ -6,6 +6,6 @@ val match_pattern : Pattern.aml -> Runtime.value -> Runtime.value list option Ru
 val top_match_pattern : Pattern.aml -> Runtime.value -> Runtime.value list option Runtime.toplevel
 
 val match_op_pattern :
-  Pattern.aml list -> Pattern.aml option ->
+  Pattern.aml list -> Pattern.judgement option ->
   Runtime.value list -> Jdg.is_type option ->
   Runtime.value list option Runtime.comp

--- a/src/runtime/matching.mli
+++ b/src/runtime/matching.mli
@@ -1,8 +1,10 @@
 
-(** Match a value against a pattern. Matches are returned in order of decreasing de Bruijn index. *)
+(** Match a value against a pattern. Matches are returned in order of increasing de Bruijn index:
+    if we match the pattern [(x,y,z)] against the value [("foo", "bar", "baz")], the list returned
+    will be [["baz", "bar", "foo"]]. *)
 val match_pattern : Pattern.aml -> Runtime.value -> Runtime.value list option Runtime.comp
 
-(** Match a value against a pattern. Matches are returned in the order of decreasing de Bruijn index. *)
+(** Match a value against a pattern. Matches are returned in the order of increasing de Bruijn index. *)
 val top_match_pattern : Pattern.aml -> Runtime.value -> Runtime.value list option Runtime.toplevel
 
 (** [match_op_pattern ps p_out vs t_out] matches patterns [ps] against values [vs] and

--- a/src/runtime/predefined.ml
+++ b/src/runtime/predefined.ml
@@ -1,4 +1,3 @@
-
 type coercible =
   | NotCoercible
   | Convertible of Jdg.eq_type
@@ -13,8 +12,8 @@ let name_alpha = Name.make (Name.greek 0)
 let predefined_aml_types = let open Input in
   let unloc x = Location.locate x Location.unknown in
   let ty_alpha = unloc (ML_TyApply (name_alpha, [])) in
-  let un_ml_is_term = unloc ML_IsTerm in
-  let un_ml_eq_type = unloc ML_EqType in
+  let un_ml_is_term = unloc (ML_Judgement (ML_NotAbstract ML_IsTerm)) in
+  let un_ml_eq_type = unloc (ML_Judgement (ML_NotAbstract ML_EqType)) in
   let decl_option = DefMLType [Name.Predefined.option, ([name_alpha],
     ML_Sum [
     (Name.Predefined.none, []);
@@ -36,10 +35,10 @@ let predefined_aml_types = let open Input in
 
 let predefined_ops = let open Input in
   let unloc x = Location.locate x Location.unknown in
-  let un_ml_is_type = unloc ML_IsType in
-  let un_ml_is_term = unloc ML_IsTerm in
-  let un_ml_eq_type = unloc ML_EqType in
-  let un_ml_eq_term = unloc ML_EqTerm in
+  let un_ml_is_type = unloc (ML_Judgement (ML_NotAbstract ML_IsType)) in
+  let un_ml_is_term = unloc (ML_Judgement (ML_NotAbstract ML_IsTerm)) in
+  let un_ml_eq_type = unloc (ML_Judgement (ML_NotAbstract ML_EqType)) in
+  let un_ml_eq_term = unloc (ML_Judgement (ML_NotAbstract ML_EqTerm)) in
   let decl_equal_term = DeclOperation (Name.Predefined.equal_term, ([un_ml_is_term; un_ml_is_term], unloc (ML_TyApply (Name.Predefined.option, [un_ml_eq_term]))))
   and decl_equal_type = DeclOperation (Name.Predefined.equal_type, ([un_ml_is_type; un_ml_is_type], unloc (ML_TyApply (Name.Predefined.option, [un_ml_eq_type]))))
   and decl_as_prod = DeclOperation (Name.Predefined.as_prod, ([un_ml_is_type], unloc (ML_TyApply (Name.Predefined.option, [un_ml_eq_type]))))
@@ -54,7 +53,7 @@ let predefined_ops = let open Input in
 
 let predefined_bound = let open Input in
   let unloc x = Location.locate x Location.unknown in
-  let un_ml_is_term = unloc ML_IsTerm in
+  let un_ml_is_term = unloc (ML_Judgement (ML_NotAbstract ML_IsTerm)) in
   let hyps_annot = unloc (ML_TyApply (Name.Predefined.list, [un_ml_is_term])) in
   let decl_hyps = TopDynamic
                     (Name.Predefined.hypotheses, Arg_annot_ty hyps_annot, unloc (List [])) in
@@ -110,6 +109,7 @@ let as_coercible ~loc = function
     NotCoercible
   | Runtime.Tag (t, [v]) when Name.eq_ident t Name.Predefined.convertible ->
     let eq = Runtime.as_eq_type ~loc v in
+    let eq = Runtime.as_unabstracted
     Convertible eq
   | Runtime.Tag (t, [v]) when Name.eq_ident t Name.Predefined.coercible_constructor ->
     let j = Runtime.as_is_term ~loc v in

--- a/src/runtime/predefined.ml
+++ b/src/runtime/predefined.ml
@@ -1,7 +1,7 @@
 type coercible =
   | NotCoercible
-  | Convertible of Jdg.eq_type
-  | Coercible of Jdg.is_term
+  | Convertible of Jdg.eq_type_abstraction
+  | Coercible of Jdg.is_term_abstraction
 
 (************************)
 (* Built-in Definitions *)
@@ -108,10 +108,10 @@ let as_coercible ~loc = function
   | Runtime.Tag (t, []) when Name.eq_ident t Name.Predefined.notcoercible ->
     NotCoercible
   | Runtime.Tag (t, [v]) when Name.eq_ident t Name.Predefined.convertible ->
-    let eq = Runtime.as_eq_type ~loc v in
+    let eq = Runtime.as_eq_type_abstraction ~loc v in
     Convertible eq
   | Runtime.Tag (t, [v]) when Name.eq_ident t Name.Predefined.coercible_constructor ->
-    let e = Runtime.as_is_term ~loc v in
+    let e = Runtime.as_is_term_abstraction ~loc v in
     Coercible e
   | (Runtime.IsType _ | Runtime.IsTerm _ | Runtime.EqType _ | Runtime.EqTerm _ |
      Runtime.Closure _ | Runtime.Handler _ | Runtime.Tag _ | Runtime.Tuple _ |
@@ -152,8 +152,8 @@ let operation_equal_type ~loc t1 t2 =
   Runtime.return (as_eq_type_option ~loc v)
 
 let operation_coerce ~loc e t =
-  let v1 = Runtime.mk_is_term (Jdg.form_not_abstract e)
-  and v2 = Runtime.mk_is_type (Jdg.form_not_abstract t) in
+  let v1 = Runtime.mk_is_term e
+  and v2 = Runtime.mk_is_type t in
   Runtime.operation Name.Predefined.coerce [v1;v2] >>= fun v ->
   Runtime.return (as_coercible ~loc v)
 

--- a/src/runtime/predefined.ml
+++ b/src/runtime/predefined.ml
@@ -1,7 +1,7 @@
 type coercible =
   | NotCoercible
-  | Convertible of Jdg.eq_type
-  | Coercible of Jdg.is_term
+  | Convertible of Jdg.eq_type_abstraction
+  | Coercible of Jdg.is_term_abstraction
 
 (************************)
 (* Built-in Definitions *)

--- a/src/runtime/predefined.ml
+++ b/src/runtime/predefined.ml
@@ -1,7 +1,7 @@
 type coercible =
   | NotCoercible
-  | Convertible of Jdg.eq_type_abstraction
-  | Coercible of Jdg.is_term_abstraction
+  | Convertible of Jdg.eq_type
+  | Coercible of Jdg.is_term
 
 (************************)
 (* Built-in Definitions *)

--- a/src/runtime/predefined.ml
+++ b/src/runtime/predefined.ml
@@ -1,7 +1,7 @@
 type coercible =
   | NotCoercible
-  | Convertible of Jdg.eq_type
-  | Coercible of Jdg.is_term
+  | Convertible of Jdg.eq_type Jdg.abstraction
+  | Coercible of Jdg.is_term Jdg.abstraction
 
 (************************)
 (* Built-in Definitions *)
@@ -109,7 +109,6 @@ let as_coercible ~loc = function
     NotCoercible
   | Runtime.Tag (t, [v]) when Name.eq_ident t Name.Predefined.convertible ->
     let eq = Runtime.as_eq_type ~loc v in
-    let eq = Runtime.as_unabstracted
     Convertible eq
   | Runtime.Tag (t, [v]) when Name.eq_ident t Name.Predefined.coercible_constructor ->
     let j = Runtime.as_is_term ~loc v in

--- a/src/runtime/predefined.mli
+++ b/src/runtime/predefined.mli
@@ -4,8 +4,8 @@
  *)
 type coercible =
   | NotCoercible
-  | Convertible of Jdg.eq_type Jdg.abstraction
-  | Coercible of Jdg.is_term Jdg.abstraction
+  | Convertible of Jdg.eq_type
+  | Coercible of Jdg.is_term
 
 (** {6 Built-in Definitions} *)
 
@@ -25,38 +25,20 @@ val definitions : Input.toplevel list
     terms (wrapped as AML values), and then returns the resulting term equation if any.
  *)
 val operation_equal_term :
-  loc:Location.t -> Jdg.is_term Jdg.abstraction -> Jdg.is_term  Jdg.abstraction ->
-  Jdg.eq_term Jdg.abstraction option Runtime.comp
+  loc:Location.t -> Jdg.is_term -> Jdg.is_term -> Jdg.eq_term option Runtime.comp
 
 (** A computation that, when run, invokes the [eq_type] operation on the given
     terms (wrapped as AML values), and then returns the resulting term equation if any.
  *)
 val operation_equal_type :
-  loc:Location.t -> Jdg.is_type Jdg.abstraction -> Jdg.is_type Jdg.abstraction ->
-  Jdg.eq_type Jdg.abstraction option Runtime.comp
+  loc:Location.t -> Jdg.is_type -> Jdg.is_type -> Jdg.eq_type option Runtime.comp
 
 (** A computation that, when run, invokes the [coerce] operation
     on the given type theory term and desired type, and decodes
     the resulting AML value as a value of the correponding ML type [coercible].
  *)
 val operation_coerce :
-  loc:Location.t -> Jdg.is_term Jdg.abstraction
-  -> Jdg.is_type Jdg.abstraction -> coercible Runtime.comp
-
-(** A computation that, when run, invokes the [coerce_fun] operation on the
-    given term and decodes the resulting AML value into the ML type [coercible].
- *)
-val operation_coerce_fun :
-  loc:Location.t -> Jdg.is_term Jdg.abstraction
-  -> coercible Runtime.comp
-
-(** A computation that, when run, invokes the [as_prod] operration on the
-    given type; unwraps the resulting evidence (if any) that the given
-    type is equal to a Pi type.
- *)
-val operation_as_prod :
-  loc:Location.t -> Jdg.is_type Jdg.abstraction
-  -> Jdg.eq_type Jdg.abstraction option Runtime.comp
+  loc:Location.t -> Jdg.is_term -> Jdg.is_type -> coercible Runtime.comp
 
 (** {6 translation between AML and ML values} *)
 

--- a/src/runtime/predefined.mli
+++ b/src/runtime/predefined.mli
@@ -14,7 +14,7 @@ type coercible =
        - ['a list] and its constructors [[]] and [::]
        - ['a option] and its constructors [Some] and [None]
        - [coercible] and its constructors (as above)
-       - operations [equal], [as_prod], [as_eq], [coerce], [coerce_fun]
+       - operations [equal], [coerce]
        - the dynamic variable [hypotheses]
  *)
 val definitions : Input.toplevel list

--- a/src/runtime/predefined.mli
+++ b/src/runtime/predefined.mli
@@ -4,8 +4,8 @@
  *)
 type coercible =
   | NotCoercible
-  | Convertible of Jdg.eq_type
-  | Coercible of Jdg.is_term
+  | Convertible of Jdg.eq_type Jdg.abstraction
+  | Coercible of Jdg.is_term Jdg.abstraction
 
 (** {6 Built-in Definitions} *)
 
@@ -24,29 +24,39 @@ val definitions : Input.toplevel list
 (** A computation that, when run, invokes the [eq_term] operation on the given
     terms (wrapped as AML values), and then returns the resulting term equation if any.
  *)
-val operation_equal_term : loc:Location.t -> Jdg.is_term -> Jdg.is_term -> Jdg.eq_term option Runtime.comp
+val operation_equal_term :
+  loc:Location.t -> Jdg.is_term Jdg.abstraction -> Jdg.is_term  Jdg.abstraction ->
+  Jdg.eq_term Jdg.abstraction option Runtime.comp
 
 (** A computation that, when run, invokes the [eq_type] operation on the given
     terms (wrapped as AML values), and then returns the resulting term equation if any.
  *)
-val operation_equal_type : loc:Location.t -> Jdg.is_type -> Jdg.is_type -> Jdg.eq_type option Runtime.comp
+val operation_equal_type :
+  loc:Location.t -> Jdg.is_type Jdg.abstraction -> Jdg.is_type Jdg.abstraction ->
+  Jdg.eq_type Jdg.abstraction option Runtime.comp
 
 (** A computation that, when run, invokes the [coerce] operation
     on the given type theory term and desired type, and decodes
     the resulting AML value as a value of the correponding ML type [coercible].
  *)
-val operation_coerce : loc:Location.t -> Jdg.is_term -> Jdg.is_type -> coercible Runtime.comp
+val operation_coerce :
+  loc:Location.t -> Jdg.is_term Jdg.abstraction
+  -> Jdg.is_type Jdg.abstraction -> coercible Runtime.comp
 
 (** A computation that, when run, invokes the [coerce_fun] operation on the
     given term and decodes the resulting AML value into the ML type [coercible].
  *)
-val operation_coerce_fun : loc:Location.t -> Jdg.is_term -> coercible Runtime.comp
+val operation_coerce_fun :
+  loc:Location.t -> Jdg.is_term Jdg.abstraction
+  -> coercible Runtime.comp
 
 (** A computation that, when run, invokes the [as_prod] operration on the
     given type; unwraps the resulting evidence (if any) that the given
     type is equal to a Pi type.
  *)
-val operation_as_prod : loc:Location.t -> Jdg.is_type -> Jdg.eq_type option Runtime.comp
+val operation_as_prod :
+  loc:Location.t -> Jdg.is_type Jdg.abstraction
+  -> Jdg.eq_type Jdg.abstraction option Runtime.comp
 
 (** {6 translation between AML and ML values} *)
 
@@ -74,4 +84,4 @@ val as_option : loc:Location.t -> Runtime.value -> Runtime.value option
     temporarily adds it to the the front of the list contained in the
     dynamic variable [hypotheses] to run the given computation.
  *)
-val add_abstracting : Jdg.is_term -> 'a Runtime.comp -> 'a Runtime.comp
+val add_abstracting : Jdg.is_term Jdg.abstraction -> 'a Runtime.comp -> 'a Runtime.comp

--- a/src/runtime/predefined.mli
+++ b/src/runtime/predefined.mli
@@ -4,8 +4,8 @@
  *)
 type coercible =
   | NotCoercible
-  | Convertible of Jdg.eq_type
-  | Coercible of Jdg.is_term
+  | Convertible of Jdg.eq_type_abstraction
+  | Coercible of Jdg.is_term_abstraction
 
 (** {6 Built-in Definitions} *)
 
@@ -38,7 +38,7 @@ val operation_equal_type :
     the resulting AML value as a value of the correponding ML type [coercible].
  *)
 val operation_coerce :
-  loc:Location.t -> Jdg.is_term -> Jdg.is_type -> coercible Runtime.comp
+  loc:Location.t -> Jdg.is_term_abstraction -> Jdg.is_type_abstraction -> coercible Runtime.comp
 
 (** {6 translation between AML and ML values} *)
 

--- a/src/runtime/runtime.ml
+++ b/src/runtime/runtime.ml
@@ -294,10 +294,10 @@ let get_env env = Return env, env.state
 
 let top_get_env env = env, env
 
-let get_typing_signature env = env.dynamic.signature
+let get_signature env = env.dynamic.signature
 
-let lookup_typing_signature env =
-  Return (get_typing_signature env), env.state
+let lookup_signature env =
+  Return env.dynamic.signature, env.state
 
 let index_of_level k env =
   let n = List.length env.lexical.bound - k - 1 in
@@ -318,7 +318,7 @@ let add_bound0 v env = {env with lexical = { env.lexical with
 
 let add_free x jt m env =
   let jy = Jdg.fresh_atom x jt in
-  let y_val = mk_is_term (Jdg.abstract_not_abstract (Jdg.form_is_term_atom jy)) in
+  let y_val = mk_is_term (Jdg.form_abstraction (Jdg.NotAbstract (Jdg.form_is_term_atom jy))) in
   let env = add_bound0 y_val env in
   m jy env
 

--- a/src/runtime/runtime.ml
+++ b/src/runtime/runtime.ml
@@ -168,12 +168,12 @@ let top_bind m f env =
 type 'a caught =
   | CaughtJdg of Jdg.error Location.located
   | CaughtRuntime of error Location.located
-  | Value of 'a
+  | Result of 'a
 
 let catch ~loc m env =
   try
     let x, env = Lazy.force m env in
-    Value x, env
+    Result x, env
   with
     | Jdg.Error err -> CaughtJdg (Location.locate err loc), env
     | Error err -> CaughtRuntime err, env

--- a/src/runtime/runtime.ml
+++ b/src/runtime/runtime.ml
@@ -43,11 +43,16 @@ and lexical = {
 
 and state = value Store.Ref.t
 
+and is_term_abstraction = Jdg.is_term Jdg.abstraction
+and is_type_abstraction = Jdg.is_type Jdg.abstraction
+and eq_term_abstraction = Jdg.eq_term Jdg.abstraction
+and eq_type_abstraction = Jdg.eq_type Jdg.abstraction
+
 and value =
-  | IsTerm of Jdg.is_term
-  | IsType of Jdg.is_type
-  | EqTerm of Jdg.eq_term
-  | EqType of Jdg.eq_type
+  | IsTerm of is_term_abstraction
+  | IsType of is_type_abstraction
+  | EqTerm of eq_term_abstraction
+  | EqType of eq_type_abstraction
   | Closure of (value, value) closure
   | Handler of handler
   | Tag of Name.ident * value list
@@ -317,12 +322,15 @@ let add_free ~loc x jt m env =
   let env = add_bound0 y_val env in
   m jy env
 
+(* XXX This will get fancier once we have rules and we want to add them to the signature
 let add_constant0 ~loc x t env =
   { env with dynamic = {env.dynamic with signature =
                            Jdg.Signature.add_constant x t env.dynamic.signature };
              lexical = {env.lexical with forbidden = x :: env.lexical.forbidden } }
 
 let add_constant ~loc x t env = (), add_constant0 ~loc x t env
+*)
+
 
 (* XXX rename to bind_value *)
 let add_bound v m env =
@@ -419,13 +427,13 @@ let rec as_list_opt = function
 let rec print_value ?max_level ~penv v ppf =
   match v with
 
-  | IsTerm e -> Jdg.print_is_term ~penv:penv ?max_level e ppf
+  | IsTerm e -> Jdg.print_is_term_abstraction ~penv:penv ?max_level e ppf
 
-  | IsType t -> Jdg.print_is_type ~penv:penv ?max_level t ppf
+  | IsType t -> Jdg.print_is_type_abstraction ~penv:penv ?max_level t ppf
 
-  | EqTerm eq -> Jdg.print_eq_term ~penv:penv ?max_level eq ppf
+  | EqTerm eq -> Jdg.print_eq_term_abstraction ~penv:penv ?max_level eq ppf
 
-  | EqType eq -> Jdg.print_eq_type ~penv:penv ?max_level eq ppf
+  | EqType eq -> Jdg.print_eq_type_abstraction ~penv:penv ?max_level eq ppf
 
   | Closure f -> Format.fprintf ppf "<function>"
 
@@ -760,13 +768,13 @@ struct
   let rec value v =
     match v with
 
-    | IsTerm e -> Json.tag "IsTerm" [Jdg.Json.is_term e]
+    | IsTerm e -> Json.tag "IsTerm" [Jdg.Json.abstraction Jdg.Json.is_term e]
 
-    | IsType t -> Json.tag "IsType" [Jdg.Json.is_type t]
+    | IsType t -> Json.tag "IsType" [Jdg.Json.abstraction Jdg.Json.is_type t]
 
-    | EqType eq -> Json.tag "EqType" [Jdg.Json.eq_type eq]
+    | EqType eq -> Json.tag "EqType" [Jdg.Json.abstraction Jdg.Json.eq_type eq]
 
-    | EqTerm eq -> Json.tag "EqTerm" [Jdg.Json.eq_term eq]
+    | EqTerm eq -> Json.tag "EqTerm" [Jdg.Json.abstraction Jdg.Json.eq_term eq]
 
     | Closure _ -> Json.tag "<fun>" []
 

--- a/src/runtime/runtime.ml
+++ b/src/runtime/runtime.ml
@@ -83,7 +83,7 @@ type error =
   | UnknownExternal of string
   | UnknownConfig of string
   | Inapplicable of value
-  | AnnotationMismatch of Jdg.is_type * Jdg.is_type
+  | AnnotationMismatch of Jdg.is_type * Jdg.is_type_abstraction
   | TypeMismatchCheckingMode of Jdg.is_term_abstraction * Jdg.is_type_abstraction
   | EqualityFail of Jdg.is_term * Jdg.is_term
   | UnannotatedAbstract of Name.ident
@@ -578,7 +578,7 @@ let print_error ~penv err ppf =
       Format.fprintf ppf
       "@[<v>The type annotation is@,   @[<hov>%t@]@ but the surroundings imply it should be@,   @[<hov>%t@].@]"
                     (Jdg.print_is_type ~penv:penv t1)
-                    (Jdg.print_is_type ~penv:penv t2)
+                    (Jdg.print_is_type_abstraction ~penv:penv t2)
 
   | TypeMismatchCheckingMode (v, t) ->
       Format.fprintf ppf "The term@,   @[<hov>%t@]@ is expected by its surroundings to have type@,   @[<hov>%t@]"

--- a/src/runtime/runtime.ml
+++ b/src/runtime/runtime.ml
@@ -89,7 +89,7 @@ type error =
   | UnknownConfig of string
   | Inapplicable of value
   | AnnotationMismatch of Jdg.is_type * Jdg.is_type
-  | TypeMismatchCheckingMode of Jdg.is_term * Jdg.is_type
+  | TypeMismatchCheckingMode of is_term_abstraction * is_type_abstraction
   | EqualityFail of Jdg.is_term * Jdg.is_term
   | UnannotatedAbstract of Name.ident
   | MatchFail of value
@@ -102,6 +102,7 @@ type error =
   | IsTermExpected of value
   | EqTypeExpected of value
   | EqTermExpected of value
+  | JudgementExpected of value
   | ClosureExpected of value
   | HandlerExpected of value
   | RefExpected of value
@@ -557,8 +558,8 @@ let print_error ~penv err ppf =
 
   | TypeMismatchCheckingMode (v, t) ->
       Format.fprintf ppf "The term@,   @[<hov>%t@]@ is expected by its surroundings to have type@,   @[<hov>%t@]"
-                    (Jdg.print_is_term ~penv:penv v)
-                    (Jdg.print_is_type ~penv:penv t)
+                    (Jdg.print_is_term_abstraction ~penv:penv v)
+                    (Jdg.print_is_type_abstraction ~penv:penv t)
 
   | EqualityFail (e1, e2) ->
      Format.fprintf ppf "failed to check that@ %t@ and@ %t@ are equal"
@@ -603,6 +604,9 @@ let print_error ~penv err ppf =
 
   | EqTermExpected v ->
      Format.fprintf ppf "expected a term equality but got %s" (name_of v)
+
+  | JudgementExpected v ->
+     Format.fprintf ppf "expected a judgement but got %s" (name_of v)
 
   | ClosureExpected v ->
      Format.fprintf ppf "expected a function but got %s" (name_of v)

--- a/src/runtime/runtime.ml
+++ b/src/runtime/runtime.ml
@@ -100,8 +100,6 @@ type error =
   | OptionExpected of value
   | IsTypeExpected of value
   | IsTermExpected of value
-  | IsTypeOrTermExpected of value
-  | AbstractTyExpected of Jdg.is_type
   | EqTypeExpected of value
   | EqTermExpected of value
   | ClosureExpected of value
@@ -583,13 +581,6 @@ let print_error ~penv err ppf =
 
   | IsTermExpected v ->
      Format.fprintf ppf "expected a term but got %s" (name_of v)
-
-  | IsTypeOrTermExpected v ->
-     Format.fprintf ppf "expected a term or a type but got %s" (name_of v)
-
-  | AbstractTyExpected t ->
-     Format.fprintf ppf "expected an abstracted type but got %t"
-                    (Jdg.print_is_type ~penv:penv t)
 
   | EqTypeExpected v ->
      Format.fprintf ppf "expected a type equality but got %s" (name_of v)

--- a/src/runtime/runtime.ml
+++ b/src/runtime/runtime.ml
@@ -1,7 +1,7 @@
 (** Runtime values and computations *)
 
-type ref = Store.Ref.key
-type dyn = Store.Dyn.key
+type ref = Store.Ref.key (* TODO rename to aml_ref, or just get rid of this *)
+type dyn = Store.Dyn.key (* TODO rename to aml_dyn, or just get rid of this *)
 
 (** This module defines 2 monads:
     - the computation monad [comp], providing operations and an environment of which part is dynamically scoped.
@@ -170,12 +170,12 @@ type 'a caught =
   | CaughtRuntime of error Location.located
   | Value of 'a
 
-let catch m env =
+let catch ~loc m env =
   try
     let x, env = Lazy.force m env in
     Value x, env
   with
-    | Jdg.Error err -> CaughtJdg err, env
+    | Jdg.Error err -> CaughtJdg (Location.locate err loc), env
     | Error err -> CaughtRuntime err, env
 
 (** Returns *)

--- a/src/runtime/runtime.mli
+++ b/src/runtime/runtime.mli
@@ -8,27 +8,21 @@ type ref
 (** An AML dynamic variable. *)
 type dyn
 
-(** In runtime, judgements are always possibly abstracted. *)
-type is_term_abstraction = Jdg.is_term Jdg.abstraction
-type is_type_abstraction = Jdg.is_type Jdg.abstraction
-type eq_term_abstraction = Jdg.eq_term Jdg.abstraction
-type eq_type_abstraction = Jdg.eq_type Jdg.abstraction
-
 (** values are "finished" or "computed". They are inert pieces of data. *)
 type value = private
-  | IsTerm of is_term_abstraction    (** A term judgment *)
-  | IsType of is_type_abstraction    (** A type judgment *)
-  | EqTerm of eq_term_abstraction    (** A term equality *)
-  | EqType of eq_type_abstraction    (** A type equality *)
-  | Closure of (value,value) closure (** An AML function *)
-  | Handler of handler               (** Handler value *)
-  | Tag of Name.ident * value list   (** Application of a data constructor *)
-  | Tuple of value list              (** Tuple of values *)
-  | Ref of ref                       (** Ref cell *)
-  | Dyn of dyn                       (** Dynamic variable *)
-  | String of string                 (** String constant (opaque, not a list) *)
+  | IsTerm of Jdg.is_term_abstraction    (** A term judgment *)
+  | IsType of Jdg.is_type_abstraction    (** A type judgment *)
+  | EqTerm of Jdg.eq_term_abstraction    (** A term equality *)
+  | EqType of Jdg.eq_type_abstraction    (** A type equality *)
+  | Closure of (value,value) closure     (** An AML function *)
+  | Handler of handler                   (** Handler value *)
+  | Tag of Name.ident * value list       (** Application of a data constructor *)
+  | Tuple of value list                  (** Tuple of values *)
+  | Ref of ref                           (** Ref cell *)
+  | Dyn of dyn                           (** Dynamic variable *)
+  | String of string                     (** String constant (opaque, not a list) *)
 
-and operation_args = { args : value list; checking : is_type_abstraction option }
+and operation_args = { args : value list; checking : Jdg.is_type_abstraction option }
 
 (** A handler contains AML code for handling zero or more operations,
     plus the default case *)
@@ -43,16 +37,16 @@ val name_of : value -> string
 (** {b Value construction} *)
 
 (** Build an [IsTerm] value *)
-val mk_is_term : is_term_abstraction -> value
+val mk_is_term : Jdg.is_term_abstraction -> value
 
 (** Build an [IsType] value *)
-val mk_is_type : is_type_abstraction -> value
+val mk_is_type : Jdg.is_type_abstraction -> value
 
 (** Build an [EqTerm] value *)
-val mk_eq_term : eq_term_abstraction -> value
+val mk_eq_term : Jdg.eq_term_abstraction -> value
 
 (** Build an [EqType] value *)
-val mk_eq_type : eq_type_abstraction -> value
+val mk_eq_type : Jdg.eq_type_abstraction -> value
 
 (** Build a [Handler] value *)
 val mk_handler : handler -> value
@@ -80,6 +74,18 @@ val as_eq_term : loc:Location.t -> value -> Jdg.eq_term
 
 (** Convert, or fail with [EqTypeExpected] *)
 val as_eq_type : loc:Location.t -> value -> Jdg.eq_type
+
+(** Convert, or fail with [IsTermAbstractionExpected] *)
+val as_is_term_abstraction : loc:Location.t -> value -> Jdg.is_term_abstraction
+
+(** Convert, or fail with [IsTypeAbstractionExpected] *)
+val as_is_type_abstraction : loc:Location.t -> value -> Jdg.is_type_abstraction
+
+(** Convert, or fail with [EqTermAbstractionExpected] *)
+val as_eq_term_abstraction : loc:Location.t -> value -> Jdg.eq_term_abstraction
+
+(** Convert, or fail with [EqTypeAbstractionExpected] *)
+val as_eq_type_abstraction : loc:Location.t -> value -> Jdg.eq_type_abstraction
 
 (** Convert, or fail with [ClosureExpected] *)
 val as_closure : loc:Location.t -> value -> (value,value) closure
@@ -118,7 +124,7 @@ type error =
   | UnknownConfig of string
   | Inapplicable of value
   | AnnotationMismatch of Jdg.is_type * Jdg.is_type
-  | TypeMismatchCheckingMode of is_term_abstraction * is_type_abstraction
+  | TypeMismatchCheckingMode of Jdg.is_term_abstraction * Jdg.is_type_abstraction
   | EqualityFail of Jdg.is_term * Jdg.is_term
   | UnannotatedAbstract of Name.ident
   | MatchFail of value
@@ -131,6 +137,10 @@ type error =
   | IsTermExpected of value
   | EqTypeExpected of value
   | EqTermExpected of value
+  | IsTypeAbstractionExpected of value
+  | IsTermAbstractionExpected of value
+  | EqTypeAbstractionExpected of value
+  | EqTermAbstractionExpected of value
   | JudgementExpected of value
   | ClosureExpected of value
   | HandlerExpected of value
@@ -169,10 +179,10 @@ val return : 'a -> 'a comp
 
 val return_unit : value comp
 
-val return_is_term : is_term_abstraction -> value comp
-val return_is_type : is_type_abstraction -> value comp
-val return_eq_term : eq_term_abstraction -> value comp
-val return_eq_type : eq_type_abstraction -> value comp
+val return_is_term : Jdg.is_term_abstraction -> value comp
+val return_is_type : Jdg.is_type_abstraction -> value comp
+val return_eq_term : Jdg.eq_term_abstraction -> value comp
+val return_eq_type : Jdg.eq_type_abstraction -> value comp
 
 val return_closure : (value -> value comp) -> value comp
 val return_handler :
@@ -197,7 +207,7 @@ val lookup_ref : ref -> value comp
 val update_ref : ref -> value -> unit comp
 
 (** A computation that invokes the specified operation. *)
-val operation : Name.operation -> ?checking:is_type_abstraction -> value list -> value comp
+val operation : Name.operation -> ?checking:Jdg.is_type_abstraction -> value list -> value comp
 
 (** Wrap the given computation with a handler. *)
 val handle_comp : handler -> value comp -> value comp
@@ -265,7 +275,7 @@ val add_topbound_rec : (value -> value comp) list -> unit toplevel
 val add_dynamic : loc:Location.t -> Name.ident -> value -> unit toplevel
 
 (** Add a top-level handler case to the environment. *)
-val add_handle : Name.ident -> (value list * is_type_abstraction option, value) closure
+val add_handle : Name.ident -> (value list * Jdg.is_type_abstraction option, value) closure
                  -> unit toplevel
 
 (** Modify the value bound by a dynamic variable *)

--- a/src/runtime/runtime.mli
+++ b/src/runtime/runtime.mli
@@ -230,7 +230,7 @@ val index_of_level : Rsyntax.level -> Rsyntax.bound comp
     then it extends [ctx] to [ctx' = ctx, y : t]
     and runs [f (ctx' |- y : t)] in the environment with [x] bound to [ctx' |- y : t].
     NB: This is an effectful computation, as it increases a global counter. *)
-val add_free: loc:Location.t -> Name.ident -> Jdg.is_type -> (Jdg.is_atom -> 'a comp) -> 'a comp
+val add_free: Name.ident -> Jdg.is_type -> (Jdg.is_atom -> 'a comp) -> 'a comp
 
 (** Lookup a free variable by its de Bruijn index *)
 val lookup_bound : loc:Location.t -> int -> value comp
@@ -255,9 +255,6 @@ val top_return_closure : ('a -> 'b comp) -> ('a,'b) closure toplevel
 val top_fold : ('a -> 'b -> 'a toplevel) -> 'a -> 'b list -> 'a toplevel
 
 (** {b Monadic interface} *)
-
-(** Add a constant of a given type to the environment. *)
-val add_constant : loc:Location.t -> Name.ident -> Jdg.is_type -> unit toplevel
 
 (** Add a bound variable with the given name to the environment. *)
 val add_topbound : value -> unit toplevel

--- a/src/runtime/runtime.mli
+++ b/src/runtime/runtime.mli
@@ -8,12 +8,19 @@ type ref
 (** An AML dynamic variable. *)
 type dyn
 
+(** In runtime, judgements are always possibly abstracted. *)
+
+type is_term = Jdg.is_term Jdg.abstraction
+type is_type = Jdg.is_type Jdg.abstraction
+type eq_term = Jdg.eq_term Jdg.abstraction
+type eq_type = Jdg.eq_type Jdg.abstraction
+
 (** values are "finished" or "computed". They are inert pieces of data. *)
 type value = private
-  | IsTerm of Jdg.is_term            (** A term judgment *)
-  | IsType of Jdg.is_type            (** A type judgment *)
-  | EqTerm of Jdg.eq_term            (** A term equality *)
-  | EqType of Jdg.eq_type            (** A type equality *)
+  | IsTerm of is_term                (** A term judgment *)
+  | IsType of is_type                (** A type judgment *)
+  | EqTerm of eq_term                (** A term equality *)
+  | EqType of eq_type                (** A type equality *)
   | Closure of (value,value) closure (** An AML function *)
   | Handler of handler               (** Handler value *)
   | Tag of Name.ident * value list   (** Application of a data constructor *)
@@ -22,7 +29,7 @@ type value = private
   | Dyn of dyn                       (** Dynamic variable *)
   | String of string                 (** String constant (opaque, not a list) *)
 
-and operation_args = { args : value list; checking : Jdg.is_type option}
+and operation_args = { args : value list; checking : is_type option}
 
 (** A handler contains AML code for handling zero or more operations,
     plus the default case *)
@@ -37,16 +44,16 @@ val name_of : value -> string
 (** {b Value construction} *)
 
 (** Build an [IsTerm] value *)
-val mk_is_term : Jdg.is_term -> value
+val mk_is_term : is_term -> value
 
 (** Build an [IsType] value *)
-val mk_is_type : Jdg.is_type-> value
+val mk_is_type : is_type-> value
 
 (** Build an [EqTerm] value *)
-val mk_eq_term : Jdg.eq_term -> value
+val mk_eq_term : eq_term -> value
 
 (** Build an [EqType] value *)
-val mk_eq_type : Jdg.eq_type -> value
+val mk_eq_type : eq_type -> value
 
 (** Build a [Handler] value *)
 val mk_handler : handler -> value
@@ -64,16 +71,16 @@ val mk_string  : string -> value
 (** {b Value extraction} *)
 
 (** Convert, or fail with [IsTermExpected] *)
-val as_is_term : loc:Location.t -> value -> Jdg.is_term
+val as_is_term : loc:Location.t -> value -> is_term
 
 (** Convert, or fail with [IsTypeExpected] *)
-val as_is_type : loc:Location.t -> value -> Jdg.is_type
+val as_is_type : loc:Location.t -> value -> is_type
 
 (** Convert, or fail with [EqTermExpected] *)
-val as_eq_term : loc:Location.t -> value -> Jdg.eq_term
+val as_eq_term : loc:Location.t -> value -> eq_term
 
 (** Convert, or fail with [EqTypeExpected] *)
-val as_eq_type : loc:Location.t -> value -> Jdg.eq_type
+val as_eq_type : loc:Location.t -> value -> eq_type
 
 (** Convert, or fail with [ClosureExpected] *)
 val as_closure : loc:Location.t -> value -> (value,value) closure
@@ -164,10 +171,10 @@ val return : 'a -> 'a comp
 
 val return_unit : value comp
 
-val return_is_term : Jdg.is_term -> value comp
-val return_is_type : Jdg.is_type -> value comp
-val return_eq_term : Jdg.eq_term -> value comp
-val return_eq_type : Jdg.eq_type -> value comp
+val return_is_term : is_term -> value comp
+val return_is_type : is_type -> value comp
+val return_eq_term : eq_term -> value comp
+val return_eq_type : eq_type -> value comp
 
 val return_closure : (value -> value comp) -> value comp
 val return_handler :
@@ -192,7 +199,7 @@ val lookup_ref : ref -> value comp
 val update_ref : ref -> value -> unit comp
 
 (** A computation that invokes the specified operation. *)
-val operation : Name.operation -> ?checking:Jdg.is_type -> value list -> value comp
+val operation : Name.operation -> ?checking:is_type -> value list -> value comp
 
 (** Wrap the given computation with a handler. *)
 val handle_comp : handler -> value comp -> value comp
@@ -263,7 +270,7 @@ val add_topbound_rec : (value -> value comp) list -> unit toplevel
 val add_dynamic : loc:Location.t -> Name.ident -> value -> unit toplevel
 
 (** Add a top-level handler case to the environment. *)
-val add_handle : Name.ident -> (value list * Jdg.is_type option,value) closure -> unit toplevel
+val add_handle : Name.ident -> (value list * is_type option, value) closure -> unit toplevel
 
 (** Modify the value bound by a dynamic variable *)
 val top_now : dyn -> value -> unit toplevel
@@ -277,7 +284,7 @@ val top_lookup_penv : TT.print_env toplevel
 type 'a caught =
   | CaughtJdg of Jdg.error Location.located
   | CaughtRuntime of error Location.located
-  | Value of 'a
+  | Result of 'a
 
 (** Catch Error exceptions. The state is not changed if an exception occurs. *)
 val catch : loc:Location.t -> 'a toplevel Lazy.t -> 'a caught toplevel

--- a/src/runtime/runtime.mli
+++ b/src/runtime/runtime.mli
@@ -280,7 +280,7 @@ type 'a caught =
   | Value of 'a
 
 (** Catch Error exceptions. The state is not changed if an exception occurs. *)
-val catch : 'a toplevel Lazy.t -> 'a caught toplevel
+val catch : loc:Location.t -> 'a toplevel Lazy.t -> 'a caught toplevel
 
 (** {6 Running a toplevel computation} *)
 

--- a/src/runtime/runtime.mli
+++ b/src/runtime/runtime.mli
@@ -125,7 +125,9 @@ type error =
   | Inapplicable of value
   | AnnotationMismatch of Jdg.is_type * Jdg.is_type_abstraction
   | TypeMismatchCheckingMode of Jdg.is_term_abstraction * Jdg.is_type_abstraction
-  | EqualityFail of Jdg.is_term * Jdg.is_term
+  | UnexpectedAbstraction of Jdg.is_type
+  | TermEqualityFail of Jdg.is_term * Jdg.is_term
+  | TypeEqualityFail of Jdg.is_type * Jdg.is_type
   | UnannotatedAbstract of Name.ident
   | MatchFail of value
   | FailureFail of value
@@ -148,8 +150,8 @@ type error =
   | DynExpected of value
   | StringExpected of value
   | CoercibleExpected of value
-  | InvalidConvertible of Jdg.is_type * Jdg.is_type * Jdg.eq_type
-  | InvalidCoerce of Jdg.is_type * Jdg.is_term
+  | InvalidConvertible of Jdg.is_type_abstraction * Jdg.is_type_abstraction * Jdg.eq_type_abstraction
+  | InvalidCoerce of Jdg.is_type_abstraction * Jdg.is_term_abstraction
   | UnhandledOperation of Name.operation * value list
 
 (** The exception that is raised on runtime error *)
@@ -235,9 +237,8 @@ val add_bound_rec :
 (** [index_of_level n] gives the De Bruijn index of the variable whose De Bruijn level is [n]. *)
 val index_of_level : Rsyntax.level -> Rsyntax.bound comp
 
-(** [add_free ~loc x (ctx,t) f] generates a fresh atom [y] from identifier [x],
-    then it extends [ctx] to [ctx' = ctx, y : t]
-    and runs [f (ctx' |- y : t)] in the environment with [x] bound to [ctx' |- y : t].
+(** [add_free ~loc x t f] generates a fresh atom [a] from identifier [x],
+    and runs [f a] in the environment extended with [a : t].
     NB: This is an effectful computation, as it increases a global counter. *)
 val add_free: Name.ident -> Jdg.is_type -> (Jdg.is_atom -> 'a comp) -> 'a comp
 

--- a/src/runtime/runtime.mli
+++ b/src/runtime/runtime.mli
@@ -212,8 +212,8 @@ val continue : loc:Location.t -> value -> value comp
 (** Get the printing environment from the monad *)
 val lookup_penv : TT.print_env comp
 
-(** Gets the current constants *)
-val lookup_typing_signature : Jdg.Signature.t comp
+(** Gets the current rules of inference. *)
+val lookup_signature : Jdg.Signature.t comp
 
 (** Bound and free variable stuff *)
 
@@ -308,7 +308,7 @@ val get_env : env comp
 (** Get the toplevel environment from the toplevel monad *)
 val top_get_env : env toplevel
 
-val get_typing_signature : env -> Jdg.Signature.t
+val get_signature : env -> Jdg.Signature.t
 
 (** For matching *)
 val get_bound : loc:Location.t -> int -> env -> value

--- a/src/runtime/runtime.mli
+++ b/src/runtime/runtime.mli
@@ -123,7 +123,7 @@ type error =
   | UnknownExternal of string
   | UnknownConfig of string
   | Inapplicable of value
-  | AnnotationMismatch of Jdg.is_type * Jdg.is_type
+  | AnnotationMismatch of Jdg.is_type * Jdg.is_type_abstraction
   | TypeMismatchCheckingMode of Jdg.is_term_abstraction * Jdg.is_type_abstraction
   | EqualityFail of Jdg.is_term * Jdg.is_term
   | UnannotatedAbstract of Name.ident

--- a/src/runtime/runtime.mli
+++ b/src/runtime/runtime.mli
@@ -70,16 +70,16 @@ val mk_string  : string -> value
 (** {b Value extraction} *)
 
 (** Convert, or fail with [IsTermExpected] *)
-val as_is_term : loc:Location.t -> value -> is_term_abstraction
+val as_is_term : loc:Location.t -> value -> Jdg.is_term
 
 (** Convert, or fail with [IsTypeExpected] *)
-val as_is_type : loc:Location.t -> value -> is_type_abstraction
+val as_is_type : loc:Location.t -> value -> Jdg.is_type
 
 (** Convert, or fail with [EqTermExpected] *)
-val as_eq_term : loc:Location.t -> value -> eq_term_abstraction
+val as_eq_term : loc:Location.t -> value -> Jdg.eq_term
 
 (** Convert, or fail with [EqTypeExpected] *)
-val as_eq_type : loc:Location.t -> value -> eq_type_abstraction
+val as_eq_type : loc:Location.t -> value -> Jdg.eq_type
 
 (** Convert, or fail with [ClosureExpected] *)
 val as_closure : loc:Location.t -> value -> (value,value) closure

--- a/src/runtime/runtime.mli
+++ b/src/runtime/runtime.mli
@@ -118,7 +118,7 @@ type error =
   | UnknownConfig of string
   | Inapplicable of value
   | AnnotationMismatch of Jdg.is_type * Jdg.is_type
-  | TypeMismatchCheckingMode of Jdg.is_term * Jdg.is_type
+  | TypeMismatchCheckingMode of is_term_abstraction * is_type_abstraction
   | EqualityFail of Jdg.is_term * Jdg.is_term
   | UnannotatedAbstract of Name.ident
   | MatchFail of value
@@ -131,6 +131,7 @@ type error =
   | IsTermExpected of value
   | EqTypeExpected of value
   | EqTermExpected of value
+  | JudgementExpected of value
   | ClosureExpected of value
   | HandlerExpected of value
   | RefExpected of value

--- a/src/runtime/runtime.mli
+++ b/src/runtime/runtime.mli
@@ -9,18 +9,17 @@ type ref
 type dyn
 
 (** In runtime, judgements are always possibly abstracted. *)
-
-type is_term = Jdg.is_term Jdg.abstraction
-type is_type = Jdg.is_type Jdg.abstraction
-type eq_term = Jdg.eq_term Jdg.abstraction
-type eq_type = Jdg.eq_type Jdg.abstraction
+type is_term_abstraction = Jdg.is_term Jdg.abstraction
+type is_type_abstraction = Jdg.is_type Jdg.abstraction
+type eq_term_abstraction = Jdg.eq_term Jdg.abstraction
+type eq_type_abstraction = Jdg.eq_type Jdg.abstraction
 
 (** values are "finished" or "computed". They are inert pieces of data. *)
 type value = private
-  | IsTerm of is_term                (** A term judgment *)
-  | IsType of is_type                (** A type judgment *)
-  | EqTerm of eq_term                (** A term equality *)
-  | EqType of eq_type                (** A type equality *)
+  | IsTerm of is_term_abstraction    (** A term judgment *)
+  | IsType of is_type_abstraction    (** A type judgment *)
+  | EqTerm of eq_term_abstraction    (** A term equality *)
+  | EqType of eq_type_abstraction    (** A type equality *)
   | Closure of (value,value) closure (** An AML function *)
   | Handler of handler               (** Handler value *)
   | Tag of Name.ident * value list   (** Application of a data constructor *)
@@ -29,7 +28,7 @@ type value = private
   | Dyn of dyn                       (** Dynamic variable *)
   | String of string                 (** String constant (opaque, not a list) *)
 
-and operation_args = { args : value list; checking : is_type option}
+and operation_args = { args : value list; checking : is_type_abstraction option }
 
 (** A handler contains AML code for handling zero or more operations,
     plus the default case *)
@@ -44,16 +43,16 @@ val name_of : value -> string
 (** {b Value construction} *)
 
 (** Build an [IsTerm] value *)
-val mk_is_term : is_term -> value
+val mk_is_term : is_term_abstraction -> value
 
 (** Build an [IsType] value *)
-val mk_is_type : is_type-> value
+val mk_is_type : is_type_abstraction -> value
 
 (** Build an [EqTerm] value *)
-val mk_eq_term : eq_term -> value
+val mk_eq_term : eq_term_abstraction -> value
 
 (** Build an [EqType] value *)
-val mk_eq_type : eq_type -> value
+val mk_eq_type : eq_type_abstraction -> value
 
 (** Build a [Handler] value *)
 val mk_handler : handler -> value
@@ -71,16 +70,16 @@ val mk_string  : string -> value
 (** {b Value extraction} *)
 
 (** Convert, or fail with [IsTermExpected] *)
-val as_is_term : loc:Location.t -> value -> is_term
+val as_is_term : loc:Location.t -> value -> is_term_abstraction
 
 (** Convert, or fail with [IsTypeExpected] *)
-val as_is_type : loc:Location.t -> value -> is_type
+val as_is_type : loc:Location.t -> value -> is_type_abstraction
 
 (** Convert, or fail with [EqTermExpected] *)
-val as_eq_term : loc:Location.t -> value -> eq_term
+val as_eq_term : loc:Location.t -> value -> eq_term_abstraction
 
 (** Convert, or fail with [EqTypeExpected] *)
-val as_eq_type : loc:Location.t -> value -> eq_type
+val as_eq_type : loc:Location.t -> value -> eq_type_abstraction
 
 (** Convert, or fail with [ClosureExpected] *)
 val as_closure : loc:Location.t -> value -> (value,value) closure
@@ -171,10 +170,10 @@ val return : 'a -> 'a comp
 
 val return_unit : value comp
 
-val return_is_term : is_term -> value comp
-val return_is_type : is_type -> value comp
-val return_eq_term : eq_term -> value comp
-val return_eq_type : eq_type -> value comp
+val return_is_term : is_term_abstraction -> value comp
+val return_is_type : is_type_abstraction -> value comp
+val return_eq_term : eq_term_abstraction -> value comp
+val return_eq_type : eq_type_abstraction -> value comp
 
 val return_closure : (value -> value comp) -> value comp
 val return_handler :
@@ -199,7 +198,7 @@ val lookup_ref : ref -> value comp
 val update_ref : ref -> value -> unit comp
 
 (** A computation that invokes the specified operation. *)
-val operation : Name.operation -> ?checking:is_type -> value list -> value comp
+val operation : Name.operation -> ?checking:is_type_abstraction -> value list -> value comp
 
 (** Wrap the given computation with a handler. *)
 val handle_comp : handler -> value comp -> value comp
@@ -270,7 +269,8 @@ val add_topbound_rec : (value -> value comp) list -> unit toplevel
 val add_dynamic : loc:Location.t -> Name.ident -> value -> unit toplevel
 
 (** Add a top-level handler case to the environment. *)
-val add_handle : Name.ident -> (value list * is_type option, value) closure -> unit toplevel
+val add_handle : Name.ident -> (value list * is_type_abstraction option, value) closure
+                 -> unit toplevel
 
 (** Modify the value bound by a dynamic variable *)
 val top_now : dyn -> value -> unit toplevel

--- a/src/runtime/runtime.mli
+++ b/src/runtime/runtime.mli
@@ -129,8 +129,6 @@ type error =
   | OptionExpected of value
   | IsTypeExpected of value
   | IsTermExpected of value
-  | IsTypeOrTermExpected of value
-  | AbstractTyExpected of Jdg.is_type
   | EqTypeExpected of value
   | EqTermExpected of value
   | ClosureExpected of value

--- a/src/typing/context.ml
+++ b/src/typing/context.ml
@@ -99,3 +99,14 @@ let predefined_type x ts {types;_} =
     | _ :: types -> search (k + 1) types
   in
   search 0 (List.rev types)
+
+let print_context {variables;_} =
+  let penv = Mlty.fresh_penv () in
+  List.iter
+    (fun (x, sch) ->
+      Format.printf
+        "%t : %t@\n"
+        (Name.print_ident x)
+        (Mlty.print_ty_schema ~penv sch)
+    )
+    variables

--- a/src/typing/context.ml
+++ b/src/typing/context.ml
@@ -5,6 +5,7 @@ type t = {
   types : (Name.ident * Mlty.ty_def) list; (* types are accessed by De Bruijn level, the name is for printing *)
   variables : (Name.ident * Mlty.ty_schema) list; (* variables are accessed by De Bruijn index, the name is for printing *)
   operations : (Mlty.ty list * Mlty.ty) OperationMap.t;
+  tt_constructors : Mlty.tt_constructor_ty Name.IdentMap.t ; (* constructors are accessed by their names *)
   continuation : (Mlty.ty * Mlty.ty) option;
 }
 
@@ -12,6 +13,7 @@ let empty = {
   types = [];
   variables = [];
   operations = OperationMap.empty;
+  tt_constructors = Name.IdentMap.empty;
   continuation = None;
 }
 
@@ -23,7 +25,10 @@ let lookup_var k {variables;_} =
 let lookup_op op {operations;_} =
   OperationMap.find op operations
 
-let lookup_constructor c {types;_} =
+let lookup_tt_constructor c {tt_constructors;_} =
+  Name.IdentMap.find c tt_constructors
+
+let lookup_aml_constructor c {types;_} =
   let rec fold = function
     | [] -> raise Not_found
     | (_, Mlty.Alias _) :: types -> fold types
@@ -75,7 +80,7 @@ let unfold ctx x ts =
        let pus = List.combine ps ts in
        Some (Mlty.instantiate pus t)
 
-let gather_known s {types = _; variables; operations = _; continuation} =
+let gather_known s {variables;continuation;_} =
   let subst = Substitution.apply s in
   let known =
     List.fold_left

--- a/src/typing/context.ml
+++ b/src/typing/context.ml
@@ -98,4 +98,3 @@ let predefined_type x ts {types;_} =
     | _ :: types -> search (k + 1) types
   in
   search 0 (List.rev types)
-

--- a/src/typing/context.ml
+++ b/src/typing/context.ml
@@ -51,10 +51,6 @@ let lookup_continuation {continuation;_} =
     | Some cont -> cont
     | None -> assert false
 
-let add_var x t ctx =
-  let variables = (x, t) :: ctx.variables in
-  {ctx with variables}
-
 let add_tydef t d ctx =
   let types = (t, d) :: ctx.types in
   {ctx with types}

--- a/src/typing/context.mli
+++ b/src/typing/context.mli
@@ -13,8 +13,11 @@ val lookup_var : Dsyntax.bound -> t -> Mlty.ty
 (** Lookup an operation, returning the expected types of its arguments and the type it returns. *)
 val lookup_op : Name.operation -> t -> Mlty.ty list * Mlty.ty
 
-(** Lookup a ML constructor, returning the expected types of its arguments and the type it returns. *)
-val lookup_constructor : Name.constructor -> t -> Mlty.ty list * Mlty.ty
+(** Lookup an AML constructor, returning the expected types of its arguments and the type it returns. *)
+val lookup_aml_constructor : Name.constructor -> t -> Mlty.ty list * Mlty.ty
+
+(** Lookup an TT constructor, returning the expected types of its arguments and the type it returns. *)
+val lookup_tt_constructor : Name.constructor -> t -> Mlty.tt_constructor_ty
 
 (** Lookup the continuation, returning the expected type of its argument and the type it returns. *)
 val lookup_continuation : t -> Mlty.ty * Mlty.ty

--- a/src/typing/context.mli
+++ b/src/typing/context.mli
@@ -42,3 +42,5 @@ val gather_known : Substitution.t -> t -> Mlty.MetaSet.t
 
 (** [predefined_type x ts ctx] creates the type [x ts] assuming the type definition for [x] can be found in [ctx]. *)
 val predefined_type : Name.ty -> Mlty.ty list -> t -> Mlty.ty
+
+val print_context : t -> unit

--- a/src/typing/context.mli
+++ b/src/typing/context.mli
@@ -22,16 +22,13 @@ val lookup_tt_constructor : Name.constructor -> t -> Mlty.tt_constructor_ty
 (** Lookup the continuation, returning the expected type of its argument and the type it returns. *)
 val lookup_continuation : t -> Mlty.ty * Mlty.ty
 
-(** Add a variable with a monomorphic type. *)
-val add_var : Name.ident -> Mlty.ty_schema -> t -> t
-
 (** Define a new type. The type definition may refer to not-yet-defined types, relying on the caller to add them afterwards. *)
 val add_tydef : Name.ident -> Mlty.ty_def -> t -> t
 
 (** Declare a new operation. *)
 val add_operation : Name.operation -> Mlty.ty list * Mlty.ty -> t -> t
 
-(** Add a variable with a polymorphic type. *)
+(** Add a variable of polymorphic type given by the schema. *)
 val add_let : Name.ident -> Mlty.ty_schema -> t -> t
 
 (** Creates the context for evaluating the operation handling of [op] *)

--- a/src/typing/mlty.ml
+++ b/src/typing/mlty.ml
@@ -35,7 +35,7 @@ type judgement =
 
 type abstracted_judgement =
   | NotAbstract of judgement
-  | Abstract of judgement * abstracted_judgement
+  | Abstract of abstracted_judgement
 
 type ty =
   | Judgement of abstracted_judgement
@@ -124,9 +124,8 @@ let print_judgement frm ppf =
 let rec print_abstracted_judgement abstr ppf =
   match abstr with
   | NotAbstract frm -> print_judgement frm ppf
-  | Abstract (frm, abstr) ->
-     Format.fprintf ppf "{%t}@ %t"
-       (print_judgement frm)
+  | Abstract abstr ->
+     Format.fprintf ppf "{}%t"
        (print_abstracted_judgement abstr)
 
 let rec print_ty ~penv ?max_level t ppf =

--- a/src/typing/mlty.ml
+++ b/src/typing/mlty.ml
@@ -76,6 +76,7 @@ type error =
   | UnknownExternal of string
   | ValueRestriction
   | Ungeneralizable of param list * ty
+  | UnknownJudgementForm
   | JudgementExpected of ty
   | UnexpectedJudgement of ty
   | UnexpectedJudgementAbstraction of judgement
@@ -223,6 +224,9 @@ let print_error err ppf =
      Format.fprintf ppf "Cannot generalize %t in %t"
                     (Print.sequence (print_param ~penv) "," ps)
                     (print_ty ~penv ty)
+
+  | UnknownJudgementForm ->
+     Format.fprintf ppf "Cannot infer the judgement form"
 
   | JudgementExpected t ->
     Format.fprintf ppf "Expected a judgement but got %t"

--- a/src/typing/mlty.ml
+++ b/src/typing/mlty.ml
@@ -78,7 +78,6 @@ type error =
   | Ungeneralizable of param list * ty
   | UnknownJudgementForm
   | JudgementExpected of ty
-  | UnexpectedJudgement of ty
   | UnexpectedJudgementAbstraction of judgement
 
 exception Error of error Location.located
@@ -231,10 +230,6 @@ let print_error err ppf =
   | JudgementExpected t ->
     Format.fprintf ppf "Expected a judgement but got %t"
       (print_ty ~penv t)
-
-  | UnexpectedJudgement t ->
-     Format.fprintf ppf "Expected %t but got a judgement"
-                    (print_ty ~penv t)
 
   | UnexpectedJudgementAbstraction jdg_actual ->
      Format.fprintf ppf "Expected %t but got an abstraction"

--- a/src/typing/mlty.ml
+++ b/src/typing/mlty.ml
@@ -77,7 +77,7 @@ type error =
   | ValueRestriction
   | Ungeneralizable of param list * ty
   | JudgementExpected of ty
-  | UnknownJudgementForm
+  | UnexpectedJudgement of ty
   | UnexpectedJudgementAbstraction of judgement
 
 exception Error of error Location.located
@@ -228,8 +228,9 @@ let print_error err ppf =
     Format.fprintf ppf "Expected a judgement but got %t"
       (print_ty ~penv t)
 
-  | UnknownJudgementForm ->
-     Format.fprintf ppf "Cannot determine the type of this judgement pattern"
+  | UnexpectedJudgement t ->
+     Format.fprintf ppf "Expected %t but got a judgement"
+                    (print_ty ~penv t)
 
   | UnexpectedJudgementAbstraction jdg_actual ->
      Format.fprintf ppf "Expected %t but got an abstraction"

--- a/src/typing/mlty.ml
+++ b/src/typing/mlty.ml
@@ -78,6 +78,7 @@ type error =
   | Ungeneralizable of param list * ty
   | JudgementExpected of ty
   | UnknownJudgementForm
+  | UnexpectedJudgementAbstraction of judgement
 
 exception Error of error Location.located
 
@@ -230,6 +231,10 @@ let print_error err ppf =
 
   | UnknownJudgementForm ->
      Format.fprintf ppf "Cannot determine the type of this judgement pattern"
+
+  | UnexpectedJudgementAbstraction jdg_actual ->
+     Format.fprintf ppf "Expected %t but got an abstraction"
+       (print_judgement jdg_actual)
 
 let rec occurs m = function
   | Judgement _ | String | Param _ -> false

--- a/src/typing/mlty.mli
+++ b/src/typing/mlty.mli
@@ -26,7 +26,7 @@ type judgement =
 (** AML typing keeps track of TT abstractions (without dependencies) *)
 type abstracted_judgement =
   | NotAbstract of judgement
-  | Abstract of judgement * abstracted_judgement
+  | Abstract of abstracted_judgement
 
 (** The type of ML types. *)
 type ty =

--- a/src/typing/mlty.mli
+++ b/src/typing/mlty.mli
@@ -83,6 +83,7 @@ type error =
   | Ungeneralizable of param list * ty
   | JudgementExpected of ty
   | UnknownJudgementForm
+  | UnexpectedJudgementAbstraction of judgement
 
 exception Error of error Location.located
 

--- a/src/typing/mlty.mli
+++ b/src/typing/mlty.mli
@@ -82,7 +82,7 @@ type error =
   | ValueRestriction
   | Ungeneralizable of param list * ty
   | JudgementExpected of ty
-  | UnknownJudgementForm
+  | UnexpectedJudgement of judgement
   | UnexpectedJudgementAbstraction of judgement
 
 exception Error of error Location.located

--- a/src/typing/mlty.mli
+++ b/src/typing/mlty.mli
@@ -81,8 +81,9 @@ type error =
   | UnknownExternal of string
   | ValueRestriction
   | Ungeneralizable of param list * ty
+  | UnknownJudgementForm
   | JudgementExpected of ty
-  | UnexpectedJudgement of judgement
+  | UnexpectedJudgement of ty
   | UnexpectedJudgementAbstraction of judgement
 
 exception Error of error Location.located

--- a/src/typing/mlty.mli
+++ b/src/typing/mlty.mli
@@ -16,12 +16,16 @@ end
 (** Sets of metavariables. *)
 module MetaSet : Set.S with type elt = meta
 
+type abstraction_level =
+  | NotAbstract
+  | Abstract of abstraction_level
+
 (** The type of ML types. *)
 type ty =
-  | IsType
-  | IsTerm
-  | EqType
-  | EqTerm
+  | IsType of abstraction_level
+  | IsTerm of abstraction_level
+  | EqType of abstraction_level
+  | EqTerm of abstraction_level
   | String
   | Meta of meta
   | Param of param
@@ -69,6 +73,7 @@ type error =
   | UnknownExternal of string
   | ValueRestriction
   | Ungeneralizable of param list * ty
+  | JudgementExpected of ty
 
 exception Error of error Location.located
 

--- a/src/typing/mlty.mli
+++ b/src/typing/mlty.mli
@@ -83,7 +83,6 @@ type error =
   | Ungeneralizable of param list * ty
   | UnknownJudgementForm
   | JudgementExpected of ty
-  | UnexpectedJudgement of ty
   | UnexpectedJudgementAbstraction of judgement
 
 exception Error of error Location.located

--- a/src/typing/substitution.ml
+++ b/src/typing/substitution.ml
@@ -17,10 +17,7 @@ let apply (s : t) t =
   then t
   else begin
       let rec app = function
-        | Mlty.IsType _
-        | Mlty.IsTerm _
-        | Mlty.EqType _
-        | Mlty.EqTerm _
+        | Mlty.Judgement _
         | Mlty.String
         | Mlty.Param _ as t -> t
 

--- a/src/typing/substitution.ml
+++ b/src/typing/substitution.ml
@@ -17,10 +17,10 @@ let apply (s : t) t =
   then t
   else begin
       let rec app = function
-        | Mlty.IsType
-        | Mlty.IsTerm
-        | Mlty.EqType
-        | Mlty.EqTerm
+        | Mlty.IsType _
+        | Mlty.IsTerm _
+        | Mlty.EqType _
+        | Mlty.EqTerm _
         | Mlty.String
         | Mlty.Param _ as t -> t
 

--- a/src/typing/substitution.mli
+++ b/src/typing/substitution.mli
@@ -24,4 +24,3 @@ val add : Mlty.meta -> Mlty.ty -> t -> t option
 
 (** [partition p s] returns [s1, s2] where [s1] is the bindings verifying [p] and [s2] are the others. *)
 val partition : (Mlty.meta -> Mlty.ty -> bool) -> t -> t * t
-

--- a/src/typing/tyenv.ml
+++ b/src/typing/tyenv.ml
@@ -70,7 +70,7 @@ let lookup_var k env =
 let lookup_op op env =
   return (Context.lookup_op op env.context) env
 
-let lookup_constructor c env =
+let lookup_aml_constructor c env =
   return (Context.lookup_constructor c env.context) env
 
 let lookup_continuation env =

--- a/src/typing/tyenv.ml
+++ b/src/typing/tyenv.ml
@@ -53,8 +53,7 @@ let remove_known ~known s =
   (* XXX: why isn't this just Mlty.MetaSet.diff s known ? *)
   Mlty.MetaSet.fold Mlty.MetaSet.remove known s
 
-let generalize ?known_context t env =
-  let known_context = match known_context with None -> env.context | Some x -> x in
+let generalize ~known_context t env =
   let known = gather_known ~known_context env in
   let t = Substitution.apply env.substitution t in
   let gen = Mlty.occuring t in
@@ -312,8 +311,7 @@ let predefined_type x ts env =
   let t = Context.predefined_type x ts env.context in
   return t env
 
-let generalizes_to ~loc ?known_context t (ps, u) env =
-  let known_context = match known_context with None -> env.context | Some x -> x in
+let generalizes_to ~loc ~known_context t (ps, u) env =
   let (), env = add_equation ~loc t u env in
   (* NB: [s1] is the one that has [ps] appearing in the image *)
   let s1, s2 = Substitution.partition

--- a/src/typing/tyenv.ml
+++ b/src/typing/tyenv.ml
@@ -110,11 +110,8 @@ let rec unifiable ctx s t t' =
          Some s
        else
          None
-    | Mlty.Abstract (frm1, abstr1), Mlty.Abstract (frm2, abstr2) ->
-       if frm1 = frm2 then
-         unifiable_judgement_abstraction s abstr1 abstr2
-       else
-         None
+    | Mlty.Abstract abstr1, Mlty.Abstract abstr2 ->
+       unifiable_judgement_abstraction s abstr1 abstr2
     | Mlty.NotAbstract _, Mlty.Abstract _
     | Mlty.Abstract _, Mlty.NotAbstract _ -> None
   in

--- a/src/typing/tyenv.ml
+++ b/src/typing/tyenv.ml
@@ -48,6 +48,7 @@ let gather_known env =
     (unsolved_known env.unsolved)
 
 let remove_known ~known s =
+  (* XXX: why isn't this just Mlty.MetaSet.diff s known ? *)
   Mlty.MetaSet.fold Mlty.MetaSet.remove known s
 
 let generalize t env =
@@ -74,12 +75,12 @@ let record_vars m env =
   let local_vars = env.local_vars in
   let x, env = m {env with local_vars = []} in
   (* XXX should we apply the substition to the types of local vars that we're returning? *)
-  (env.local_vars, x), {env with local_vars}
+  (List.rev env.local_vars, x), {env with local_vars}
 
 let add_var x t env =
   let t = Substitution.apply env.substitution t in
   let context = Context.add_var x ([], t) env.context in
-  (), {env with context}
+  (), {env with context; local_vars = (x,t) :: env.local_vars}
 
 let locally_add_var x t m =
   locally (add_var x t >>= fun () -> m)

--- a/src/typing/tyenv.ml
+++ b/src/typing/tyenv.ml
@@ -357,3 +357,5 @@ let add_tydef t d env =
 let add_operation op opty env =
   let context = Context.add_operation op opty env.context in
   (), { env with context }
+
+let print_context {context;_} = Context.print_context context

--- a/src/typing/tyenv.ml
+++ b/src/typing/tyenv.ml
@@ -10,14 +10,18 @@ type constrain =
 type t =
   { context : Context.t;
     substitution : Substitution.t;
-    unsolved : constrain list }
+    unsolved : constrain list;
+    local_vars : (Name.ident * Mlty.ty) list (* the variables bound since the last call to [locally] *)
+ }
 
 type 'a tyenvM = t -> 'a * t
 
 let empty =
   { context = Context.empty;
     substitution = Substitution.empty;
-    unsolved = [] }
+    unsolved = [];
+    local_vars = []
+  }
 
 let return x env = x, env
 
@@ -27,8 +31,9 @@ let (>>=) m f env =
 
 let locally m env =
   let context = env.context in
-  let x, env = m env in
-  x, {env with context}
+  let local_vars = env.local_vars in
+  let x, env = m {env with local_vars = []} in
+  (x, env.local_vars), {env with context; local_vars}
 
 let unsolved_known unsolved =
   List.fold_left

--- a/src/typing/tyenv.ml
+++ b/src/typing/tyenv.ml
@@ -65,10 +65,14 @@ let ungeneralize t env =
 
 let locally m env =
   let context = env.context in
+  let x, env = m env in
+  x, {env with context}
+
+let record_vars m env =
   let local_vars = env.local_vars in
   let x, env = m {env with local_vars = []} in
   (* XXX should we apply the substition to the types of local vars that we're returning? *)
-  (x, env.local_vars), {env with context; local_vars}
+  (env.local_vars, x), {env with local_vars}
 
 let add_var x t env =
   let t = Substitution.apply env.substitution t in
@@ -76,7 +80,7 @@ let add_var x t env =
   (), {env with context}
 
 let locally_add_var x t m =
-  locally (add_var x t >>= fun () -> m) >>= fun (r, _) -> return r
+  locally (add_var x t >>= fun () -> m)
 
 let add_let x s env =
   let context = Context.add_let x s env.context in

--- a/src/typing/tyenv.ml
+++ b/src/typing/tyenv.ml
@@ -79,10 +79,14 @@ let record_vars m env =
   (* XXX should we apply the substition to the types of local vars that we're returning? *)
   (List.rev env.local_vars, x), {env with local_vars}
 
+let record_var x t env =
+  let t = Substitution.apply env.substitution t in
+  (), {env with local_vars = (x,t) :: env.local_vars}
+
 let add_var x t env =
   let t = Substitution.apply env.substitution t in
-  let context = Context.add_var x ([], t) env.context in
-  (), {env with context; local_vars = (x,t) :: env.local_vars}
+  let context = Context.add_let x ([], t) env.context in
+  (), {env with context}
 
 let locally_add_var x t m =
   locally (add_var x t >>= fun () -> m)

--- a/src/typing/tyenv.ml
+++ b/src/typing/tyenv.ml
@@ -29,6 +29,8 @@ let (>>=) m f env =
   let x, env = m env in
   f x env
 
+let run env m = let x, env = m env in env, x
+
 let unsolved_known unsolved =
   List.fold_left
     (fun known (AppConstraint (_, t1, t2, t3)) ->

--- a/src/typing/tyenv.mli
+++ b/src/typing/tyenv.mli
@@ -25,6 +25,9 @@ val lookup_op : Name.operation -> (Mlty.ty list * Mlty.ty) tyenvM
 (** Lookup an AML constructor, returning the expected types of its arguments and the type it returns. *)
 val lookup_aml_constructor : Name.constructor -> (Mlty.ty list * Mlty.ty) tyenvM
 
+(** Lookup a TT constructor, returning its expected form. *)
+val lookup_tt_constructor : Name.constructor -> Mlty.tt_constructor_ty tyenvM
+
 (** Lookup the continuation, returning the expected type of its argument and the type it returns. *)
 val lookup_continuation : (Mlty.ty * Mlty.ty) tyenvM
 

--- a/src/typing/tyenv.mli
+++ b/src/typing/tyenv.mli
@@ -22,8 +22,8 @@ val lookup_var : Rsyntax.bound -> Mlty.ty tyenvM
 (** Lookup an operation, returning the expected types of its arguments and the type it returns. *)
 val lookup_op : Name.operation -> (Mlty.ty list * Mlty.ty) tyenvM
 
-(** Lookup a ML constructor, returning the expected types of its arguments and the type it returns. *)
-val lookup_constructor : Name.constructor -> (Mlty.ty list * Mlty.ty) tyenvM
+(** Lookup an AML constructor, returning the expected types of its arguments and the type it returns. *)
+val lookup_aml_constructor : Name.constructor -> (Mlty.ty list * Mlty.ty) tyenvM
 
 (** Lookup the continuation, returning the expected type of its argument and the type it returns. *)
 val lookup_continuation : (Mlty.ty * Mlty.ty) tyenvM

--- a/src/typing/tyenv.mli
+++ b/src/typing/tyenv.mli
@@ -18,7 +18,7 @@ val (>>=) : 'a tyenvM -> ('a -> 'b tyenvM) -> 'b tyenvM
 
 (** [locally m] runs the computation [m] and upon its completetion restores the context.
     This is used to handle locally scoped variables in let bindings and match cases. *)
-val locally : 'a tyenvM -> 'a tyenvM
+val locally : 'a tyenvM -> ('a * (Name.ident * Mlty.ty) list) tyenvM
 
 (** Lookup a bound variable by its De Bruijn index and instantiate its type parameters with fresh metavariables. *)
 val lookup_var : Rsyntax.bound -> Mlty.ty tyenvM
@@ -72,10 +72,13 @@ val ungeneralize : Mlty.ty -> Mlty.ty_schema tyenvM
 (** Apply the current substitution to the given schema. *)
 (* val normalize_schema : Mlty.ty_schema -> Mlty.ty_schema tyenvM *)
 
-(** Bind a variable with a polymorphic type. *)
+(** Bind a variable with a polymorphic type. NB: if the scope of the variable is local
+    then the call to the function should be suitable enclosed by [locally], see above. *)
 val add_let : Name.ident -> Mlty.ty_schema -> unit tyenvM
 
-(** [add_var x t m] binds a variable with name [x] and monomorphic type [t]. *)
+(** [add_var x t m] binds a variable with name [x] and monomorphic type [t]. NB: if the
+   scope of the variable is local then the call to the function should be suitable
+   enclosed by [locally], see above. *)
 val add_var : Name.ident -> Mlty.ty -> unit tyenvM
 
 (** Define a new type. The type definition may refer to not-yet-defined types, relying on the caller to add them afterwards. *)

--- a/src/typing/tyenv.mli
+++ b/src/typing/tyenv.mli
@@ -114,3 +114,6 @@ val add_tydef : Name.ty -> Mlty.ty_def -> unit tyenvM
 
 (** Declare a new operation. *)
 val add_operation : Name.operation -> Mlty.ty list * Mlty.ty -> unit tyenvM
+
+(** Print the typing context (useful for debugging) *)
+val print_context : t -> unit

--- a/src/typing/tyenv.mli
+++ b/src/typing/tyenv.mli
@@ -67,14 +67,14 @@ val predefined_type : Name.ty -> Mlty.ty list -> Mlty.ty tyenvM
     but using only [known_context] as typing context, possibly solving
     unification problems. If [known_context] is not provided, use the one from
     the current typechecking environment. *)
-val generalize : ?known_context:Context.t -> Mlty.ty -> Mlty.ty_schema tyenvM
+val generalize : known_context:Context.t -> Mlty.ty -> Mlty.ty_schema tyenvM
 
 (** Check that the given type can be generalized to the given schema in the
     current environment but using only [known_context] as typing context,
     possibly solving unification problems. If [known_context] is not provided,
     use the one from the current typechecking environment. *)
 val generalizes_to
-  : loc:Location.t -> ?known_context:Context.t -> Mlty.ty -> Mlty.ty_schema -> unit tyenvM
+  : loc:Location.t -> known_context:Context.t -> Mlty.ty -> Mlty.ty_schema -> unit tyenvM
 
 (** Return the given type as a schema without generalizing anything. *)
 val ungeneralize : Mlty.ty -> Mlty.ty_schema tyenvM

--- a/src/typing/tyenv.mli
+++ b/src/typing/tyenv.mli
@@ -90,8 +90,15 @@ val add_let : Name.ident -> Mlty.ty_schema -> unit tyenvM
     This is used to handle locally scoped variables in let bindings and match cases. *)
 val locally : 'a tyenvM -> 'a tyenvM
 
-(** [record_vars m] runs the computation [m] and records what variables were added by it, with their types.
-    It then returns the list of variables so added by [m], and the original result of [m]. *)
+(** [record_var x t] records the fact that variable [x] of type [t] was found.
+    Later the so recorded variables are reported by [record_vars]. This is used
+    for collecting bound variables in match cases and let bindings. *)
+val record_var : Name.ident -> Mlty.ty -> unit tyenvM
+
+(** [record_vars m] runs the computation [m] and records what variables were registered
+   using [record_var]. It then returns the list of variables so added by [m], and the
+   original result of [m]. This is used for collecting bound variables in match cases
+   and let bindings. *)
 val record_vars : 'a tyenvM -> ((Name.ident * Mlty.ty) list * 'a) tyenvM
 
 (** [locally_add_var x t m] runs the computation [m] in the context extended with the

--- a/src/typing/tyenv.mli
+++ b/src/typing/tyenv.mli
@@ -75,7 +75,11 @@ val add_let : Name.ident -> Mlty.ty_schema -> unit tyenvM
 
 (** [locally m] runs the computation [m] and upon its completetion restores the context.
     This is used to handle locally scoped variables in let bindings and match cases. *)
-val locally : 'a tyenvM -> ('a * (Name.ident * Mlty.ty) list) tyenvM
+val locally : 'a tyenvM -> 'a tyenvM
+
+(** [record_vars m] runs the computation [m] and records what variables were added by it, with their types.
+    It then returns the list of variables so added by [m], and the original result of [m]. *)
+val record_vars : 'a tyenvM -> ((Name.ident * Mlty.ty) list * 'a) tyenvM
 
 (** [locally_add_var x t m] runs the computation [m] in the context extended with the
     variable [x] of type [t]. It removes the variable from the context after [m] is done. *)

--- a/src/typing/tyenv.mli
+++ b/src/typing/tyenv.mli
@@ -34,7 +34,8 @@ val lookup_continuation : (Mlty.ty * Mlty.ty) tyenvM
 (** [add_var x t m] binds a variable with name [x] and monomorphic type [t] while computing in [m]. *)
 val add_var : Name.ident -> Mlty.ty -> 'a tyenvM -> 'a tyenvM
 
-(** Try to unify the given types. If successful, retry to solve the current unsolved constraints. *)
+(** [add_equation ~loc t1 t2] try to unify the actual type [t1] with the expected type
+    [t2]. If successful, retry to solve the current unsolved constraints. *)
 val add_equation : loc:Location.t -> Mlty.ty -> Mlty.ty -> unit tyenvM
 
 (** [add_application h arg out] checks that a value of type [h] applied to a value of type [arg] will produce a value of type [out].

--- a/src/typing/tyenv.mli
+++ b/src/typing/tyenv.mli
@@ -16,6 +16,8 @@ val return : 'a -> 'a tyenvM
 (** Monadic bind. *)
 val (>>=) : 'a tyenvM -> ('a -> 'b tyenvM) -> 'b tyenvM
 
+val run : t -> 'a tyenvM -> t * 'a
+
 (** Lookup a bound variable by its De Bruijn index and instantiate its type parameters with fresh metavariables. *)
 val lookup_var : Rsyntax.bound -> Mlty.ty tyenvM
 

--- a/src/typing/tyenv.mli
+++ b/src/typing/tyenv.mli
@@ -18,6 +18,11 @@ val (>>=) : 'a tyenvM -> ('a -> 'b tyenvM) -> 'b tyenvM
 
 val run : t -> 'a tyenvM -> t * 'a
 
+(** Return the typing context at the current stage. Only exposed for use with
+   [generalize] and [generalizes_to]. The context will likely become invalid at
+   a later point and should be used only with the greatest care. *)
+val get_context : Context.t tyenvM
+
 (** Lookup a bound variable by its De Bruijn index and instantiate its type parameters with fresh metavariables. *)
 val lookup_var : Rsyntax.bound -> Mlty.ty tyenvM
 
@@ -58,12 +63,18 @@ val op_cases : Name.operation -> output:Mlty.ty -> (Mlty.ty list -> 'a tyenvM) -
     can be found in the environment. *)
 val predefined_type : Name.ty -> Mlty.ty list -> Mlty.ty tyenvM
 
-(** Generalize the given type as much as possible in the current environment. *)
-val generalize : Mlty.ty -> Mlty.ty_schema tyenvM
+(** Generalize the given type as much as possible in the current environment,
+    but using only [known_context] as typing context, possibly solving
+    unification problems. If [known_context] is not provided, use the one from
+    the current typechecking environment. *)
+val generalize : ?known_context:Context.t -> Mlty.ty -> Mlty.ty_schema tyenvM
 
-(** Check that the given type can be generalized to the given schema in the current
-    environment, possibly solving unification problems. *)
-val generalizes_to : loc:Location.t -> Mlty.ty -> Mlty.ty_schema -> unit tyenvM
+(** Check that the given type can be generalized to the given schema in the
+    current environment but using only [known_context] as typing context,
+    possibly solving unification problems. If [known_context] is not provided,
+    use the one from the current typechecking environment. *)
+val generalizes_to
+  : loc:Location.t -> ?known_context:Context.t -> Mlty.ty -> Mlty.ty_schema -> unit tyenvM
 
 (** Return the given type as a schema without generalizing anything. *)
 val ungeneralize : Mlty.ty -> Mlty.ty_schema tyenvM

--- a/src/typing/typecheck.ml
+++ b/src/typing/typecheck.ml
@@ -181,7 +181,7 @@ let rec tt_infer_form {Location.thing=p';_} =
   | Dsyntax.Patt_TT_EqTerm _ ->
      Tyenv.return (Some Mlty.EqTerm)
 
-  | Dsyntax.Patt_TT_Abstraction (_, _, _, abstr) ->
+  | Dsyntax.Patt_TT_Abstraction (_, _, abstr) ->
      tt_infer_form abstr
 
 (** Check that a TT pattern matched type judgements, and return the processed pattern. *)

--- a/src/typing/typecheck.ml
+++ b/src/typing/typecheck.ml
@@ -296,7 +296,9 @@ and check_pattern ~bind_var ({Location.thing=p'; loc} as p) t =
 
      | Mlty.String | Mlty.Meta _ | Mlty.Param _ | Mlty.Prod _ | Mlty.Arrow _
      | Mlty.Handler _ | Mlty.App _ | Mlty.Ref _ | Mlty.Dynamic _ ->
-          Mlty.error ~loc (Mlty.UnexpectedJudgement t)
+        tt_pattern ~bind_var p >>= fun (p, pt) ->
+        Tyenv.add_equation ~loc (Mlty.Judgement pt) t >>= fun () ->
+        return_located ~loc (Pattern.Judgement p)
      end
 
   | Dsyntax.Patt_Tuple ps ->

--- a/src/typing/typecheck.ml
+++ b/src/typing/typecheck.ml
@@ -715,7 +715,10 @@ and let_clauses
           end >>= fun () ->
           let rec fold xss = function
             | [] -> fold_lhs (Rsyntax.Let_clause (List.rev xss, p, c) :: clauses_out) clauses_in
-            | (x,t) :: xts -> Tyenv.ungeneralize t >>= fun sch -> fold ((x,sch) :: xss) xts
+            | (x,t) :: xts ->
+               Tyenv.ungeneralize t >>= fun sch ->
+               Tyenv.add_let x sch >>= fun () ->
+               fold ((x,sch) :: xss) xts
           in
           fold [] xts
        end

--- a/src/typing/typecheck.ml
+++ b/src/typing/typecheck.ml
@@ -140,7 +140,7 @@ let rec check_tt_pattern ({Location.thing=p';loc} as p) t =
         check_tt_pattern p1 (Mlty.NotAbstract Mlty.IsType) >>= fun p1 ->
         begin match xopt with
         | None -> return ()
-        | Some x -> Tyenv.add_var x (Mlty.NotAbstract Mlty.IsType)
+        | Some x -> Tyenv.add_var x (Mlty.Judgement (Mlty.NotAbstract Mlty.IsType))
         end >>= fun () ->
         check_tt_pattern p2 t >>= fun p2 ->
         return_located ~loc (Pattern.TTAbstract (xopt, p1, p2))

--- a/src/typing/typecheck.ml
+++ b/src/typing/typecheck.ml
@@ -228,9 +228,7 @@ let rec is_type_pattern {Location.thing=p';loc} =
      judgement_mismatch ~loc Mlty.IsType Mlty.EqTerm
 
   | Dsyntax.Patt_TT_Abstraction _ ->
-     Mlty.err ~loc (Mlty.ExpectedJudgementButAbstraction Mlty.IsType
-
-
+     Mlty.error ~loc (Mlty.UnexpectedJudgementAbstraction Mlty.IsType)
 
 (** Infer the type of a TT pattern. *)
 let rec tt_pattern p =

--- a/src/typing/typecheck.ml
+++ b/src/typing/typecheck.ml
@@ -373,7 +373,7 @@ let rec comp ({Location.thing=c; loc} : Dsyntax.comp) : (Rsyntax.comp * Mlty.ty)
     in
     fold [] cs ts
 
-  | Dsyntax.AML_Constructor (c, cs) ->
+  | Dsyntax.AMLConstructor (c, cs) ->
     Tyenv.lookup_aml_constructor c >>= fun (ts, out) ->
     let tcs = List.combine ts cs in
     let rec fold cs = function

--- a/src/typing/typecheck.ml
+++ b/src/typing/typecheck.ml
@@ -131,7 +131,7 @@ let rec check_tt_pattern ({Location.thing=p';loc} as p) t =
      check_tt_pattern p2 t >>= fun p2 ->
      return_located ~loc (Pattern.TTAs (p1, p2))
 
-  | Dsyntax.Patt_TT_Abstraction (x, p1, p2) ->
+  | Dsyntax.Patt_TT_Abstraction (xopt, p1, p2) ->
      begin match t with
 
      | Mlty.NotAbstract t ->
@@ -139,8 +139,12 @@ let rec check_tt_pattern ({Location.thing=p';loc} as p) t =
 
      | Mlty.Abstract t ->
         check_tt_pattern p1 (Mlty.NotAbstract Mlty.IsType) >>= fun p1 ->
+        begin match xopt with
+        | None -> return ()
+        | Some x -> Tyenv.add_var x (Mlty.NotAbstract Mlty.IsType)
+        end >>= fun () ->
         check_tt_pattern p2 t >>= fun p2 ->
-        return_located ~loc (Pattern.TTAbstract (x, p1, p2))
+        return_located ~loc (Pattern.TTAbstract (xopt, p1, p2))
      end
 
   (* inferring *)

--- a/src/typing/typecheck.ml
+++ b/src/typing/typecheck.ml
@@ -114,7 +114,7 @@ let ml_schema {Location.thing=(Dsyntax.ML_Forall (params, t)); _} =
   (params, t)
 
 (** Check a TT pattern against an abstracted judgement type and return the processed pattern. *)
-let rec check_tt_pattern ({Location.thing=p';loc} as p) t =
+let rec check_tt_pattern ~bind_var ({Location.thing=p';loc} as p) t =
   match p' with
 
   | Dsyntax.Patt_TT_Anonymous ->
@@ -122,12 +122,12 @@ let rec check_tt_pattern ({Location.thing=p';loc} as p) t =
 
   | Dsyntax.Patt_TT_Var x ->
      (* This [add_var] is enclosed by [Tyenv.locally] in [match_case] or [let_clause] *)
-     Tyenv.add_var x (Mlty.Judgement t) >>= fun () ->
+     bind_var x (Mlty.Judgement t) >>= fun () ->
      return_located ~loc (Pattern.TTVar x)
 
   | Dsyntax.Patt_TT_As (p1, p2) ->
-     check_tt_pattern p1 t >>= fun p1 ->
-     check_tt_pattern p2 t >>= fun p2 ->
+     check_tt_pattern ~bind_var p1 t >>= fun p1 ->
+     check_tt_pattern ~bind_var p2 t >>= fun p2 ->
      return_located ~loc (Pattern.TTAs (p1, p2))
 
   | Dsyntax.Patt_TT_Abstraction (xopt, p1, p2) ->
@@ -137,12 +137,12 @@ let rec check_tt_pattern ({Location.thing=p';loc} as p) t =
         Mlty.error ~loc (Mlty.UnexpectedJudgementAbstraction t)
 
      | Mlty.Abstract t ->
-        check_tt_pattern p1 (Mlty.NotAbstract Mlty.IsType) >>= fun p1 ->
+        check_tt_pattern ~bind_var p1 (Mlty.NotAbstract Mlty.IsType) >>= fun p1 ->
         begin match xopt with
         | None -> return ()
-        | Some x -> Tyenv.add_var x (Mlty.Judgement (Mlty.NotAbstract Mlty.IsType))
+        | Some x -> bind_var x (Mlty.Judgement (Mlty.NotAbstract Mlty.IsType))
         end >>= fun () ->
-        check_tt_pattern p2 t >>= fun p2 ->
+        check_tt_pattern ~bind_var p2 t >>= fun p2 ->
         return_located ~loc (Pattern.TTAbstract (xopt, p1, p2))
      end
 
@@ -153,53 +153,53 @@ let rec check_tt_pattern ({Location.thing=p';loc} as p) t =
   | Dsyntax.Patt_TT_IsTerm _
   | Dsyntax.Patt_TT_EqType _
   | Dsyntax.Patt_TT_EqTerm _ ->
-     tt_pattern p >>= fun (p, t') ->
+     tt_pattern ~bind_var p >>= fun (p, t') ->
      Tyenv.add_equation ~loc (Mlty.Judgement t') (Mlty.Judgement t) >>= fun () ->
      return p
 
 
 (** Infer the type of a TT pattern. *)
-and tt_pattern {Location.thing=p';loc} =
+and tt_pattern ~bind_var {Location.thing=p';loc} =
   match p' with
 
   | Dsyntax.Patt_TT_As (p1, p2) ->
      (* We insist that the first pattern be inferrable *)
-     tt_pattern p1 >>= fun (p1, t) ->
-     check_tt_pattern p2 t >>= fun p2 ->
+     tt_pattern ~bind_var p1 >>= fun (p1, t) ->
+     check_tt_pattern ~bind_var p2 t >>= fun p2 ->
      return (locate ~loc (Pattern.TTAs (p1, p2)), t)
 
   | Dsyntax.Patt_TT_Constructor (c, ps) ->
      Tyenv.lookup_tt_constructor c >>= fun (args, t) ->
-     check_tt_args args ps >>= fun ps ->
+     check_tt_args ~bind_var args ps >>= fun ps ->
      return (locate ~loc (Pattern.TTConstructor (c, ps)), Mlty.NotAbstract t)
 
   | Dsyntax.Patt_TT_GenAtom p ->
-     check_tt_pattern p (Mlty.NotAbstract Mlty.IsTerm) >>= fun p ->
+     check_tt_pattern ~bind_var p (Mlty.NotAbstract Mlty.IsTerm) >>= fun p ->
      return (p, Mlty.NotAbstract Mlty.IsTerm)
 
   | Dsyntax.Patt_TT_IsType p ->
-     check_tt_pattern p (Mlty.NotAbstract Mlty.IsType) >>= fun p ->
+     check_tt_pattern ~bind_var p (Mlty.NotAbstract Mlty.IsType) >>= fun p ->
      return (p, Mlty.NotAbstract Mlty.IsType)
 
   | Dsyntax.Patt_TT_IsTerm (p1, p2) ->
-     check_tt_pattern p1 (Mlty.NotAbstract Mlty.IsTerm) >>= fun p1 ->
-     check_tt_pattern p2 (Mlty.NotAbstract Mlty.IsType) >>= fun p2 ->
+     check_tt_pattern ~bind_var p1 (Mlty.NotAbstract Mlty.IsTerm) >>= fun p1 ->
+     check_tt_pattern ~bind_var p2 (Mlty.NotAbstract Mlty.IsType) >>= fun p2 ->
      return (locate ~loc (Pattern.TTIsTerm (p1, p2)), Mlty.NotAbstract Mlty.IsTerm)
 
   | Dsyntax.Patt_TT_EqType (p1, p2) ->
-     check_tt_pattern p1 (Mlty.NotAbstract Mlty.IsType) >>= fun p1 ->
-     check_tt_pattern p2 (Mlty.NotAbstract Mlty.IsType) >>= fun p2 ->
+     check_tt_pattern ~bind_var p1 (Mlty.NotAbstract Mlty.IsType) >>= fun p1 ->
+     check_tt_pattern ~bind_var p2 (Mlty.NotAbstract Mlty.IsType) >>= fun p2 ->
      return (locate ~loc (Pattern.TTEqType (p1, p2)), Mlty.NotAbstract Mlty.EqType)
 
   | Dsyntax.Patt_TT_EqTerm (p1, p2, p3) ->
-     check_tt_pattern p1 (Mlty.NotAbstract Mlty.IsTerm) >>= fun p1 ->
-     check_tt_pattern p2 (Mlty.NotAbstract Mlty.IsTerm) >>= fun p2 ->
-     check_tt_pattern p3 (Mlty.NotAbstract Mlty.IsType) >>= fun p3 ->
+     check_tt_pattern ~bind_var p1 (Mlty.NotAbstract Mlty.IsTerm) >>= fun p1 ->
+     check_tt_pattern ~bind_var p2 (Mlty.NotAbstract Mlty.IsTerm) >>= fun p2 ->
+     check_tt_pattern ~bind_var p3 (Mlty.NotAbstract Mlty.IsType) >>= fun p3 ->
      return (locate ~loc (Pattern.TTEqTerm (p1, p2, p3)), Mlty.NotAbstract Mlty.EqTerm)
 
   | Dsyntax.Patt_TT_Abstraction (x, p1, p2) ->
-     check_tt_pattern p1 (Mlty.NotAbstract Mlty.IsType) >>= fun p1 ->
-     tt_pattern p2 >>= fun (p2, t) ->
+     check_tt_pattern ~bind_var p1 (Mlty.NotAbstract Mlty.IsType) >>= fun p1 ->
+     tt_pattern ~bind_var p2 >>= fun (p2, t) ->
      return (locate ~loc (Pattern.TTAbstract (x, p1, p2)), Mlty.Abstract t)
 
   (* non-inferrable *)
@@ -207,14 +207,14 @@ and tt_pattern {Location.thing=p';loc} =
   | Dsyntax.Patt_TT_Var _ ->
      Mlty.error ~loc Mlty.UnknownJudgementForm
 
-and check_tt_args args ps =
+and check_tt_args ~bind_var args ps =
   let rec fold ps_out args ps =
     begin match (ps, args) with
 
     | [], [] -> return (List.rev ps_out)
 
     | p :: ps, arg :: args ->
-       check_tt_pattern p arg >>= fun p ->
+       check_tt_pattern ~bind_var p arg >>= fun p ->
        fold (p :: ps_out) args ps
 
     | [], _::_
@@ -227,23 +227,23 @@ and check_tt_args args ps =
 
 
 (** Infer the type of a pattern *)
-let rec pattern {Location.thing=p;loc} =
+let rec pattern ~bind_var {Location.thing=p;loc} =
   match p with
   | Dsyntax.Patt_Anonymous ->
      return (locate ~loc Pattern.Anonymous, Mlty.fresh_type ())
 
   | Dsyntax.Patt_Var x ->
      let t = Mlty.fresh_type () in
-     Tyenv.add_var x t >>= fun () ->
+     bind_var x t >>= fun () ->
      return (locate ~loc (Pattern.Var x), t)
 
   | Dsyntax.Patt_As (p1, p2) ->
-     pattern p1 >>= fun (p1, t1) ->
-     check_pattern p2 t1 >>= fun p2 ->
+     pattern ~bind_var p1 >>= fun (p1, t1) ->
+     check_pattern ~bind_var p2 t1 >>= fun p2 ->
      return (locate ~loc (Pattern.As (p1, p2)), t1)
 
   | Dsyntax.Patt_Judgement p ->
-     tt_pattern p >>= fun (p, t) ->
+     tt_pattern ~bind_var p >>= fun (p, t) ->
      return (locate ~loc (Pattern.Judgement p), Mlty.Judgement t)
 
   | Dsyntax.Patt_Constr (c, ps) ->
@@ -254,7 +254,7 @@ let rec pattern {Location.thing=p;loc} =
          let qs = List.rev qs in
          return (locate ~loc (Pattern.AMLConstructor (c, qs)), out)
       | p::ps, t::ts ->
-        check_pattern p t >>= fun q ->
+        check_pattern ~bind_var p t >>= fun q ->
         fold (q::qs) ps ts
       | [], _::_ | _::_, [] ->
          assert false
@@ -268,30 +268,30 @@ let rec pattern {Location.thing=p;loc} =
          and ts = List.rev ts in
          return (locate ~loc (Pattern.Tuple qs), Mlty.Prod ts)
       | p :: ps ->
-         pattern p >>= fun (q, t) ->
+         pattern ~bind_var p >>= fun (q, t) ->
          fold (q :: qs) (t :: ts) ps
     in
     fold [] [] ps
 
-and check_pattern ({Location.thing=p'; loc} as p) t =
+and check_pattern ~bind_var ({Location.thing=p'; loc} as p) t =
   match p' with
   | Dsyntax.Patt_Anonymous ->
      return_located ~loc Pattern.Anonymous
 
   | Dsyntax.Patt_Var x ->
-     Tyenv.add_var x t >>= fun () ->
+     bind_var x t >>= fun () ->
      return_located ~loc (Pattern.Var x)
 
   | Dsyntax.Patt_As (p1, p2) ->
-     check_pattern p1 t >>= fun p1 ->
-     check_pattern p2 t >>= fun p2 ->
+     check_pattern ~bind_var p1 t >>= fun p1 ->
+     check_pattern ~bind_var p2 t >>= fun p2 ->
      return_located ~loc (Pattern.As (p1, p2))
 
   | Dsyntax.Patt_Judgement p ->
      begin match t with
 
      | Mlty.Judgement t ->
-        check_tt_pattern p t >>= fun p ->
+        check_tt_pattern ~bind_var p t >>= fun p ->
         return_located ~loc (Pattern.Judgement p)
 
      | Mlty.String | Mlty.Meta _ | Mlty.Param _ | Mlty.Prod _ | Mlty.Arrow _
@@ -308,7 +308,7 @@ and check_pattern ({Location.thing=p'; loc} as p) t =
              let ps_out = List.rev ps_out in
              return_located ~loc (Pattern.Tuple ps_out)
           | p :: ps, t :: ts ->
-             check_pattern p t >>= fun p ->
+             check_pattern ~bind_var p t >>= fun p ->
              fold (p :: ps_out) ps ts
           | [], _::_ | _::_, [] -> assert false
         in
@@ -316,14 +316,14 @@ and check_pattern ({Location.thing=p'; loc} as p) t =
 
      | Mlty.Prod _ | Mlty.Judgement _  | Mlty.String | Mlty.Meta _ | Mlty.Param _
      | Mlty.Arrow _ | Mlty.Handler _ | Mlty.App _ | Mlty.Ref _ | Mlty.Dynamic _ ->
-        pattern p >>= fun (p, t') ->
+        pattern ~bind_var p >>= fun (p, t') ->
         Tyenv.add_equation ~loc t' t >>= fun () ->
         return p
      end
 
 
   | Dsyntax.Patt_Constr _ ->
-     pattern p >>= fun (p, t') ->
+     pattern ~bind_var p >>= fun (p, t') ->
      Tyenv.add_equation ~loc:p.Location.loc t' t >>= fun () ->
      return p
 
@@ -604,7 +604,7 @@ and handler ~loc {Dsyntax.handler_val=handler_val;handler_ops;handler_finally} =
 and match_case p t c =
   Tyenv.locally
     begin
-      check_pattern p t >>= fun p ->
+      check_pattern ~bind_var:Tyenv.add_var p t >>= fun p ->
       comp c >>= fun (c, tc) ->
       return (p, c, tc)
     end
@@ -612,7 +612,7 @@ and match_case p t c =
 and check_match_case p tp c tc =
   Tyenv.locally
     begin
-      check_pattern p tp >>= fun p ->
+      check_pattern ~bind_var:Tyenv.add_var p tp >>= fun p ->
       check_comp c tc >>= fun c ->
       return (p, c)
     end
@@ -647,13 +647,13 @@ and match_op_cases op cases t_out =
                 begin match popt with
                 | None -> return None
                 | Some p ->
-                   check_tt_pattern p (Mlty.NotAbstract Mlty.IsType) >>= fun p ->
+                   check_tt_pattern ~bind_var:Tyenv.add_var p (Mlty.NotAbstract Mlty.IsType) >>= fun p ->
                    return (Some p)
                 end >>= fun popt ->
                 check_comp c t_out >>= fun c ->
                 return (ps_out, popt, c)
              | p::ps, t::ts ->
-                check_pattern p t >>= fun p ->
+                check_pattern ~bind_var:Tyenv.add_var p t >>= fun p ->
                 fold_args (p :: ps_out) ps ts
              | [], _::_ | _::_, [] ->
                 assert false
@@ -682,7 +682,7 @@ and let_clauses
           variables that we want to generalise, but [Tyenv.generalize] needs to
           know about the [old_context]. *)
        Tyenv.get_context >>= fun old_context ->
-       Tyenv.record_vars (check_pattern p t) >>= fun (xts, p) ->
+       Tyenv.record_vars (check_pattern ~bind_var:Tyenv.record_var p t) >>= fun (xts, p) ->
        begin match generalizable c with
 
        | Generalizable ->
@@ -697,7 +697,9 @@ and let_clauses
           let rec fold xss = function
             | [] -> fold_lhs (Rsyntax.Let_clause (List.rev xss, p, c) :: clauses_out) clauses_in
             | (x,t) :: xts ->
-               Tyenv.generalize ~known_context:old_context t >>= fun sch -> fold ((x,sch) :: xss) xts
+               Tyenv.generalize ~known_context:old_context t >>= fun sch ->
+               Tyenv.add_let x sch >>= fun () ->
+               fold ((x,sch) :: xss) xts
           in
           fold [] xts
 

--- a/src/typing/typecheck.mli
+++ b/src/typing/typecheck.mli
@@ -1,3 +1,2 @@
-
 (** [toplevel env c] checks that toplevel command [c] is well typed and updates the environment accordingly. *)
 val toplevel : Tyenv.t -> Dsyntax.toplevel -> Tyenv.t * Rsyntax.toplevel

--- a/src/utils/name.ml
+++ b/src/utils/name.ml
@@ -230,4 +230,6 @@ struct
 
   let atomset s = Json.List (List.map atom (AtomSet.elements s))
 
+  let atommap s = Json.List (List.map (fun (x, _) -> atom x) (AtomMap.bindings s))
+
 end

--- a/src/utils/name.ml
+++ b/src/utils/name.ml
@@ -112,7 +112,13 @@ let refresh xs ((Ident (s, fixity)) as x) =
 
 let eq_ident (x : ident) (y : ident) = (x = y)
 
+(* XXX why do we compare fixities? *)
 let compare_ident (x : ident) (y : ident) = Pervasives.compare x y
+
+module IdentSet = Set.Make (struct
+                    type t = ident
+                    let compare = compare_ident
+                  end)
 
 module IdentMap = Map.Make (struct
                     type t = ident

--- a/src/utils/name.mli
+++ b/src/utils/name.mli
@@ -109,6 +109,7 @@ val eq_ident : ident -> ident -> bool
 (** Compare identifiers. *)
 val compare_ident : ident -> ident -> int
 
+module IdentSet : Set.S with type elt = ident
 module IdentMap : Map.S with type key = ident
 
 (** Compare atoms for equality. *)

--- a/src/utils/name.mli
+++ b/src/utils/name.mli
@@ -144,4 +144,7 @@ sig
 
   (** Convert a set of atoms to JSON. *)
   val atomset : AtomSet.t -> Json.t
+
+  (** Convert a map of atoms to JSON (dropping the values). *)
+  val atommap : 'a AtomMap.t -> Json.t
 end

--- a/std/base.m31
+++ b/std/base.m31
@@ -14,11 +14,13 @@ mltype debug a = (!!) of a end
 let debug x = print (!! x)
 
 (* Top-level handlers default to failure. *)
+(*
 handle
   | equal _ _ ⇒ None
   | as_prod _ ⇒ None
   | as_eq _ ⇒ None
 end
+*)
 
 let (|>) x f :> Π α β, α → (α → β) → β = f x
 
@@ -26,16 +28,18 @@ let failure x = print ("FAILURE", x); exit ()
 
 mltype mlbool = mltrue | mlfalse end
 
-operation whnf : judgement -> judgement
+(* operation whnf : judgement -> judgement *)
 
 mltype eagerness =
   | eager
   | lazy
   end
 
+(*
 constant funext : forall (A : Type) (B : A -> Type) (f g : forall x : A, B x),
   (forall x : A, f x ≡ g x) -> f ≡ g
 
 constant uip : forall (A : Type) (lhs rhs : A) (p q : lhs ≡ rhs), p ≡ q
+*)
 
 mltype empty = end

--- a/tests/dynamic-rec.m31
+++ b/tests/dynamic-rec.m31
@@ -3,13 +3,13 @@ dynamic fixed = None
 
 let fix f x =
  let g x =
-   let self = (match current fixed with Some ?self => self end) in
+   let self = (match current fixed with Some self => self end) in
    f self x
  in
  now fixed = Some g in 
  g x
 
-let iter f = fix (fun iter l => match l with [] => () | ?x :: ?l => f x; iter l end)
+let iter f = fix (fun iter l => match l with [] => () | x :: l => f x; iter l end)
 
 let _ = iter print [None,Some [],Some [None]]
 

--- a/tests/error_apply_non_function.m31
+++ b/tests/error_apply_non_function.m31
@@ -1,7 +1,7 @@
 (* Test whether application errors have sensible locations *)
-let f = Type
-let x = Type
-let y = Type
+let f = ()
+let x = ()
+let y = ()
 
 
 

--- a/tests/error_apply_non_function.m31.ref
+++ b/tests/error_apply_non_function.m31.ref
@@ -1,11 +1,3 @@
-val f :> judgment
 
-val x :> judgment
-
-val y :> judgment
-
-
-File "./error_apply_non_function.m31", line 9, characters 9-9:
-Application of the non-function:
-   ⊢ Type : Type
-
+File "error_apply_non_function.m31", line 9, characters 9-11:
+Invalid application of mlunit to mlunit producing _α

--- a/tests/let_pattern.m31
+++ b/tests/let_pattern.m31
@@ -1,28 +1,28 @@
 (* Let-patterns *)
 
-do let (?x, ?y) = ("foo", ["bar"]) in (y, x)
+do let (x, y) = ("foo", ["bar"]) in (y, x)
 
-do let (?x, ?y) :> mlstring * list mlstring = ("foo", ["bar"]) in (y, x)
+do let (x, y) :> mlstring * list mlstring = ("foo", ["bar"]) in (y, x)
 
 do let () = () in ()
 
-do let (?a :: ?a :: _) = ["cow", "cow", "bar"] in a
+do let (a :: _ :: _) = ["cow", "cow", "bar"] in a
 
-do let ((?x1, ?y1)) = ("yeah", []) in x1 :: y1
+do let ((x1, y1)) = ("yeah", []) in x1 :: y1
 
-do let (?x2, ?y2) = ("yeah", []) in x2 :: y2
+do let (x2, y2) = ("yeah", []) in x2 :: y2
 
-do let (?x3, ?y3) :> forall a, mlstring * list a = ("yeah", []) in x3 :: y3
+do let (x3, y3) :> forall a, mlstring * list a = ("yeah", []) in x3 :: y3
 
 (* Toplevel let-patterns *)
-let (?x, ?y) = ("foo", ["bar"])
+let (x, y) = ("foo", ["bar"])
 
 do x
 do y
 
 let () = (fun x => x) ()
 
-let (?a :: ?a :: _) = ["cow", "cow", "bar"]
+let (a :: _ :: _) = ["cow", "cow", "bar"]
 
 do a
 

--- a/tests/mlascribe.m31
+++ b/tests/mlascribe.m31
@@ -3,5 +3,5 @@ mltype cow = Bull end
 let id x = x
 
 let f = (id id :> cow -> cow)
-let l = ([] :> list judgment)
+let l = ([] :> list cow)
 

--- a/tests/rec-list-length.m31
+++ b/tests/rec-list-length.m31
@@ -6,7 +6,7 @@ mltype rec nat =
 let rec length lst =
   match lst with
   | [] => z
-  | _ :: ?lst => s (length lst)
+  | _ :: lst => s (length lst)
   end
 
 let mylist = "foo" :: ("bar" :: ("baz" :: []))

--- a/tests/recursion.m31
+++ b/tests/recursion.m31
@@ -5,14 +5,14 @@ mltype rec tree a =
 
 let rec left t =
   match t with
-  | Leaf ?x => Leaf ("left", x)
-  | Node ?a ?b => Node (left a) (right b)
+  | Leaf x => Leaf ("left", x)
+  | Node a b => Node (left a) (right b)
   end
 
 and right t =
   match t with
-  | Leaf ?x => Leaf ("right", x)
-  | Node ?a ?b => Node (left a) (right b)
+  | Leaf x => Leaf ("right", x)
+  | Node a b => Node (left a) (right b)
   end
 
 let t =

--- a/tests/shadowing.m31.ref
+++ b/tests/shadowing.m31.ref
@@ -1,3 +1,3 @@
 
 File "./shadowing.m31", line 17, characters 1-16:
-An AML constructor x is already declared.
+The AML constructor x is already declared.

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -38,11 +38,18 @@ VALIDATE=0
 if [ "$1" = "-v" ]
 then
     VALIDATE=1
+    shift
+fi
+
+FILES="$@"
+if [ "$FILES" = "" ]
+then
+    FILES="$BASEDIR"/*.m31
 fi
 
 _EXIT=0
 
-for FILE in $BASEDIR/*.m31
+for FILE in $FILES
 do
     while :
     do
@@ -53,6 +60,7 @@ do
             if [ "$?" = "0" ]
             then
                 $PRINTF "Test: $FILE                        \r"
+                $PRINTF "SUCCESS: $FILE\n"
                 rm "$FILE.out"
             else
                 _EXIT=1

--- a/tests/value-restriction.m31
+++ b/tests/value-restriction.m31
@@ -1,7 +1,7 @@
 
 dynamic r (* : 'a option *) = None
 
-let f (* 'b -> jdg option *) = fun _ => match current r with Some (|- _) => r end
+let f (* 'b -> mlunit option *) = fun _ => match current r with Some () => r end
 
-do now r = Some "foo" in match f () with Some ?x => x end
+do now r = Some "foo" in match f () with Some x => x end
 

--- a/tests/value-restriction.m31.ref
+++ b/tests/value-restriction.m31.ref
@@ -1,3 +1,3 @@
 
 File "./value-restriction.m31", line 6, characters 12-15:
-Expected option judgment but got option mlstring
+Expected option mlunit but got option mlstring


### PR DESCRIPTION
This PR pulls into `master` the initial work done by @haselwarter and @andrejbauer of turning Andromeda into a generic proof assistant that allows user-specified rules. The type theory supported by this version of Andromeda is in the style of Martin-Löf:

* there are four separate judgement forms (types, terms, type equalites, term equalities)
* the rules must be well-formed in the sense of *general type theories*, as studied by @peterlefanulumsdaine, @haselwarter and @andrejbauer. The exact formulation of these concepts is work in progress. When it is done, the Andromeda documentation will properly refer to it.

This PR is not meant to undergo a review, which would be quite an impossible task. Rather, imagine we are in the middle of an open-heart surgery and we're taking a photo of what's going on. So I am just going to merge it, but I wanted to make a PR to alert various observers to the fact that something is going on.

P.S. The old Andromeda is now tagged as `andromeda-1.0` and the accompanying documentation as `andromeda-documentation-1.0`.