### PR TITLE
Fix precedence of `where` so that `x where y = a where z = b` parses

### DIFF
--- a/src/parser/parser.mly
+++ b/src/parser/parser.mly
@@ -140,10 +140,9 @@ plain_term:
   | LET a=separated_nonempty_list(AND,let_clause) IN c=term      { Let (a, c) }
   | LET REC lst=separated_nonempty_list(AND, recursive_clause) IN c=term
                                                                  { LetRec (lst, c) }
-  | NOW x=term EQ c1=term IN c2=term                             { Now (x,c1,c2) }
+  | NOW x=simple_term EQ c1=term IN c2=term                      { Now (x,c1,c2) }
   | CURRENT c=term                                               { Current c }
   | ASSUME x=var_name COLON t=ty_term IN c=term                  { Assume ((x, t), c) }
-  | c1=equal_term WHERE e=simple_term EQ c2=term                 { Where (c1, e, c2) }
   | MATCH e=term WITH lst=match_cases END                        { Match (e, lst) }
   | HANDLE c=term WITH hcs=handler_cases END                     { Handle (c, hcs) }
   | WITH h=term HANDLE c=term                                    { With (h, c) }
@@ -155,11 +154,16 @@ plain_term:
 
 ty_term: mark_location(plain_ty_term) { $1 }
 plain_ty_term:
-  | e=plain_equal_term                               { e }
+  | e=plain_where_term                               { e }
   | PROD a=prod_abstraction COMMA e=term             { Prod (a, e) }
   | LAMBDA a=lambda_abstraction COMMA e=term         { Lambda (a, e) }
   | FUNCTION xs=ml_arg+ DARROW e=term                { Function (xs, e) }
   | t1=equal_term ARROW t2=ty_term                   { Prod ([(Name.anonymous (), t1)], t2) }
+
+where_term: mark_location(plain_where_term) { $1 }
+plain_where_term:
+  | e=plain_equal_term { e }
+  | c1=where_term WHERE e=simple_term EQ c2=equal_term           { Where (c1, e, c2) }
 
 equal_term: mark_location(plain_equal_term) { $1 }
 plain_equal_term:

--- a/tests/inconsistent.m31
+++ b/tests/inconsistent.m31
@@ -62,10 +62,10 @@ let paradox = (lemma2 Omega) : B
 let instantiated =
 ((((paradox
   where bool = Type)
-  where p2b = lambda T, T)
-  where b2p = lambda T, T)
-  where p2p1 = lambda A H, H)
-  where p2p2 = lambda A H, H
+  where p2b = (lambda T, T))
+  where b2p = (lambda T, T))
+  where p2p1 = (lambda A H, H))
+  where p2p2 = (lambda A H, H)
 
 let inhab = (lambda A, instantiated where B = A) : forall A : Type, A
 

--- a/tests/where-precedence-associativity.m31
+++ b/tests/where-precedence-associativity.m31
@@ -1,0 +1,32 @@
+constant A : Type
+
+let x = assume x : A in x
+let x' = assume x' : A in x'
+
+constant P : A → Type
+
+let y = assume y : P x in y
+
+constant R : forall z : A, P z → Type
+
+let rxy = R x y
+
+constant X : A
+constant Y : P X
+
+
+do rxy where x = X where y = Y
+(* is parsed as *)
+do (rxy where x = X) where y = Y
+
+do rxy == rxy where x = X
+
+do λ z : A, P z == P z where z = X
+
+do P x == P x where x = X where (y where x = X) = Y
+
+constant ( + ) : A → A → Type
+constant f : A → A → A
+do x + f x x' where x = X
+
+do f x x' where x = X

--- a/tests/where-precedence-associativity.m31.ref
+++ b/tests/where-precedence-associativity.m31.ref
@@ -1,0 +1,39 @@
+Constant A is declared.
+
+val x :> judgment
+
+val x' :> judgment
+
+Constant P is declared.
+
+val y :> judgment
+
+Constant R is declared.
+
+val rxy :> judgment
+
+Constant X is declared.
+
+Constant Y is declared.
+
+⊢ R X Y : Type
+
+⊢ R X Y : Type
+
+y₀ : P X
+⊢ R X y₀ ≡ R X y₀ : Type
+
+⊢ λ (_ : A), P X ≡ P X : A → Type
+
+⊢ P X ≡ P X : Type
+
+Constant ( + ) is declared.
+
+Constant f is declared.
+
+x'₁ : A
+⊢ X + f X x'₁ : Type
+
+x'₁ : A
+⊢ f X x'₁ : A
+


### PR DESCRIPTION
Closes #387.