### PR TITLE
Remove the `end` keyword from type definitions.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,8 @@ profile: andromeda.p.native
 andromeda.byte andromeda.native andromeda.d.byte andromeda.p.native: src/build.ml
 	ocamlbuild $(OCAMLBUILD_MENHIRFLAGS) $(OCAMLBUILD_FLAGS) $@
 
-menhir-explain: andromeda.native
-	ocamlbuild $(OCAMLBUILD_MENHIRFLAGS_EXPLAINa) $(OCAMLBUILD_FLAGS) $@
+menhir-explain:
+	ocamlbuild $(OCAMLBUILD_MENHIRFLAGS_EXPLAIN) $(OCAMLBUILD_FLAGS) andromeda.native
 
 # "make test" to see if anything broke
 test: default
@@ -120,6 +120,18 @@ uninstall-examples:
 clean:
 	ocamlbuild -clean
 
-.PHONY: doc src/build.ml clean andromeda.byte andromeda.native version \
-install install-binary install-doc install-examples install-lib uninstall \
-andromeda.docdir/andromeda.dot andromeda.odocl
+.PHONY: andromeda.byte \
+	andromeda.docdir/andromeda.dot \
+	andromeda.native \
+	andromeda.odocl \
+	clean \
+	doc \
+	install \
+	install-binary \
+	install-doc \
+	install-examples \
+	install-lib \
+	menhir-explain \
+	src/build.ml \
+	uninstall \
+	version \

--- a/src/parser/parser.mly
+++ b/src/parser/parser.mly
@@ -515,13 +515,13 @@ mlty_def:
   | a=var_name xs=list(opt_name) EQ body=mlty_def_body { (a, (xs, body)) }
 
 mlty_def_body:
-  | t=mlty                                                       { ML_Alias t }
-  | lst=separated_list(BAR, mlty_constructor) END                { ML_Sum lst }
-  | BAR lst=separated_nonempty_list(BAR, mlty_constructor) END   { ML_Sum lst }
+  | t=mlty                                                           { ML_Alias t }
+  | c=mlty_constructor BAR lst=separated_list(BAR, mlty_constructor) { ML_Sum (c :: lst) }
+  | BAR lst=separated_list(BAR, mlty_constructor)                    { ML_Sum lst }
 
 mlty_constructor:
-  | c=var_name OF lst=separated_nonempty_list(AND, mlty)      { (c, lst) }
-  | c=var_name                                                { (c, []) }
+  | c=var_name OF lst=separated_nonempty_list(WITH, mlty)            { (c, lst) }
+  | c=var_name                                                       { (c, []) }
 
 mark_location(X):
   x=X

--- a/src/runtime/eval.ml
+++ b/src/runtime/eval.ml
@@ -868,8 +868,7 @@ let rec toplevel ~quiet ~print_annot {Location.thing=c;loc} =
      (if not quiet then
         Format.printf "@[<hov 2>ML type%s %t declared.@]@."
           (match lst with [_] -> "" | _ -> "s")
-          (Print.sequence (fun (t,_) -> Name.print_ident t)
-             " " lst)) ;
+          (Print.sequence (fun (t,_) -> Name.print_ident t) "," lst)) ;
      return ()
 
   | Rsyntax.DeclOperation (x, k) ->

--- a/std/base.m31
+++ b/std/base.m31
@@ -13,7 +13,8 @@ external print_json : mlforall a, mlunit -> a = "print_json"
 external compare : mlforall a, a -> a -> mlorder = "compare"
 
 (* Poor man's debugging mechanism. *)
-mltype debug a = (!!) of a end
+mltype debug a = | (!!) of a ;;
+
 let debug x = print (!! x)
 
 (* Top-level handlers default to failure. *)
@@ -40,7 +41,6 @@ let ( = ) x y =
 mltype eagerness =
   | eager
   | lazy
-  end
 
 (*
 constant funext : forall (A : Type) (B : A -> Type) (f g : forall x : A, B x),
@@ -49,4 +49,4 @@ constant funext : forall (A : Type) (B : A -> Type) (f g : forall x : A, B x),
 constant uip : forall (A : Type) (lhs rhs : A) (p q : lhs ≡ rhs), p ≡ q
 *)
 
-mltype empty = end
+mltype mlempty = |

--- a/tests/runtime/list_pattern.m31
+++ b/tests/runtime/list_pattern.m31
@@ -1,0 +1,4 @@
+let [x; y; z] = ["x"; "y"; "z"] ;;
+let ([x; y; z]) = ["x"; "y"; "z"] ;;
+let (x :: y :: z :: lst) = ["x"; "y"; "z"] ;;
+let (x :: lst) = ["x"; "y"; "z"] ;;

--- a/tests/runtime/list_pattern.m31.ref
+++ b/tests/runtime/list_pattern.m31.ref
@@ -1,0 +1,12 @@
+val x :> mlstring = "x"
+val y :> mlstring = "y"
+val z :> mlstring = "z"
+val x :> mlstring = "x"
+val y :> mlstring = "y"
+val z :> mlstring = "z"
+val x :> mlstring = "x"
+val y :> mlstring = "y"
+val z :> mlstring = "z"
+val lst :> list mlstring = []
+val x :> mlstring = "x"
+val lst :> list mlstring = ["y"; "z"]

--- a/tests/types/typedefs.m31
+++ b/tests/types/typedefs.m31
@@ -1,0 +1,19 @@
+mltype test_empty = |
+
+mltype test_unit1 = | test_cow1
+
+mltype test_unit2 = test_cow2 |
+
+mltype test_unit3 = test_unit1
+
+mltype fruit = ananas | banana
+
+mltype part a = ear | tail | paw of a * a | wing
+
+mltype rec rodent a =
+  | Hare of part (rodent (a * fruit)) with a with a
+  | Squirrel of part fruit * part fruit
+
+and insect =
+  | Bee
+  | Ant of part fruit with rodent insect -> part (part fruit)

--- a/tests/types/typedefs.m31.ref
+++ b/tests/types/typedefs.m31.ref
@@ -1,0 +1,7 @@
+ML type test_empty declared.
+ML type test_unit1 declared.
+ML type test_unit2 declared.
+ML type test_unit3 declared.
+ML type fruit declared.
+ML type part declared.
+ML types rodent, insect declared.


### PR DESCRIPTION
This change requires a bit of acrobatics to avoid parser conflicts:

1. Is `type cow = bull` a type alias or a datatype with a single constructor?
   To disambiguate, write `type cow = | bull` when it's a datatype.

2. The empty type is defined as `type empty = |`.

3. In order to avoid conflicts with `type t = ... and u = ...`, a curried
   constructor should we written using `with`: `type cow = Horn of string with
   bool with ...` (formerly it was `and` instead of `with`).