### PR TITLE
Split metas in assumptions into four categories

### DIFF
--- a/src/nucleus/TT.ml
+++ b/src/nucleus/TT.ml
@@ -17,7 +17,7 @@ and eq_type = EqType of assumption * ty * ty
 
 and eq_term = EqTerm of assumption * term * term * ty
 
-and assumption = (ty, premise_boundary) Assumption.t
+and assumption = (ty, type_boundary, term_boundary, eq_type_boundary, eq_term_boundary) Assumption.t
 
 and atom = { atom_name : Name.atom ; atom_type : ty }
 
@@ -85,7 +85,7 @@ let rec assumptions_term ?(lvl=0) = function
 
 and assumptions_term_meta ~lvl {meta_name; meta_type} =
   let asmp = assumptions_abstraction assumptions_type ~lvl meta_type in
-  Assumption.add_meta meta_name (BoundaryTerm meta_type) asmp
+  Assumption.add_is_term_meta meta_name meta_type asmp
 
 and assumptions_type ?(lvl=0) = function
   | TypeConstructor (_, args) -> assumptions_arguments ~lvl args
@@ -98,7 +98,7 @@ and assumptions_type_meta ~lvl {meta_name; meta_type} =
   let asmp =
     assumptions_abstraction (fun ?lvl () -> Assumption.empty) ~lvl meta_type
   in
-  Assumption.add_meta meta_name (BoundaryType meta_type) asmp
+  Assumption.add_is_type_meta meta_name meta_type asmp
 
 and assumptions_term_args ~lvl ts =
   List.fold_left
@@ -145,7 +145,7 @@ let assumptions_arguments = assumptions_arguments ~lvl:0
 
 let context_u assumptions_u t =
   let asmp = assumptions_u t in
-  let free, _meta, bound = Assumption.unpack asmp in
+  let free, _is_type_meta, _, _, _, bound = Assumption.unpack asmp in
   assert (Assumption.BoundSet.is_empty bound) ;
   let free = Name.AtomMap.bindings free in
   List.map (fun (atom_name, atom_type) -> {atom_name; atom_type}) free

--- a/src/nucleus/TT.mli
+++ b/src/nucleus/TT.mli
@@ -36,7 +36,7 @@ and eq_type = private EqType of assumption * ty * ty
 
 and eq_term = private EqTerm of assumption * term * term * ty
 
-and assumption = (ty, premise_boundary) Assumption.t
+and assumption = (ty, type_boundary, term_boundary, eq_type_boundary, eq_term_boundary) Assumption.t
 
 and atom = private { atom_name : Name.atom ; atom_type : ty }
 

--- a/src/nucleus/assumption.mli
+++ b/src/nucleus/assumption.mli
@@ -2,48 +2,59 @@
 module BoundSet : Set.S with type elt = int
 
 (** A pair of sets, corresponding to free and bound assumptions *)
-type ('a, 'b) t
+type ('a, 'b, 'c, 'd, 'e) t
 
-val empty : ('a, 'b) t
+val empty : ('a, 'b, 'c, 'd, 'e) t
 
-val is_empty : ('a, 'b) t -> bool
+val is_empty : ('a, 'b, 'c, 'd, 'e) t -> bool
 
-val unpack : ('a, 'b) t -> 'a Name.AtomMap.t * 'b Name.MetaMap.t * BoundSet.t
+val unpack : ('a, 'b, 'c, 'd, 'e) t
+  -> 'a Name.AtomMap.t
+     * 'b Name.MetaMap.t
+     * 'c Name.MetaMap.t
+     * 'd Name.MetaMap.t
+     * 'e Name.MetaMap.t
+     * BoundSet.t
 
-val mem_atom : Name.atom -> ('a, 'b) t -> bool
+val mem_atom : Name.atom -> ('a, 'b, 'c, 'd, 'e) t -> bool
 
-val mem_bound : int -> ('a, 'b) t -> bool
+val mem_bound : int -> ('a, 'b, 'c, 'd, 'e) t -> bool
 
 (** [at_level ~lvl asmp] removes bound variables below [lvl] and subtracts [lvl] from the other ones. *)
-val at_level : lvl:int -> ('a, 'b) t -> ('a, 'b) t
+val at_level : lvl:int -> ('a, 'b, 'c, 'd, 'e) t -> ('a, 'b, 'c, 'd, 'e) t
 
 (** [shift ~lvl k asmp] shifts bound variables above [lvl] by [k]. *)
-val shift : lvl:int -> int -> ('a, 'b) t -> ('a, 'b) t
+val shift : lvl:int -> int -> ('a, 'b, 'c, 'd, 'e) t -> ('a, 'b, 'c, 'd, 'e) t
 
-val singleton_bound : int -> ('a, 'b) t
+val singleton_bound : int -> ('a, 'b, 'c, 'd, 'e) t
 
-val singleton_meta : Name.meta -> 'b -> ('a, 'b) t
+val add_free : Name.atom -> 'a -> ('a, 'b, 'c, 'd, 'e) t -> ('a, 'b, 'c, 'd, 'e) t
 
-val add_free : Name.atom -> 'a -> ('a, 'b) t -> ('a, 'b) t
+val add_is_type_meta : Name.meta -> 'b -> ('a, 'b, 'c, 'd, 'e) t -> ('a, 'b, 'c, 'd, 'e) t
+val add_is_term_meta : Name.meta -> 'c -> ('a, 'b, 'c, 'd, 'e) t -> ('a, 'b, 'c, 'd, 'e) t
+val add_eq_type_meta : Name.meta -> 'd -> ('a, 'b, 'c, 'd, 'e) t -> ('a, 'b, 'c, 'd, 'e) t
+val add_eq_term_meta : Name.meta -> 'e -> ('a, 'b, 'c, 'd, 'e) t -> ('a, 'b, 'c, 'd, 'e) t
 
-val add_meta : Name.meta -> 'b -> ('a, 'b) t -> ('a, 'b) t
+val add_bound : int -> ('a, 'b, 'c, 'd, 'e) t -> ('a, 'b, 'c, 'd, 'e) t
 
-val add_bound : int -> ('a, 'b) t -> ('a, 'b) t
-
-val union : ('a, 'b) t -> ('a, 'b) t -> ('a, 'b) t
+val union : ('a, 'b, 'c, 'd, 'e) t -> ('a, 'b, 'c, 'd, 'e) t -> ('a, 'b, 'c, 'd, 'e) t
 
 (** [instantiate asmp0 ~lvl:k asmp] replaces bound variable [k] with the assumptions [asmp0] in [asmp]. *)
-val instantiate : ('a, 'b) t -> lvl:int -> ('a, 'b) t -> ('a, 'b) t
+val instantiate : ('a, 'b, 'c, 'd, 'e) t -> lvl:int -> ('a, 'b, 'c, 'd, 'e) t
+  -> ('a, 'b, 'c, 'd, 'e) t
 
 (** [fully_instantiate asmps ~lvl:k asmp] replaces bound variables in [asmp] with assumptions [asmps]. *)
-val fully_instantiate : ('a, 'b) t list -> lvl:int -> ('a, 'b) t -> ('a, 'b) t
+val fully_instantiate : ('a, 'b, 'c, 'd, 'e) t list -> lvl:int
+  -> ('a, 'b, 'c, 'd, 'e) t
+  -> ('a, 'b, 'c, 'd, 'e) t
 
 (** [abstract x ~lvl:k l] replaces the free variable [x] by the bound variable [k]. *)
-val abstract : Name.atom -> lvl:int -> ('a, 'b) t -> ('a, 'b) t
+val abstract : Name.atom -> lvl:int -> ('a, 'b, 'c, 'd, 'e) t
+  -> ('a, 'b, 'c, 'd, 'e) t
 
 module Json :
 sig
 
-  val assumptions : ('a, 'b) t -> Json.t
+  val assumptions : ('a, 'b, 'c, 'd, 'e) t -> Json.t
 
 end


### PR DESCRIPTION
If we throw them all together we break physical equality because each of the
four types of boundary has to be wrapped in a constructor.

Instead we keep a different meta-map for each judgement type.