### PR TITLE
Constructor checking mode

### DIFF
--- a/src/nucleus/alpha_equal.ml
+++ b/src/nucleus/alpha_equal.ml
@@ -97,6 +97,5 @@ let check_is_type_boundary abstr bdry =
 let check_is_term_boundary sgn abstr bdry =
   abstraction (fun e t -> is_type (Sanity.type_of_term sgn e) t) abstr bdry
 
-
-let check_eq_type_boundary = Sanity.check_eq_type_boundary
-let check_eq_term_boundary = Sanity.check_eq_term_boundary
+let check_eq_type_boundary _ _ = failwith "check_eq_type_boundary"
+let check_eq_term_boundary _ _ = failwith "check_eq_term_boundary"

--- a/src/nucleus/alpha_equal.ml
+++ b/src/nucleus/alpha_equal.ml
@@ -44,10 +44,8 @@ and is_term e1 e2 =
   end
 
 and abstraction
-  : 'a . ('a -> 'a -> bool) -> 'a abstraction -> 'a abstraction -> bool
+  : 'a 'b . ('a -> 'b -> bool) -> 'a abstraction -> 'b abstraction -> bool
   = fun equal_v e e' ->
-    e == e' ||
-    (* XXX try e = e' ? *)
     match e, e' with
 
     | Abstract ({atom_type=u;_}, abstr), Abstract({atom_type=u';_}, abstr') ->
@@ -92,3 +90,13 @@ and arguments args args' =
         was applied in two different ways, and somehow the nucleus was happy
         with that *)
      assert false
+
+let check_is_type_boundary abstr bdry =
+  abstraction (fun _ _ -> true) abstr bdry
+
+let check_is_term_boundary sgn abstr bdry =
+  abstraction (fun e t -> is_type (Sanity.type_of_term sgn e) t) abstr bdry
+
+
+let check_eq_type_boundary = Sanity.check_eq_type_boundary
+let check_eq_term_boundary = Sanity.check_eq_term_boundary

--- a/src/nucleus/congruence.ml
+++ b/src/nucleus/congruence.ml
@@ -51,13 +51,13 @@ let process_congruence_args args =
 
 let congruence_type_constructor sgn c eqs =
   let (asmp, lhs, rhs) = process_congruence_args eqs in
-  let t1 = Form.form_is_type sgn c lhs
-  and t2 = Form.form_is_type sgn c rhs
+  let t1 = Mk.type_constructor c lhs
+  and t2 = Mk.type_constructor c rhs
   in Mk.eq_type asmp t1 t2
 
 let congruence_term_constructor sgn c eqs =
   let (asmp, lhs, rhs) = process_congruence_args eqs in
-  let e1 = Form.form_is_term sgn c lhs
-  and e2 = Form.form_is_term sgn c rhs in
+  let e1 = Mk.term_constructor c lhs
+  and e2 = Mk.term_constructor c rhs in
   let t = Sanity.type_of_term sgn e1
   in Mk.eq_term asmp e1 e2 t

--- a/src/nucleus/form.ml
+++ b/src/nucleus/form.ml
@@ -51,6 +51,12 @@ let rec form_alpha_equal_abstraction equal_u abstr1 abstr2 =
   | (NotAbstract _, Abstract _)
   | (Abstract _, NotAbstract _) -> None
 
+let form_rap_is_type sgn c = failwith "not done"
+let form_rap_is_term sgn c = failwith "not done"
+let form_rap_eq_type sgn c = failwith "not done"
+let form_rap_eq_term sgn c = failwith "not done"
+
+let rap_apply rap arg = failwith "not done"
 
 let form_is_type sgn c arguments =
   let prems, () = Signature.lookup_rule_is_type c sgn in

--- a/src/nucleus/form.ml
+++ b/src/nucleus/form.ml
@@ -120,41 +120,6 @@ let rap_apply sgn {rap_arguments; rap_boundary; rap_premises; rap_constructor} a
              ; rap_premises
              ; rap_constructor }
 
-let form_is_type sgn c arguments =
-  let prems, () = Signature.lookup_rule_is_type c sgn in
-  (* [match_arguments] reverses the order of arguments for the benefit of instantiation *)
-  let args = Indices.to_list (Form_rule.match_arguments sgn prems arguments) in
-  Mk.type_constructor c args
-
-let form_is_term sgn c arguments =
-  let (premises, _boundary) = Signature.lookup_rule_is_term c sgn in
-  (* [match_arguments] reverses the order of arguments for the benefit of instantiation *)
-  let args = Indices.to_list (Form_rule.match_arguments sgn premises arguments) in
-  Mk.term_constructor c args
-
-let form_eq_type sgn c arguments =
-  let (premises, (lhs_schema, rhs_schema)) =
-    Signature.lookup_rule_eq_type c sgn in
-  let inds = Form_rule.match_arguments sgn premises arguments in
-  (* order of arguments not important in [Collect_assumptions.arguments],
-     we could try avoiding a list reversal caused by [Indices.to_list]. *)
-  let asmp = Collect_assumptions.arguments (Indices.to_list inds)
-  and lhs = Instantiate_meta.is_type ~lvl:0 inds lhs_schema
-  and rhs = Instantiate_meta.is_type ~lvl:0 inds rhs_schema
-  in Mk.eq_type asmp lhs rhs
-
-let form_eq_term sgn c arguments =
-  let (premises, (e1_schema, e2_schema, t_schema)) =
-    Signature.lookup_rule_eq_term c sgn in
-  let inds = Form_rule.match_arguments sgn premises arguments in
-  (* order of arguments not important in [Collect_assumptions.arguments],
-     we could try avoiding a list reversal caused by [Indices.to_list]. *)
-  let asmp = Collect_assumptions.arguments (Indices.to_list inds)
-  and e1 = Instantiate_meta.is_term ~lvl:0 inds e1_schema
-  and e2 = Instantiate_meta.is_term ~lvl:0 inds e2_schema
-  and t = Instantiate_meta.is_type ~lvl:0 inds t_schema
-  in Mk.eq_term asmp e1 e2 t
-
 let form_is_term_atom = Mk.atom
 
 (** Conversion *)

--- a/src/nucleus/form_rule.ml
+++ b/src/nucleus/form_rule.ml
@@ -86,7 +86,7 @@ let lookup_meta_index x mvs =
   search 0 mvs
 
 (** The [mk_rule_XYZ] functions are auxiliary functions that should not be
-    exposed. The external interface exopses the [form_rule_XYZ] functions defined
+    exposed. The external interface exposes the [form_rule_XYZ] functions defined
     below. *)
 
 let rec mk_rule_is_type metas = function

--- a/src/nucleus/nucleus.ml
+++ b/src/nucleus/nucleus.ml
@@ -45,6 +45,7 @@ let form_rap_is_term = Form.form_rap_is_term
 let form_rap_eq_type = Form.form_rap_eq_type
 let form_rap_eq_term = Form.form_rap_eq_term
 let rap_apply = Form.rap_apply
+let rap_boundary = Form.rap_boundary
 
 let form_eq_term = Form.form_eq_term
 let form_eq_type = Form.form_eq_type

--- a/src/nucleus/nucleus.ml
+++ b/src/nucleus/nucleus.ml
@@ -47,10 +47,6 @@ let form_rap_eq_term = Form.form_rap_eq_term
 let rap_apply = Form.rap_apply
 let rap_boundary = Form.rap_boundary
 
-let form_eq_term = Form.form_eq_term
-let form_eq_type = Form.form_eq_type
-let form_is_term = Form.form_is_term
-let form_is_type = Form.form_is_type
 let form_is_term_atom = Form.form_is_term_atom
 let form_eq_term_convert = Form.form_eq_term_convert
 let form_is_term_convert = Form.form_is_term_convert

--- a/src/nucleus/nucleus.ml
+++ b/src/nucleus/nucleus.ml
@@ -20,6 +20,12 @@ let type_at_abstraction = Sanity.type_at_abstraction
 let type_of_atom = Sanity.type_of_atom
 let natural_type_eq = Sanity.natural_type_eq
 
+let check_is_type_boundary = Alpha_equal.check_is_type_boundary
+let check_is_term_boundary = Alpha_equal.check_is_term_boundary
+let check_eq_type_boundary = Alpha_equal.check_eq_type_boundary
+let check_eq_term_boundary = Alpha_equal.check_eq_term_boundary
+
+
 let fresh_atom = Mk.fresh_atom
 let fresh_is_type_meta = Mk.fresh_type_meta
 let fresh_is_term_meta = Mk.fresh_term_meta
@@ -34,6 +40,12 @@ let alpha_equal_abstraction = Alpha_equal.abstraction
 let form_alpha_equal_term = Form.form_alpha_equal_term
 let form_alpha_equal_type = Form.form_alpha_equal_type
 let form_alpha_equal_abstraction = Form.form_alpha_equal_abstraction
+let form_rap_is_type = Form.form_rap_is_type
+let form_rap_is_term = Form.form_rap_is_term
+let form_rap_eq_type = Form.form_rap_eq_type
+let form_rap_eq_term = Form.form_rap_eq_term
+let rap_apply = Form.rap_apply
+
 let form_eq_term = Form.form_eq_term
 let form_eq_type = Form.form_eq_type
 let form_is_term = Form.form_is_term

--- a/src/nucleus/nucleus.mli
+++ b/src/nucleus/nucleus.mli
@@ -127,24 +127,27 @@ val form_rule_eq_term :
    be able to compute the boundary of the next argument from the already given
    ones _before_ the next argument is known. We call such a partially applied
    rule a (partial) _rule application_. *)
-type 'a rule_application
+type 'a rule_application_status
 
 (** When we apply a rule application to one more argument two things may happen.
    Either we are done and we get a result, or more arguments are needed, in
    which case we get the rap with one more argument applied, and the boundary of
    the next argument. *)
-type 'a rule_application_status = private
+type 'a rule_application = private
   | RapDone of 'a
-  | RapMore of 'a rule_application * boundary
+  | RapMore of 'a rule_application_status
 
 (** Form a fully non-applied rule application for a given constructor *)
-val form_rap_is_type : signature -> Ident.t -> is_type rule_application_status
-val form_rap_is_term : signature -> Ident.t -> is_term rule_application_status
-val form_rap_eq_type : signature -> Ident.t -> eq_type rule_application_status
-val form_rap_eq_term : signature -> Ident.t -> eq_term rule_application_status
+val form_rap_is_type : signature -> Ident.t -> is_type rule_application
+val form_rap_is_term : signature -> Ident.t -> is_term rule_application
+val form_rap_eq_type : signature -> Ident.t -> eq_type rule_application
+val form_rap_eq_term : signature -> Ident.t -> eq_term rule_application
 
 (** Apply a rap to one more argument *)
-val rap_apply : 'a rule_application -> argument -> 'a rule_application_status
+val rap_apply : signature -> 'a rule_application_status -> argument -> 'a rule_application
+
+(** Give the boundary of a rap status, i.e., the boundary of the next argument. *)
+val rap_boundary : 'a rule_application_status -> boundary
 
 (** Given a type formation rule and a list of arguments, match the rule
    against the given arguments, make sure they fit the rule, and return the
@@ -261,7 +264,7 @@ val type_at_abstraction : 'a abstraction -> is_type option
 
 (** Checking that an abstracted judgement has the desired boundary *)
 val check_is_type_boundary : is_type_abstraction -> is_type_boundary -> bool
-val check_is_type_boundary : is_term_abstraction -> is_term_boundary -> bool
+val check_is_term_boundary : signature -> is_term_abstraction -> is_term_boundary -> bool
 val check_eq_type_boundary : eq_type_abstraction -> eq_type_boundary -> bool
 val check_eq_term_boundary : eq_term_abstraction -> eq_term_boundary -> bool
 

--- a/src/nucleus/nucleus.mli
+++ b/src/nucleus/nucleus.mli
@@ -149,17 +149,6 @@ val rap_apply : signature -> 'a rule_application_status -> argument -> 'a rule_a
 (** Give the boundary of a rap status, i.e., the boundary of the next argument. *)
 val rap_boundary : 'a rule_application_status -> boundary
 
-(** Given a type formation rule and a list of arguments, match the rule
-   against the given arguments, make sure they fit the rule, and return the
-   judgement corresponding to the conclusion of the rule. *)
-val form_is_type : signature -> Ident.t -> argument list -> is_type
-
-(** Given a term rule and a list of arguments, match the rule against the given
-    arguments, make sure they fit the rule, and return the list of arguments that
-    the term constructor should be applied to, together with the natural type of
-    the resulting term. *)
-val form_is_term : signature -> Ident.t -> argument list -> is_term
-
 (** Convert atom judgement to term judgement *)
 val form_is_term_atom : is_atom -> is_term
 
@@ -175,19 +164,9 @@ val form_is_term_meta : signature -> is_term_meta -> is_term list -> is_term
 
 val form_is_term_convert : signature -> is_term -> eq_type -> is_term
 
-(** Given an equality type rule and a list of arguments, match the rule against
-    the given arguments, make sure they fit the rule, and return the conclusion
-    of the instance of the rule so obtained. *)
-val form_eq_type : signature -> Ident.t -> argument list -> eq_type
-
 val form_eq_type_meta : signature -> eq_type_meta -> is_term list -> eq_type
 
 val form_eq_term_meta : signature -> eq_term_meta -> is_term list -> eq_term
-
-(** Given an terms equality type rule and a list of arguments, match the rule
-    against the given arguments, make sure they fit the rule, and return the
-    conclusion of the instance of the rule so obtained. *)
-val form_eq_term : signature -> Ident.t -> argument list -> eq_term
 
 (** Form a non-abstracted abstraction *)
 val abstract_not_abstract : 'a -> 'a abstraction

--- a/src/nucleus/nucleus_types.ml
+++ b/src/nucleus/nucleus_types.ml
@@ -55,6 +55,16 @@ and boundary =
     | BoundaryEqType of eq_type_boundary
     | BoundaryEqTerm of eq_term_boundary
 
+type 'a rule_application =
+  { rap_metas : argument list
+  ; rap_next_boundary : boundary option
+  ; rep_premises : Rule.premise list
+  ; rap_constructor : argument list -> 'a
+  }
+
+type 'a rule_application_status = private
+  | RapDone of 'a
+  | RapMore of 'a rule_application * boundary
 
 type signature =
   { is_type : Rule.rule_is_type Ident.map

--- a/src/nucleus/nucleus_types.ml
+++ b/src/nucleus/nucleus_types.ml
@@ -55,16 +55,17 @@ and boundary =
     | BoundaryEqType of eq_type_boundary
     | BoundaryEqTerm of eq_term_boundary
 
-type 'a rule_application =
-  { rap_metas : argument list
-  ; rap_next_boundary : boundary option
-  ; rep_premises : Rule.premise list
-  ; rap_constructor : argument list -> 'a
+type 'a rule_application_status =
+  { rap_arguments : argument list (* the arguments collected so far *)
+  ; rap_boundary : boundary (* the boundary of the next argument *)
+  ; rap_premises : Rule.premise list (* the remaining premises to be applied *)
+  ; rap_constructor : argument list -> 'a (* the function which makes the final result *)
   }
 
-type 'a rule_application_status = private
+(* A partial rule application *)
+type 'a rule_application =
   | RapDone of 'a
-  | RapMore of 'a rule_application * boundary
+  | RapMore of 'a rule_application_status
 
 type signature =
   { is_type : Rule.rule_is_type Ident.map
@@ -130,10 +131,7 @@ type error =
   | ExtraAssumptions
   | InvalidApplication
   | InvalidArgument
-  | IsTypeExpected
-  | IsTermExpected
-  | EqTypeExpected
-  | EqTermExpected
+  | ArgumentExpected of boundary
   | AbstractionExpected
   | InvalidSubstitution
   | InvalidCongruence

--- a/src/nucleus/rule.mli
+++ b/src/nucleus/rule.mli
@@ -31,8 +31,8 @@ and 'a abstraction =
 type premise =
   | PremiseIsType of unit abstraction
   | PremiseIsTerm of ty abstraction
-  | PremiseEqType of eq_type abstraction
-  | PremiseEqTerm of eq_term abstraction
+  | PremiseEqType of (ty * ty) abstraction
+  | PremiseEqTerm of (term * term * ty) abstraction
 
 type rule_is_type = premise list * unit
 type rule_is_term = premise list * ty

--- a/src/nucleus/sanity.ml
+++ b/src/nucleus/sanity.ml
@@ -85,6 +85,11 @@ let boundary_is_term_abstraction sgn abstr =
   (* NB: this is _not_ like the others as it actually computes the type of a term *)
   type_of_term_abstraction sgn abstr
 
-let boundary_eq_type_abstraction abstr = abstr
+let boundary_eq_type_abstraction abstr =
+  (* We may drop the assumption set of the argument because that assumption set
+     is needed to inhabit the equality, not to form its boundary. The boundary carries
+     its own assumptions. *)
+  boundary_abstraction (fun (EqType (_, t, u)) -> (t, u)) abstr
 
-let boundary_eq_term_abstraction abstr = abstr
+let boundary_eq_term_abstraction abstr =
+  boundary_abstraction (fun (EqTerm (_, a, b, t)) -> (a, b, t)) abstr

--- a/src/runtime/runtime.ml
+++ b/src/runtime/runtime.ml
@@ -728,7 +728,7 @@ let print_operation ~penv op vs ppf =
      begin
        match vs with
        | [] -> Path.print ~opens:penv.opens ~parentheses:true op ppf
-       | (_::_) -> Print.print ~at_level:Level.ml_operation ppf "[@<hov 2>%t@ %t@]"
+       | (_::_) -> Print.print ~at_level:Level.ml_operation ppf "@[<hov 2>%t@ %t@]"
                      (Path.print ~opens:penv.opens ~parentheses:true op)
                      (Print.sequence (print_value ~max_level:Level.ml_operation_arg ~penv) "" vs)
      end

--- a/tests/nucleus/order_of_arguments.m31
+++ b/tests/nucleus/order_of_arguments.m31
@@ -1,0 +1,12 @@
+(* Test whether the order of arguments is accidentally reversed *)
+rule A type
+rule B type
+rule a : A
+rule b : B
+rule P (⊢ _ : A) (⊢ _ : B) type
+rule p : P a b
+rule Q (⊢ _ : P a b) (⊢ _ : A) (⊢ _ : B) type ;;
+P a b ;;
+p ;;
+Q p a b ;;
+

--- a/tests/nucleus/order_of_arguments.m31.ref
+++ b/tests/nucleus/order_of_arguments.m31.ref
@@ -1,0 +1,10 @@
+Rule A is postulated.
+Rule B is postulated.
+Rule a is postulated.
+Rule b is postulated.
+Rule P is postulated.
+Rule p is postulated.
+Rule Q is postulated.
+- : is_type = ⊢ P a b type
+- : is_term = ⊢ p
+- : is_type = ⊢ Q p a b type


### PR DESCRIPTION
This PR implements the checking mode for arguments of TT formers.

Implementing it also shows how we need to fix the infer/checking algorithm. Traditionally, we have

* infer mode, which calculates the type of a term
* check mode, which checks that a term has a given type

Because we have four judgement forms, we shall instead have:

* infer mode, which calculates a judgement
* check mode, which checks that a judgement has the required boundary

So in fact there will be four possible ways to check against. Consequently, we need to introduce boundaries into the absract syntax, namely in the form of patterns on handlers.
