### PR TITLE
Boundary checking mode

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -12,7 +12,7 @@
             ;; m31 tags file
             (when m31-root-directory
               (setq tags-file-name (concat m31-root-directory "TAGS"))
-              (make-local-variable 'compilation-search-path)
+              ; (make-local-variable 'compilation-search-path)
               (add-to-list 'compilation-search-path m31-root-directory)
               ;; Setting the compilation directory to m31 root. This is
               ;; mutually exclusive with the setting of default-directory

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,9 @@
 #50: unexpected documentation comment
 
 # Use this to not die on all warnings
-#OCAMLBUILD_FLAGS = -j 4 -lib unix -cflags -g,-annot,-w,+a-4-27-29-50 -use-ocamlfind -pkg menhirLib -pkg sedlex
+#OCAMLBUILD_FLAGS = -j 4 -lib unix -cflags -g,-annot,-w,+a-4-27-29-50 -use-ocamlfind -pkg menhirLib -pkg sedlex.ppx
 
-OCAMLBUILD_FLAGS = -j 4 -lib unix -cflags -g,-annot,-w,+a-4-27-29-50,"-warn-error +a" -use-ocamlfind -pkg menhirLib -pkg sedlex
+OCAMLBUILD_FLAGS = -j 4 -lib unix -cflags -g,-annot,-w,+a-4-27-29-50,"-warn-error +a" -use-ocamlfind -pkg menhirLib -pkg sedlex.ppx
 
 # The --strict flag prevents --explain, so we make a separate Makefile target to get
 # menhir explanations

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ andromeda.byte andromeda.native andromeda.d.byte andromeda.p.native: src/build.m
 	ocamlbuild $(OCAMLBUILD_MENHIRFLAGS) $(OCAMLBUILD_FLAGS) $@
 
 menhir-explain:
-	ocamlbuild $(OCAMLBUILD_MENHIRFLAGS_EXPLAIN) $(OCAMLBUILD_FLAGS) andromeda.native
+	ocamlbuild $(OCAMLBUILD_MENHIRFLAGS_EXPLAIN) $(OCAMLBUILD_FLAGS) src/parser/parser.ml
 
 # "make test" to see if anything broke
 test: default

--- a/src/dsyntax.mli
+++ b/src/dsyntax.mli
@@ -105,20 +105,19 @@ type ml_tydef =
 
 type local_context = (Name.t * comp) list
 
+type boundary =
+   | BoundaryIsType
+   | BoundaryIsTerm of comp
+   | BoundaryEqType of comp * comp
+   | BoundaryEqTerm of comp * comp * comp
+
 type premise = premise' located
-and premise' =
-  | PremiseIsType of Name.t option * local_context
-  | PremiseIsTerm of Name.t option * local_context * comp
-  | PremiseEqType of Name.t option * local_context * (comp * comp)
-  | PremiseEqTerm of Name.t option * local_context * (comp * comp * comp)
+and premise' = Premise of Name.t option * local_context * boundary
 
 (** Desugared toplevel commands *)
 type toplevel = toplevel' located
 and toplevel' =
-  | RuleIsType of Path.t * premise list
-  | RuleIsTerm of Path.t * premise list * comp
-  | RuleEqType of Path.t * premise list * (comp * comp)
-  | RuleEqTerm of Path.t * premise list * (comp * comp * comp)
+  | Rule of Path.t * premise list * boundary
   | DefMLType of (Path.t * (Name.t option list * ml_tydef)) list
   | DefMLTypeRec of (Path.t * (Name.t option list * ml_tydef)) list
   | DeclOperation of Path.t * (ml_ty list * ml_ty)

--- a/src/dsyntax.mli
+++ b/src/dsyntax.mli
@@ -114,7 +114,7 @@ type ml_tydef =
 type local_context = (Name.t * comp) list
 
 type premise = premise' located
-and premise' = Premise of Name.t option * local_context * boundary
+and premise' = Premise of Name.t * local_context * boundary
 
 (** Desugared toplevel commands *)
 type toplevel = toplevel' located

--- a/src/dsyntax.mli
+++ b/src/dsyntax.mli
@@ -79,8 +79,16 @@ and comp' =
   | Yield of comp
   | String of string
   | Occurs of comp * comp
+  | Convert of comp * comp
   | Context of comp
   | Natural of comp
+  | MLBoundary of boundary
+
+and boundary =
+   | BoundaryIsType
+   | BoundaryIsTerm of comp
+   | BoundaryEqType of comp * comp
+   | BoundaryEqTerm of comp * comp * comp
 
 and let_clause =
   | Let_clause of ml_pattern * let_annotation * comp (* [let (?p :> t) = c] *)
@@ -104,12 +112,6 @@ type ml_tydef =
   | ML_Alias of ml_ty
 
 type local_context = (Name.t * comp) list
-
-type boundary =
-   | BoundaryIsType
-   | BoundaryIsTerm of comp
-   | BoundaryEqType of comp * comp
-   | BoundaryEqTerm of comp * comp * comp
 
 type premise = premise' located
 and premise' = Premise of Name.t option * local_context * boundary

--- a/src/dsyntax.mli
+++ b/src/dsyntax.mli
@@ -2,16 +2,6 @@
 
 type 'a located = 'a Location.located
 
-type ml_judgement =
-  | ML_IsType
-  | ML_IsTerm
-  | ML_EqType
-  | ML_EqTerm
-
-type ml_abstracted_judgement =
-  | ML_NotAbstract of ml_judgement
-  | ML_Abstract of ml_abstracted_judgement
-
 type ml_ty = ml_ty' located
 and ml_ty' =
   | ML_Arrow of ml_ty * ml_ty
@@ -20,7 +10,8 @@ and ml_ty' =
   | ML_Handler of ml_ty * ml_ty
   | ML_Ref of ml_ty
   | ML_Dynamic of ml_ty
-  | ML_Judgement of ml_abstracted_judgement
+  | ML_Judgement
+  | ML_Boundary
   | ML_String
   | ML_Bound of Path.index
   | ML_Anonymous

--- a/src/nucleus/abstract.ml
+++ b/src/nucleus/abstract.ml
@@ -4,9 +4,11 @@ open Nucleus_types
 
 (** [abstract_is_type x0 ~lvl:k t] replaces atom [x0] in type [t] with bound variable [k] (default [0]). *)
 let rec is_type x ?(lvl=0) = function
+
   | TypeConstructor (c, args) ->
      let args = arguments x ~lvl args in
      TypeConstructor (c, args)
+
   | TypeMeta (mv, args) ->
      let args = term_arguments x ~lvl args
      and mv = is_type_meta x ~lvl mv in
@@ -18,8 +20,8 @@ and is_term x ?(lvl=0) = function
        e
      else
        assert false
-  (* we should never get here because abstracting should always introduce a
-     highest-level bound index. *)
+       (* we should never get here because abstracting should always introduce a
+          highest-level bound index. *)
 
   | (TermAtom {atom_nonce=y; atom_type=t}) as e ->
      begin match Nonce.equal x y with
@@ -40,10 +42,11 @@ and is_term x ?(lvl=0) = function
      let args = arguments x ~lvl args in
      TermConstructor (c, args)
 
-  | TermConvert (c, asmp, t) ->
-     let asmp = Assumption.abstract x ~lvl asmp
+  | TermConvert (e, asmp, t) ->
+     let e = is_term x ~lvl e
+     and asmp = Assumption.abstract x ~lvl asmp
      and t = is_type x ~lvl t in
-     TermConvert (c, asmp, t)
+     TermConvert (e, asmp, t)
 
 and eq_type x ?(lvl=0) (EqType (asmp, t1, t2)) =
   let asmp = assumptions x ~lvl asmp

--- a/src/nucleus/abstract.ml
+++ b/src/nucleus/abstract.ml
@@ -86,9 +86,9 @@ and abstraction
 
 and term_arguments x ?(lvl=0) args = List.map (is_term x ~lvl) args
 
-and arguments x ?(lvl=0) args = List.map (abstraction argument x ~lvl) args
+and arguments x ?(lvl=0) args = List.map (abstraction judgement x ~lvl) args
 
-and argument x ?(lvl=0) = function
+and judgement x ?(lvl=0) = function
   | JudgementIsType t -> JudgementIsType (is_type x ~lvl t)
 
   | JudgementIsTerm e -> JudgementIsTerm (is_term x ~lvl e)
@@ -98,8 +98,6 @@ and argument x ?(lvl=0) = function
   | JudgementEqTerm asmp -> JudgementEqTerm (eq_term x ~lvl asmp)
 
 let not_abstract u = Mk.not_abstract u
-
-let judgement atm jdg = argument atm.atom_nonce jdg
 
 let is_type_abstraction atm abstr =
   (* XXX occurs check?! *)
@@ -118,6 +116,10 @@ let eq_term_abstraction atm abstr =
   let abstr = abstraction eq_term atm.atom_nonce abstr in
   Mk.abstract atm abstr
 
+let judgement_abstraction atm abstr =
+  let abstr = abstraction judgement atm.atom_nonce abstr in
+  Mk.abstract atm abstr
+
 let boundary_is_type _atm ?lvl () = ()
 
 let boundary_is_term atm ?lvl t = is_type atm ?lvl t
@@ -132,6 +134,12 @@ let boundary_eq_term atm ?lvl (lhs, rhs, t) =
   and rhs = is_term ?lvl atm rhs
   and t = is_type ?lvl atm t in
   (lhs, rhs, t)
+
+let boundary atm ?lvl = function
+  | BoundaryIsTerm bdry -> BoundaryIsTerm (boundary_is_term atm ?lvl bdry)
+  | BoundaryIsType bdry -> BoundaryIsType (boundary_is_type atm ?lvl bdry)
+  | BoundaryEqType bdry -> BoundaryEqType (boundary_eq_type atm ?lvl bdry)
+  | BoundaryEqTerm bdry -> BoundaryEqTerm (boundary_eq_term atm ?lvl bdry)
 
 let boundary_is_type_abstraction atm abstr =
   let abstr = abstraction boundary_is_type atm.atom_nonce abstr in
@@ -149,8 +157,6 @@ let boundary_eq_term_abstraction atm abstr =
   let abstr = abstraction boundary_eq_term atm.atom_nonce abstr in
   Mk.abstract atm abstr
 
-let boundary atm = function
-  | BoundaryIsTerm bdry -> BoundaryIsTerm (boundary_is_term atm.atom_nonce bdry)
-  | BoundaryIsType bdry -> BoundaryIsType (boundary_is_type atm.atom_nonce bdry)
-  | BoundaryEqType bdry -> BoundaryEqType (boundary_eq_type atm.atom_nonce bdry)
-  | BoundaryEqTerm bdry -> BoundaryEqTerm (boundary_eq_term atm.atom_nonce bdry)
+let boundary_abstraction atm abstr =
+  let abstr = abstraction boundary atm.atom_nonce abstr in
+  Mk.abstract atm abstr

--- a/src/nucleus/abstract.ml
+++ b/src/nucleus/abstract.ml
@@ -87,17 +87,17 @@ and arguments x ?(lvl=0) args = List.map (argument x ~lvl) args
 
 and argument x ?(lvl=0) = function
 
-  | ArgumentIsType t -> ArgumentIsType (abstraction is_type x ~lvl t)
+  | JudgementIsType t -> JudgementIsType (abstraction is_type x ~lvl t)
 
-  | ArgumentIsTerm e -> ArgumentIsTerm (abstraction is_term x ~lvl e)
+  | JudgementIsTerm e -> JudgementIsTerm (abstraction is_term x ~lvl e)
 
-  | ArgumentEqType asmp ->
+  | JudgementEqType asmp ->
      let asmp = abstraction eq_type x ~lvl asmp in
-     ArgumentEqType asmp
+     JudgementEqType asmp
 
-  | ArgumentEqTerm asmp ->
+  | JudgementEqTerm asmp ->
      let asmp = abstraction eq_term x ~lvl asmp in
-     ArgumentEqTerm asmp
+     JudgementEqTerm asmp
 
 
 let not_abstract u = Mk.not_abstract u

--- a/src/nucleus/abstract.ml
+++ b/src/nucleus/abstract.ml
@@ -99,8 +99,9 @@ and argument x ?(lvl=0) = function
      let asmp = abstraction eq_term x ~lvl asmp in
      JudgementEqTerm asmp
 
-
 let not_abstract u = Mk.not_abstract u
+
+let judgement atm jdg = argument atm.atom_nonce jdg
 
 let is_type_abstraction atm abstr =
   (* XXX occurs check?! *)
@@ -145,3 +146,9 @@ let boundary_eq_term_abstraction atm abstr =
          (lhs, rhs, t))
       atm.atom_nonce abstr in
   Mk.abstract atm abstr
+
+let boundary atm = function
+  | BoundaryIsTerm abstr -> BoundaryIsTerm (boundary_is_term_abstraction atm abstr)
+  | BoundaryIsType abstr -> BoundaryIsType (boundary_is_type_abstraction atm abstr)
+  | BoundaryEqType abstr -> BoundaryEqType (boundary_eq_type_abstraction atm abstr)
+  | BoundaryEqTerm abstr -> BoundaryEqTerm (boundary_eq_term_abstraction atm abstr)

--- a/src/nucleus/alpha_equal.ml
+++ b/src/nucleus/alpha_equal.ml
@@ -91,6 +91,41 @@ and arguments args args' =
         with that *)
      assert false
 
+let judgement jdg1 jdg2 =
+  match jdg1, jdg2 with
+  | JudgementIsType t1, JudgementIsType t2 -> abstraction is_type t1 t2
+
+  | JudgementIsTerm e1, JudgementIsTerm e2 -> abstraction is_term e1 e2
+
+  (** Comparing equality types means comparing their "proof terms", not their boundaries! *)
+  | JudgementEqType eq1, JudgementEqType eq2 -> abstraction (fun _ _ -> true) eq1 eq2
+  | JudgementEqTerm eq1, JudgementEqTerm eq2 -> abstraction (fun _ _ -> true) eq1 eq2
+
+  | JudgementIsType _, (JudgementIsTerm _ | JudgementEqType _ | JudgementEqTerm _)
+  | JudgementIsTerm _, (JudgementIsType _ | JudgementEqType _ | JudgementEqTerm _)
+  | JudgementEqType _, (JudgementIsType _ | JudgementIsTerm _ | JudgementEqTerm _)
+  | JudgementEqTerm _, (JudgementIsType _ | JudgementIsTerm _ | JudgementEqType _) ->
+     false
+
+let boundary jdg1 jdg2 =
+  match jdg1, jdg2 with
+  | BoundaryIsType abstr1, BoundaryIsType abstr2 -> abstraction (fun () () -> true) abstr1 abstr2
+
+  | BoundaryIsTerm t1, BoundaryIsTerm t2 -> abstraction is_type t1 t2
+
+  | BoundaryEqType eq1, BoundaryEqType eq2 ->
+     abstraction (fun (u1, t1) (u2, t2) -> is_type u1 u2 && is_type t1 t2) eq1 eq2
+
+  | BoundaryEqTerm eq1, BoundaryEqTerm eq2 ->
+     abstraction (fun (a1, b1, t1) (a2, b2, t2) -> is_type t1 t2 && is_term a1 a2 && is_term b1 b2) eq1 eq2
+
+  | BoundaryIsType _, (BoundaryIsTerm _ | BoundaryEqType _ | BoundaryEqTerm _)
+  | BoundaryIsTerm _, (BoundaryIsType _ | BoundaryEqType _ | BoundaryEqTerm _)
+  | BoundaryEqType _, (BoundaryIsType _ | BoundaryIsTerm _ | BoundaryEqTerm _)
+  | BoundaryEqTerm _, (BoundaryIsType _ | BoundaryIsTerm _ | BoundaryEqType _) ->
+     false
+
+
 let check_is_type_boundary abstr bdry =
   abstraction (fun _ _ -> true) abstr bdry
 

--- a/src/nucleus/alpha_equal.ml
+++ b/src/nucleus/alpha_equal.ml
@@ -135,4 +135,31 @@ let check_is_term_boundary sgn abstr bdry =
 let check_eq_type_boundary _ _ = failwith "check_eq_type_boundary"
 let check_eq_term_boundary _ _ = failwith "check_eq_term_boundary"
 
+let check_judgement_boundary sgn jdg bdry =
+  match bdry with
+    | BoundaryIsType bdry ->
+       begin match jdg with
+       | JudgementIsType jdg -> check_is_type_boundary jdg bdry
+       | JudgementIsTerm _ | JudgementEqType _ | JudgementEqTerm _ -> false
+       end
+
+    | BoundaryIsTerm bdry ->
+       begin match jdg with
+       | JudgementIsTerm jdg -> check_is_term_boundary sgn jdg bdry
+       | JudgementIsType _ | JudgementEqType _ | JudgementEqTerm _ -> false
+       end
+
+    | BoundaryEqType bdry ->
+       begin match jdg with
+       | JudgementEqType jdg -> check_eq_type_boundary jdg bdry
+       | JudgementIsType _ | JudgementIsTerm _ | JudgementEqTerm _ -> false
+       end
+
+    | BoundaryEqTerm bdry ->
+       begin match jdg with
+       | JudgementEqTerm jdg -> check_eq_term_boundary jdg bdry
+       | JudgementIsType _ | JudgementIsTerm _ | JudgementEqType _ -> false
+       end
+
+
 let abstraction eq_v e e' = e == e' || abstraction eq_v e e'

--- a/src/nucleus/alpha_equal.ml
+++ b/src/nucleus/alpha_equal.ml
@@ -44,7 +44,7 @@ and is_term e1 e2 =
   end
 
 and abstraction
-  : 'a 'b . ('a -> 'b -> bool) -> 'a abstraction -> 'b abstraction -> bool
+  : 'a 'a . ('a -> 'a -> bool) -> 'a abstraction -> 'a abstraction -> bool
   = fun equal_v e e' ->
     match e, e' with
 
@@ -117,45 +117,5 @@ let boundary jdg1 jdg2 =
   | BoundaryEqType _, (BoundaryIsType _ | BoundaryIsTerm _ | BoundaryEqTerm _)
   | BoundaryEqTerm _, (BoundaryIsType _ | BoundaryIsTerm _ | BoundaryEqType _) ->
      false
-
-let check_is_type_boundary abstr bdry = true
-
-let check_is_term_boundary sgn e t =
-  is_type (Sanity.type_of_term sgn e) t
-
-let check_eq_type_boundary (EqType (_asmp, t1, t2)) (u1, u2) =
-  is_type t1 u1 && is_type t2 u2
-
-let check_eq_term_boundary (EqTerm (_asmp, a, b, t)) (a', b', t') =
-  is_type t t' && is_term a a' && is_term b b'
-
-let check_judgement_boundary sgn jdg bdry =
-  match bdry with
-    | BoundaryIsType bdry ->
-       begin match jdg with
-       | JudgementIsType jdg -> check_is_type_boundary jdg bdry
-       | JudgementIsTerm _ | JudgementEqType _ | JudgementEqTerm _ -> false
-       end
-
-    | BoundaryIsTerm bdry ->
-       begin match jdg with
-       | JudgementIsTerm jdg -> check_is_term_boundary sgn jdg bdry
-       | JudgementIsType _ | JudgementEqType _ | JudgementEqTerm _ -> false
-       end
-
-    | BoundaryEqType bdry ->
-       begin match jdg with
-       | JudgementEqType jdg -> check_eq_type_boundary jdg bdry
-       | JudgementIsType _ | JudgementIsTerm _ | JudgementEqTerm _ -> false
-       end
-
-    | BoundaryEqTerm bdry ->
-       begin match jdg with
-       | JudgementEqTerm jdg -> check_eq_term_boundary jdg bdry
-       | JudgementIsType _ | JudgementIsTerm _ | JudgementEqType _ -> false
-       end
-
-let check_judgement_boundary_abstraction sgn =
-  abstraction (check_judgement_boundary sgn)
 
 (* let abstraction eq_v e e' = e == e' || abstraction eq_v e e' *)

--- a/src/nucleus/alpha_equal.ml
+++ b/src/nucleus/alpha_equal.ml
@@ -71,17 +71,17 @@ and arguments args args' =
 
   | [], [] -> true
 
-  | (ArgumentIsTerm e) :: args, (ArgumentIsTerm e') :: args' ->
+  | (JudgementIsTerm e) :: args, (JudgementIsTerm e') :: args' ->
      abstraction is_term e e' && arguments args args'
 
-  | (ArgumentIsType t) :: args, (ArgumentIsType t') :: args' ->
+  | (JudgementIsType t) :: args, (JudgementIsType t') :: args' ->
      abstraction is_type t t' && arguments args args'
 
-  | ArgumentEqType _ :: args, ArgumentEqType _ :: args' -> arguments args args'
+  | JudgementEqType _ :: args, JudgementEqType _ :: args' -> arguments args args'
 
-  | ArgumentEqTerm _ :: args, ArgumentEqTerm _ :: args' -> arguments args args'
+  | JudgementEqTerm _ :: args, JudgementEqTerm _ :: args' -> arguments args args'
 
-  | (ArgumentIsTerm _ | ArgumentIsType _ | ArgumentEqType _ | ArgumentEqTerm _)::_, _::_
+  | (JudgementIsTerm _ | JudgementIsType _ | JudgementEqType _ | JudgementEqTerm _)::_, _::_
 
   | (_::_), []
 

--- a/src/nucleus/apply_abstraction.ml
+++ b/src/nucleus/apply_abstraction.ml
@@ -21,6 +21,9 @@ let apply_eq_type_abstraction sgn abstr e0 =
 let apply_eq_term_abstraction sgn abstr e0 =
   apply_abstraction Instantiate_bound.eq_term sgn abstr e0
 
+let apply_judgement_abstraction sgn abstr e0 =
+  apply_abstraction Instantiate_bound.judgement sgn abstr e0
+
 (* Apply [abstr] to a list of terms of length equal to the abstraction level
    of [abstr]. Verify that the terms to be substituted match the types on the
    abstraction. *)

--- a/src/nucleus/apply_abstraction.ml
+++ b/src/nucleus/apply_abstraction.ml
@@ -30,7 +30,7 @@ let apply_judgement_abstraction sgn abstr e0 =
 let rec fully_apply_abstraction inst_u sgn abstr = function
   | [] ->
      begin match abstr with
-     | NotAbstract eq -> eq
+     | NotAbstract x -> x
      | Abstract _ -> Error.raise TooFewArguments
      end
   | arg :: args ->

--- a/src/nucleus/assumption.ml
+++ b/src/nucleus/assumption.ml
@@ -39,18 +39,11 @@ let add_meta x t asmp = { asmp with meta = Nonce.map_add x t asmp.meta }
 let add_bound k asmp = { asmp with bound = Bound_set.add k asmp.bound }
 
 let union a1 a2 =
-  (* XXX figure out why this is happening, fix it, and remove the code below. *)
-  let f = (fun vtype a t1 t2 ->
-      (if not (t1 == t2)
-       then
-         (Print.error "XXX %s variable %t occurs at physically different types@." vtype (Nonce.print ~parentheses:false a)
-         (* ; assert false  *))
-       else ()) ;
-      Some t1) in
-  let f_free = f "free"
-  in
-  { free = Nonce.map_union f_free a1.free a2.free
-  ; meta = Nonce.map_union (f "is_type_meta") a1.meta a2.meta
+  (* We arbitrarily pick the first type because they're supposed to be equal. It
+     would be more paranoid to check that they are equal and complain if not
+     (this shouldn't happen). *)
+  { free = Nonce.map_union (fun _ t _ -> Some t) a1.free a2.free
+  ; meta = Nonce.map_union (fun _ bdry _ -> Some bdry) a1.meta a2.meta
   ; bound = Bound_set.union a1.bound a2.bound
   }
 

--- a/src/nucleus/assumption.ml
+++ b/src/nucleus/assumption.ml
@@ -44,7 +44,7 @@ let union a1 a2 =
       (if not (t1 == t2)
        then
          (Print.error "XXX %s variable %t occurs at physically different types@." vtype (Nonce.print ~parentheses:false a)
-         ; assert false )
+         (* ; assert false  *))
        else ()) ;
       Some t1) in
   let f_free = f "free"

--- a/src/nucleus/assumption.ml
+++ b/src/nucleus/assumption.ml
@@ -2,18 +2,12 @@ open Nucleus_types
 
 let empty =
   { free = Nonce.map_empty
-  ; is_type_meta = Nonce.map_empty
-  ; is_term_meta = Nonce.map_empty
-  ; eq_type_meta = Nonce.map_empty
-  ; eq_term_meta = Nonce.map_empty
+  ; meta = Nonce.map_empty
   ; bound = Bound_set.empty }
 
-let is_empty {free; is_type_meta; is_term_meta; eq_type_meta; eq_term_meta; bound } =
+let is_empty {free; meta; bound } =
   Nonce.map_is_empty free
-  && Nonce.map_is_empty is_type_meta
-  && Nonce.map_is_empty is_term_meta
-  && Nonce.map_is_empty eq_type_meta
-  && Nonce.map_is_empty eq_term_meta
+  && Nonce.map_is_empty meta
   && Bound_set.is_empty bound
 
 let mem_atom x s = Nonce.map_mem x s.free
@@ -40,10 +34,7 @@ let singleton_bound k = { empty with bound = Bound_set.singleton k }
 
 let add_free x t asmp = { asmp with free = Nonce.map_add x t asmp.free }
 
-let add_is_type_meta x t asmp = { asmp with is_type_meta = Nonce.map_add x t asmp.is_type_meta }
-let add_is_term_meta x t asmp = { asmp with is_term_meta = Nonce.map_add x t asmp.is_term_meta }
-let add_eq_type_meta x t asmp = { asmp with eq_type_meta = Nonce.map_add x t asmp.eq_type_meta }
-let add_eq_term_meta x t asmp = { asmp with eq_term_meta = Nonce.map_add x t asmp.eq_term_meta }
+let add_meta x t asmp = { asmp with meta = Nonce.map_add x t asmp.meta }
 
 let add_bound k asmp = { asmp with bound = Bound_set.add k asmp.bound }
 
@@ -59,10 +50,7 @@ let union a1 a2 =
   let f_free = f "free"
   in
   { free = Nonce.map_union f_free a1.free a2.free
-  ; is_type_meta = Nonce.map_union (f "is_type_meta") a1.is_type_meta a2.is_type_meta
-  ; is_term_meta = Nonce.map_union (f "is_term_meta") a1.is_term_meta a2.is_term_meta
-  ; eq_type_meta = Nonce.map_union (f "eq_type_meta") a1.eq_type_meta a2.eq_type_meta
-  ; eq_term_meta = Nonce.map_union (f "eq_term_meta") a1.eq_term_meta a2.eq_term_meta
+  ; meta = Nonce.map_union (f "is_type_meta") a1.meta a2.meta
   ; bound = Bound_set.union a1.bound a2.bound
   }
 

--- a/src/nucleus/boundary.ml
+++ b/src/nucleus/boundary.ml
@@ -1,0 +1,37 @@
+open Nucleus_types
+
+(** Conversion between abstracted general and particular boundaries. *)
+
+exception ConversionError
+
+let rec convert f = function
+  | NotAbstract a -> NotAbstract (f a)
+  | Abstract (atm, abstr) -> Abstract (atm, convert f abstr)
+
+let as_is_type_abstraction abstr =
+  try
+    Some
+      (convert
+         (function
+          | BoundaryIsType () -> ()
+          | BoundaryIsTerm _ | BoundaryEqType _ | BoundaryEqTerm _ -> raise ConversionError)
+         abstr)
+  with
+  | ConversionError -> None
+
+let as_is_term_abstraction abstr =
+  try
+    Some
+      (convert
+         (function
+          | BoundaryIsTerm e -> e
+          | BoundaryIsType _ | BoundaryEqType _ | BoundaryEqTerm _ -> raise ConversionError)
+         abstr)
+  with
+  | ConversionError -> None
+
+let from_is_type_abstraction abstr =
+  convert (fun t -> BoundaryIsType t) abstr
+
+let from_is_term_abstraction abstr =
+  convert (fun t -> BoundaryIsTerm t) abstr

--- a/src/nucleus/check.ml
+++ b/src/nucleus/check.ml
@@ -1,0 +1,50 @@
+open Nucleus_types
+
+(** Checking judgements against their boundaries *)
+
+let is_type_boundary abstr bdry = true
+
+let is_term_boundary sgn e t =
+  Alpha_equal.is_type (Sanity.type_of_term sgn e) t
+
+let eq_type_boundary (EqType (_asmp, t1, t2)) (u1, u2) =
+  Alpha_equal.is_type t1 u1 && Alpha_equal.is_type t2 u2
+
+let eq_term_boundary (EqTerm (_asmp, a, b, t)) (a', b', t') =
+  Alpha_equal.is_type t t' && Alpha_equal.is_term a a' && Alpha_equal.is_term b b'
+
+let judgement_boundary sgn jdg bdry =
+  match bdry with
+    | BoundaryIsType bdry ->
+       begin match jdg with
+       | JudgementIsType jdg -> is_type_boundary jdg bdry
+       | JudgementIsTerm _ | JudgementEqType _ | JudgementEqTerm _ -> false
+       end
+
+    | BoundaryIsTerm bdry ->
+       begin match jdg with
+       | JudgementIsTerm jdg -> is_term_boundary sgn jdg bdry
+       | JudgementIsType _ | JudgementEqType _ | JudgementEqTerm _ -> false
+       end
+
+    | BoundaryEqType bdry ->
+       begin match jdg with
+       | JudgementEqType jdg -> eq_type_boundary jdg bdry
+       | JudgementIsType _ | JudgementIsTerm _ | JudgementEqTerm _ -> false
+       end
+
+    | BoundaryEqTerm bdry ->
+       begin match jdg with
+       | JudgementEqTerm jdg -> eq_term_boundary jdg bdry
+       | JudgementIsType _ | JudgementIsTerm _ | JudgementEqType _ -> false
+       end
+
+let rec judgement_boundary_abstraction sgn abstr_jdg abstr_bdry =
+  match Invert.invert_abstractions Instantiate_bound.judgement Instantiate_bound.boundary abstr_jdg abstr_bdry with
+  | None -> false
+
+  | Some (Stumps_NotAbstract (jdg, bdry)) ->
+     judgement_boundary sgn jdg bdry
+
+  | Some (Stumps_Abstract (_atm, abstr_jdg, abstr_bdry)) ->
+     judgement_boundary_abstraction sgn abstr_jdg abstr_bdry

--- a/src/nucleus/collect_assumptions.ml
+++ b/src/nucleus/collect_assumptions.ml
@@ -72,15 +72,15 @@ and term_arguments ~lvl ts =
 and arguments ~lvl args =
   let rec fold asmp = function
     | [] -> asmp
-    | arg :: args -> Assumption.union (argument ~lvl arg) (fold asmp args)
+    | arg :: args -> Assumption.union (abstraction argument ~lvl arg) (fold asmp args)
   in
   fold Assumption.empty args
 
 and argument ?(lvl=0) = function
-  | JudgementIsType abstr -> abstraction is_type ~lvl abstr
-  | JudgementIsTerm abstr -> abstraction is_term ~lvl abstr
-  | JudgementEqType abstr -> abstraction eq_type ~lvl abstr
-  | JudgementEqTerm abstr -> abstraction eq_term ~lvl abstr
+  | JudgementIsType t -> is_type ~lvl t
+  | JudgementIsTerm e -> is_term ~lvl e
+  | JudgementEqType eq -> eq_type ~lvl eq
+  | JudgementEqTerm eq -> eq_term ~lvl eq
 
 and assumptions ?(lvl=0) asmp = Assumption.at_level ~lvl asmp
 

--- a/src/nucleus/collect_assumptions.ml
+++ b/src/nucleus/collect_assumptions.ml
@@ -47,11 +47,13 @@ and eq_term ?(lvl=0) (EqTerm (asmp, e1, e2, t)) =
 
 and is_type_meta ~lvl {meta_nonce; meta_type} =
   let asmp = abstraction (fun ?lvl () -> Assumption.empty) ~lvl meta_type in
-  Assumption.add_is_type_meta meta_nonce meta_type asmp
+  let meta_type = Boundary.from_is_type_abstraction meta_type in
+  Assumption.add_meta meta_nonce meta_type asmp
 
 and is_term_meta ~lvl {meta_nonce; meta_type} =
   let asmp = abstraction is_type ~lvl meta_type in
-  Assumption.add_is_term_meta meta_nonce meta_type asmp
+  let meta_type = Boundary.from_is_term_abstraction meta_type in
+  Assumption.add_meta meta_nonce meta_type asmp
 
 and abstraction
   : 'a . (?lvl:bound -> 'a -> assumption) ->

--- a/src/nucleus/collect_assumptions.ml
+++ b/src/nucleus/collect_assumptions.ml
@@ -77,10 +77,10 @@ and arguments ~lvl args =
   fold Assumption.empty args
 
 and argument ?(lvl=0) = function
-  | ArgumentIsType abstr -> abstraction is_type ~lvl abstr
-  | ArgumentIsTerm abstr -> abstraction is_term ~lvl abstr
-  | ArgumentEqType abstr -> abstraction eq_type ~lvl abstr
-  | ArgumentEqTerm abstr -> abstraction eq_term ~lvl abstr
+  | JudgementIsType abstr -> abstraction is_type ~lvl abstr
+  | JudgementIsTerm abstr -> abstraction is_term ~lvl abstr
+  | JudgementEqType abstr -> abstraction eq_type ~lvl abstr
+  | JudgementEqTerm abstr -> abstraction eq_term ~lvl abstr
 
 and assumptions ?(lvl=0) asmp = Assumption.at_level ~lvl asmp
 

--- a/src/nucleus/collect_assumptions.ml
+++ b/src/nucleus/collect_assumptions.ml
@@ -72,11 +72,11 @@ and term_arguments ~lvl ts =
 and arguments ~lvl args =
   let rec fold asmp = function
     | [] -> asmp
-    | arg :: args -> Assumption.union (abstraction argument ~lvl arg) (fold asmp args)
+    | arg :: args -> Assumption.union (abstraction judgement ~lvl arg) (fold asmp args)
   in
   fold Assumption.empty args
 
-and argument ?(lvl=0) = function
+and judgement ?(lvl=0) = function
   | JudgementIsType t -> is_type ~lvl t
   | JudgementIsTerm e -> is_term ~lvl e
   | JudgementEqType eq -> eq_type ~lvl eq

--- a/src/nucleus/congruence.ml
+++ b/src/nucleus/congruence.ml
@@ -26,7 +26,7 @@ let process_congruence_args args =
             Alpha_equal.is_type t1 t1' && Alpha_equal.is_type t2 t2')
          t1 t2 eq ;
        let asmp_out = Assumption.union asmp_out (Collect_assumptions.abstraction Collect_assumptions.eq_type eq)
-       in fold asmp_out (ArgumentIsType t1 :: lhs) (ArgumentIsType t2 :: rhs) eqs
+       in fold asmp_out (JudgementIsType t1 :: lhs) (JudgementIsType t2 :: rhs) eqs
 
     | CongrIsTerm (e1, e2, eq) :: eqs ->
        check_endpoints
@@ -34,16 +34,16 @@ let process_congruence_args args =
             Alpha_equal.is_term e1 e1' && Alpha_equal.is_term e2 e2')
          e1 e2 eq ;
        let asmp_out = Assumption.union asmp_out (Collect_assumptions.abstraction Collect_assumptions.eq_term eq)
-       in fold asmp_out (ArgumentIsTerm e1 :: lhs) (ArgumentIsTerm e2 :: rhs) eqs
+       in fold asmp_out (JudgementIsTerm e1 :: lhs) (JudgementIsTerm e2 :: rhs) eqs
 
     | CongrEqType (eq1, eq2) :: eqs ->
-       let l = ArgumentEqType eq1
-       and r = ArgumentEqType eq2
+       let l = JudgementEqType eq1
+       and r = JudgementEqType eq2
        in fold asmp_out (l :: lhs) (r :: rhs) eqs
 
     | CongrEqTerm (eq1, eq2) :: eqs ->
-       let l = ArgumentEqTerm eq1
-       and r = ArgumentEqTerm eq2
+       let l = JudgementEqTerm eq1
+       and r = JudgementEqTerm eq2
        in fold asmp_out (l :: lhs) (r :: rhs) eqs
 
   in fold Assumption.empty [] [] args

--- a/src/nucleus/congruence.ml
+++ b/src/nucleus/congruence.ml
@@ -26,7 +26,7 @@ let process_congruence_args args =
             Alpha_equal.is_type t1 t1' && Alpha_equal.is_type t2 t2')
          t1 t2 eq ;
        let asmp_out = Assumption.union asmp_out (Collect_assumptions.abstraction Collect_assumptions.eq_type eq)
-       in fold asmp_out (JudgementIsType t1 :: lhs) (JudgementIsType t2 :: rhs) eqs
+       in fold asmp_out (Judgement.from_is_type_abstraction t1 :: lhs) (Judgement.from_is_type_abstraction t2 :: rhs) eqs
 
     | CongrIsTerm (e1, e2, eq) :: eqs ->
        check_endpoints
@@ -34,16 +34,16 @@ let process_congruence_args args =
             Alpha_equal.is_term e1 e1' && Alpha_equal.is_term e2 e2')
          e1 e2 eq ;
        let asmp_out = Assumption.union asmp_out (Collect_assumptions.abstraction Collect_assumptions.eq_term eq)
-       in fold asmp_out (JudgementIsTerm e1 :: lhs) (JudgementIsTerm e2 :: rhs) eqs
+       in fold asmp_out (Judgement.from_is_term_abstraction e1 :: lhs) (Judgement.from_is_term_abstraction e2 :: rhs) eqs
 
     | CongrEqType (eq1, eq2) :: eqs ->
-       let l = JudgementEqType eq1
-       and r = JudgementEqType eq2
+       let l = Judgement.from_eq_type_abstraction eq1
+       and r = Judgement.from_eq_type_abstraction  eq2
        in fold asmp_out (l :: lhs) (r :: rhs) eqs
 
     | CongrEqTerm (eq1, eq2) :: eqs ->
-       let l = JudgementEqTerm eq1
-       and r = JudgementEqTerm eq2
+       let l = Judgement.from_eq_term_abstraction eq1
+       and r = Judgement.from_eq_term_abstraction eq2
        in fold asmp_out (l :: lhs) (r :: rhs) eqs
 
   in fold Assumption.empty [] [] args

--- a/src/nucleus/convert.ml
+++ b/src/nucleus/convert.ml
@@ -1,0 +1,51 @@
+open Nucleus_types
+
+exception Convert_fail
+
+let opt_fail = function
+  | None -> raise Convert_fail
+  | Some x -> x
+
+let rec abstraction converter jdg eq =
+  match jdg, eq with
+
+  | NotAbstract jdg, NotAbstract eq ->
+     NotAbstract (converter jdg eq)
+
+  | Abstract ({atom_type=u;_} as x, jdg), Abstract ({atom_type=v;_}, eq) ->
+     begin match Alpha_equal.is_type u v with
+     | false -> raise Convert_fail
+     | true -> Abstract (x, abstraction converter jdg eq)
+     end
+
+  | NotAbstract _, Abstract _
+  | Abstract _, NotAbstract _ -> raise Convert_fail
+
+let term sgn e eq = opt_fail (Form.form_is_term_convert_opt sgn e eq)
+
+let eq_term eq1 eq2 = opt_fail (Form.form_eq_term_convert_opt eq1 eq2)
+
+let judgement sgn jdg eq =
+  match jdg with
+  | JudgementIsTerm e -> JudgementIsTerm (opt_fail (Form.form_is_term_convert_opt sgn e eq))
+  | JudgementEqTerm eq' -> JudgementEqTerm (opt_fail (Form.form_eq_term_convert_opt eq' eq))
+  | JudgementEqType _ -> raise Convert_fail
+  | JudgementIsType _ -> raise Convert_fail
+
+let term_abstraction sgn e eq =
+  try
+    Some (abstraction (term sgn) e eq)
+  with
+  | Convert_fail -> None
+
+let eq_term_abstraction eq1 eq2 =
+  try
+    Some (abstraction eq_term eq1 eq2)
+  with
+  | Convert_fail -> None
+
+let judgement_abstraction sgn jdg eq =
+  try
+    Some (abstraction (judgement sgn) jdg eq)
+  with
+  | Convert_fail -> None

--- a/src/nucleus/convert.ml
+++ b/src/nucleus/convert.ml
@@ -6,20 +6,17 @@ let opt_fail = function
   | None -> raise Convert_fail
   | Some x -> x
 
-let rec abstraction converter jdg eq =
-  match jdg, eq with
+let rec abstraction inst_u abstr_v converter u eq =
+  match Invert.invert_abstractions inst_u Instantiate_bound.eq_type u eq with
+  | None -> raise Convert_fail
 
-  | NotAbstract jdg, NotAbstract eq ->
-     NotAbstract (converter jdg eq)
+  | Some (Stumps_NotAbstract (u, eq)) ->
+     Mk.not_abstract (converter u eq)
 
-  | Abstract ({atom_type=u;_} as x, jdg), Abstract ({atom_type=v;_}, eq) ->
-     begin match Alpha_equal.is_type u v with
-     | false -> raise Convert_fail
-     | true -> Abstract (x, abstraction converter jdg eq)
-     end
-
-  | NotAbstract _, Abstract _
-  | Abstract _, NotAbstract _ -> raise Convert_fail
+  | Some (Stumps_Abstract (a, u, eq)) ->
+     let v = abstraction inst_u abstr_v converter u eq in
+     let v = Abstract.abstraction abstr_v a.atom_nonce v in
+     Mk.abstract a v
 
 let term sgn e eq = opt_fail (Form.form_is_term_convert_opt sgn e eq)
 
@@ -34,18 +31,18 @@ let judgement sgn jdg eq =
 
 let term_abstraction sgn e eq =
   try
-    Some (abstraction (term sgn) e eq)
+    Some (abstraction Instantiate_bound.is_term Abstract.is_term (term sgn) e eq)
   with
   | Convert_fail -> None
 
 let eq_term_abstraction eq1 eq2 =
   try
-    Some (abstraction eq_term eq1 eq2)
+    Some (abstraction Instantiate_bound.eq_term Abstract.eq_term eq_term eq1 eq2)
   with
   | Convert_fail -> None
 
 let judgement_abstraction sgn jdg eq =
   try
-    Some (abstraction (judgement sgn) jdg eq)
+    Some (abstraction Instantiate_bound.judgement Abstract.judgement (judgement sgn) jdg eq)
   with
   | Convert_fail -> None

--- a/src/nucleus/form.ml
+++ b/src/nucleus/form.ml
@@ -98,15 +98,15 @@ let rap_boundary {rap_boundary;_} = rap_boundary
 (* Apply the given partially applied rule instance to the given argument. The result
    is again a partially applied rule (a special case of which is a fully applied rule). *)
 let rap_apply sgn {rap_arguments; rap_boundary; rap_premises; rap_constructor} arg =
-  if not (Alpha_equal.abstraction (Alpha_equal.check_judgement_boundary sgn) arg rap_boundary)
+  if not (Check.judgement_boundary_abstraction sgn arg rap_boundary)
   then Error.raise InvalidArgument ;
   let rap_arguments = arg :: rap_arguments in
   match rap_premises with
-  | [] -> RapDone (rap_constructor rap_arguments)
+  | [] ->
+     RapDone (rap_constructor rap_arguments)
   | p :: rap_premises ->
-     (** XXX Should we not use the available arguments instead of [] in the line below? *)
-     let rap_boundary = (Instantiate_meta.abstraction Form_rule.instantiate_premise ~lvl:0 [] p) in
-     RapMore { rap_arguments
+     let rap_boundary = (Instantiate_meta.abstraction Form_rule.instantiate_premise ~lvl:0 rap_arguments p) in
+       RapMore { rap_arguments
              ; rap_boundary
              ; rap_premises
              ; rap_constructor }

--- a/src/nucleus/form.ml
+++ b/src/nucleus/form.ml
@@ -104,10 +104,10 @@ let form_rap_eq_term sgn c =
 
 let rap_apply sgn {rap_arguments; rap_boundary; rap_premises; rap_constructor} arg =
   if not (match rap_boundary, arg with
-          | BoundaryIsType bdry, ArgumentIsType arg -> Alpha_equal.check_is_type_boundary arg bdry
-          | BoundaryIsTerm bdry, ArgumentIsTerm arg -> Alpha_equal.check_is_term_boundary sgn arg bdry
-          | BoundaryEqType bdry, ArgumentEqType arg -> Alpha_equal.check_eq_type_boundary arg bdry
-          | BoundaryEqTerm bdry, ArgumentEqTerm arg -> Alpha_equal.check_eq_term_boundary arg bdry
+          | BoundaryIsType bdry, JudgementIsType arg -> Alpha_equal.check_is_type_boundary arg bdry
+          | BoundaryIsTerm bdry, JudgementIsTerm arg -> Alpha_equal.check_is_term_boundary sgn arg bdry
+          | BoundaryEqType bdry, JudgementEqType arg -> Alpha_equal.check_eq_type_boundary arg bdry
+          | BoundaryEqTerm bdry, JudgementEqTerm arg -> Alpha_equal.check_eq_term_boundary arg bdry
           | _, _ -> false)
   then Error.raise InvalidArgument ;
   let rap_arguments = arg :: rap_arguments in

--- a/src/nucleus/form_rule.ml
+++ b/src/nucleus/form_rule.ml
@@ -112,16 +112,13 @@ and mk_rule_is_term metas = function
      Rule.TermBound k
 
   | TermConvert (e, asmp, t) ->
-     let {free; is_type_meta; is_term_meta; eq_type_meta; eq_term_meta; bound} = asmp
+     let {free; meta; bound} = asmp
      (* NB: We do not check that the types of the metas match because we assume that
         the type of a meta never changes. *)
      and metas_set = Nonce.set_of_list metas in
      let mem_metas_set mv _bnd = Nonce.set_mem mv metas_set in
      begin match Nonce.map_is_empty free
-                 && Nonce.map_for_all mem_metas_set is_type_meta
-                 && Nonce.map_for_all mem_metas_set is_term_meta
-                 && Nonce.map_for_all mem_metas_set eq_type_meta
-                 && Nonce.map_for_all mem_metas_set eq_term_meta
+                 && Nonce.map_for_all mem_metas_set meta
                  && Bound_set.is_empty bound
      with
      | true -> mk_rule_is_term metas e

--- a/src/nucleus/form_rule.ml
+++ b/src/nucleus/form_rule.ml
@@ -23,16 +23,16 @@ let check_judgement ~lvl sgn metas arg prem =
   match arg, instantiate_premise ~lvl metas prem with
 
   | JudgementIsType abstr, BoundaryIsType bdry ->
-     Alpha_equal.check_is_type_boundary abstr bdry
+     Check.is_type_boundary abstr bdry
 
   | JudgementIsTerm e, BoundaryIsTerm t ->
-     Alpha_equal.check_is_term_boundary sgn e t
+     Check.is_term_boundary sgn e t
 
   | JudgementEqType eq, BoundaryEqType bdry ->
-     Alpha_equal.check_eq_type_boundary eq bdry
+     Check.eq_type_boundary eq bdry
 
   | JudgementEqTerm eq, BoundaryEqTerm bdry  ->
-     Alpha_equal.check_eq_term_boundary eq bdry
+     Check.eq_term_boundary eq bdry
 
   | (JudgementIsTerm _ | JudgementEqType _ | JudgementEqTerm _) , (BoundaryIsType _ as bdry)
   | (JudgementIsType _ | JudgementEqType _ | JudgementEqTerm _) , (BoundaryIsTerm _ as bdry)

--- a/src/nucleus/form_rule.ml
+++ b/src/nucleus/form_rule.ml
@@ -34,36 +34,36 @@ let instantiate_premise metas prem =
 let check_argument sgn metas arg prem =
   match arg, instantiate_premise metas prem with
 
-  | ArgumentIsType abstr, BoundaryIsType bdry ->
+  | JudgementIsType abstr, BoundaryIsType bdry ->
      Alpha_equal.check_is_type_boundary abstr bdry
 
-  | ArgumentIsTerm abstr, BoundaryIsTerm bdry  ->
+  | JudgementIsTerm abstr, BoundaryIsTerm bdry  ->
      Alpha_equal.check_is_term_boundary sgn abstr bdry
 
-  | ArgumentEqType abstr, BoundaryEqType bdry ->
+  | JudgementEqType abstr, BoundaryEqType bdry ->
      Alpha_equal.check_eq_type_boundary abstr bdry
 
-  | ArgumentEqTerm abstr, BoundaryEqTerm bdry  ->
+  | JudgementEqTerm abstr, BoundaryEqTerm bdry  ->
      Alpha_equal.check_eq_term_boundary abstr bdry
 
-  | (ArgumentIsTerm _ | ArgumentEqType _ | ArgumentEqTerm _) , (BoundaryIsType _ as bdry)
-  | (ArgumentIsType _ | ArgumentEqType _ | ArgumentEqTerm _) , (BoundaryIsTerm _ as bdry)
-  | (ArgumentIsType _ | ArgumentIsTerm _ | ArgumentEqTerm _) , (BoundaryEqType _ as bdry)
-  | (ArgumentIsType _ | ArgumentIsTerm _ | ArgumentEqType _) , (BoundaryEqTerm _ as bdry) ->
+  | (JudgementIsTerm _ | JudgementEqType _ | JudgementEqTerm _) , (BoundaryIsType _ as bdry)
+  | (JudgementIsType _ | JudgementEqType _ | JudgementEqTerm _) , (BoundaryIsTerm _ as bdry)
+  | (JudgementIsType _ | JudgementIsTerm _ | JudgementEqTerm _) , (BoundaryEqType _ as bdry)
+  | (JudgementIsType _ | JudgementIsTerm _ | JudgementEqType _) , (BoundaryEqTerm _ as bdry) ->
      Error.raise (ArgumentExpected bdry)
 
 let arg_of_argument = function
-  | ArgumentIsType t -> Mk.arg_is_type t
-  | ArgumentIsTerm e -> Mk.arg_is_term e
-  | ArgumentEqType eq -> Mk.arg_eq_type eq
-  | ArgumentEqTerm eq-> Mk.arg_eq_term eq
+  | JudgementIsType t -> Mk.arg_is_type t
+  | JudgementIsTerm e -> Mk.arg_is_term e
+  | JudgementEqType eq -> Mk.arg_eq_type eq
+  | JudgementEqTerm eq-> Mk.arg_eq_term eq
 
-let match_argument sgn metas (s : Rule.premise) (p : argument) : argument =
+let match_argument sgn metas (s : Rule.premise) (p : judgement) : judgement =
   failwith "form_rule match_argument shouldn't be needed"
   (* check_argument sgn metas s p ;
    * arg_of_argument p *)
 
-let match_arguments sgn (premises : Rule.premise list) (arguments : argument list) =
+let match_arguments sgn (premises : Rule.premise list) (arguments : judgement list) =
   let rec fold args_out = function
     | [], [] ->
        (* The arguments must _not_ be reversed because we refer to them by meta-variable
@@ -159,21 +159,21 @@ and mk_rule_assumptions metas asmp =
 
 and mk_rule_arg metas = function
 
-  | ArgumentIsType abstr ->
+  | JudgementIsType abstr ->
      let abstr = mk_rule_abstraction mk_rule_is_type metas abstr in
-     Rule.ArgumentIsType abstr
+     Rule.JudgementIsType abstr
 
-  | ArgumentIsTerm abstr ->
+  | JudgementIsTerm abstr ->
      let abstr = mk_rule_abstraction mk_rule_is_term metas abstr in
-     Rule.ArgumentIsTerm abstr
+     Rule.JudgementIsTerm abstr
 
-  | ArgumentEqType abstr ->
+  | JudgementEqType abstr ->
      let abstr = mk_rule_abstraction mk_rule_eq_type metas abstr in
-     Rule.ArgumentEqType abstr
+     Rule.JudgementEqType abstr
 
-  | ArgumentEqTerm abstr ->
+  | JudgementEqTerm abstr ->
      let abstr = mk_rule_abstraction mk_rule_eq_term metas abstr in
-     Rule.ArgumentEqTerm abstr
+     Rule.JudgementEqTerm abstr
 
 and mk_rule_args metas args =
   List.map (mk_rule_arg metas) args

--- a/src/nucleus/indices.mli
+++ b/src/nucleus/indices.mli
@@ -1,5 +1,5 @@
 open Nucleus_types
-val nth : indices -> int -> argument
-val of_list : argument list -> indices
-val to_list : indices -> argument list
-val cons : argument -> indices -> indices
+val nth : indices -> int -> judgement
+val of_list : judgement list -> indices
+val to_list : indices -> judgement list
+val cons : judgement -> indices -> indices

--- a/src/nucleus/indices.mli
+++ b/src/nucleus/indices.mli
@@ -1,5 +1,5 @@
 open Nucleus_types
-val nth : indices -> int -> judgement
-val of_list : judgement list -> indices
-val to_list : indices -> judgement list
-val cons : judgement -> indices -> indices
+val nth : 'a indices -> int -> 'a
+val of_list : 'a list -> 'a indices
+val to_list : 'a indices -> 'a list
+val cons : 'a -> 'a indices -> 'a indices

--- a/src/nucleus/instantiate_bound.ml
+++ b/src/nucleus/instantiate_bound.ml
@@ -76,7 +76,7 @@ and abstraction
      Abstract ({atom_nonce=x; atom_type=u}, abstr)
 
 and arguments e0 ~lvl args =
-  List.map (judgement e0 ~lvl) args
+  List.map (abstraction judgement e0 ~lvl) args
 
 and term_arguments e0 ~lvl args =
   List.map (is_term e0 ~lvl) args
@@ -84,20 +84,16 @@ and term_arguments e0 ~lvl args =
 and judgement e0 ?(lvl=0) = function
 
     | JudgementIsType t ->
-       let t = abstraction is_type e0 ~lvl t in
-       JudgementIsType t
+       JudgementIsType (is_type e0 ~lvl t)
 
     | JudgementIsTerm e ->
-       let e = abstraction is_term e0 ~lvl e in
-       JudgementIsTerm e
+       JudgementIsTerm (is_term e0 ~lvl e)
 
     | JudgementEqType asmp ->
-       let asmp = abstraction eq_type e0 ~lvl asmp in
-       JudgementEqType asmp
+       JudgementEqType (eq_type e0 ~lvl asmp)
 
     | JudgementEqTerm asmp ->
-       let asmp = abstraction eq_term e0 ~lvl asmp in
-       JudgementEqTerm asmp
+       JudgementEqTerm (eq_term e0 ~lvl asmp)
 
 
 (* [instantiate_fully ?lvl es t] replaces bound variables [k] for
@@ -176,27 +172,23 @@ and abstraction_fully
      in Abstract ({atom_nonce=x; atom_type=t}, abstr)
 
 and arguments_fully ?(lvl=0) es args =
-  List.map (argument_fully ~lvl es) args
+  List.map (abstraction_fully judgement_fully ~lvl es) args
 
 and term_arguments_fully ?(lvl=0) es args =
   List.map (is_term_fully ~lvl es) args
 
-and argument_fully ?(lvl=0) es = function
-  | JudgementIsType abstr ->
-     let abstr = abstraction_fully is_type_fully ~lvl es abstr in
-     JudgementIsType abstr
+and judgement_fully ?(lvl=0) es = function
+  | JudgementIsType t ->
+     JudgementIsType (is_type_fully ~lvl es t)
 
-  | JudgementIsTerm abstr ->
-     let abstr = abstraction_fully is_term_fully ~lvl es abstr in
-     JudgementIsTerm abstr
+  | JudgementIsTerm e ->
+     JudgementIsTerm (is_term_fully ~lvl es e)
 
-  | JudgementEqType abstr ->
-     let abstr = abstraction_fully eq_type_fully ~lvl es abstr in
-     JudgementEqType abstr
+  | JudgementEqType eq ->
+     JudgementEqType (eq_type_fully ~lvl es eq)
 
-  | JudgementEqTerm abstr ->
-     let abstr = abstraction_fully eq_term_fully ~lvl es abstr in
-     JudgementEqTerm abstr
+  | JudgementEqTerm eq ->
+     JudgementEqTerm (eq_term_fully ~lvl es eq)
 
 let is_type_boundary _ ?(lvl=0) () = ()
 

--- a/src/nucleus/instantiate_bound.ml
+++ b/src/nucleus/instantiate_bound.ml
@@ -76,12 +76,12 @@ and abstraction
      Abstract ({atom_nonce=x; atom_type=u}, abstr)
 
 and arguments e0 ~lvl args =
-  List.map (argument e0 ~lvl) args
+  List.map (judgement e0 ~lvl) args
 
 and term_arguments e0 ~lvl args =
   List.map (is_term e0 ~lvl) args
 
-and argument e0 ?(lvl=0) = function
+and judgement e0 ?(lvl=0) = function
 
     | JudgementIsType t ->
        let t = abstraction is_type e0 ~lvl t in

--- a/src/nucleus/instantiate_bound.ml
+++ b/src/nucleus/instantiate_bound.ml
@@ -197,3 +197,19 @@ and argument_fully ?(lvl=0) es = function
   | ArgumentEqTerm abstr ->
      let abstr = abstraction_fully eq_term_fully ~lvl es abstr in
      ArgumentEqTerm abstr
+
+let is_type_boundary _ ?(lvl=0) () = ()
+
+let is_term_boundary e0 ?(lvl=0) t =
+  is_type e0 ~lvl t
+
+let eq_type_boundary e0 ?(lvl=0) (t1, t2) =
+  let t1 = is_type e0 ~lvl t1
+  and t2 = is_type e0 ~lvl t2 in
+  (t1, t2)
+
+let eq_term_boundary e0 ?(lvl=0) (e1, e2, t) =
+  let e1 = is_term e0 ~lvl e1
+  and e2 = is_term e0 ~lvl e2
+  and t = is_type e0 ~lvl t in
+  (e1, e2, t)

--- a/src/nucleus/instantiate_bound.ml
+++ b/src/nucleus/instantiate_bound.ml
@@ -205,3 +205,16 @@ let eq_term_boundary e0 ?(lvl=0) (e1, e2, t) =
   and e2 = is_term e0 ~lvl e2
   and t = is_type e0 ~lvl t in
   (e1, e2, t)
+
+let boundary e0 ?(lvl=0) = function
+  | BoundaryIsType () ->
+     BoundaryIsType (is_type_boundary e0 ~lvl ())
+
+  | BoundaryIsTerm t ->
+     BoundaryIsTerm (is_term_boundary e0 ~lvl t)
+
+  | BoundaryEqType (t1, t2) ->
+     BoundaryEqType (eq_type_boundary e0 ~lvl (t1, t2))
+
+  | BoundaryEqTerm (e1, e2, t) ->
+     BoundaryEqTerm (eq_term_boundary e0 ~lvl (e1, e2, t))

--- a/src/nucleus/instantiate_bound.ml
+++ b/src/nucleus/instantiate_bound.ml
@@ -83,21 +83,21 @@ and term_arguments e0 ~lvl args =
 
 and argument e0 ?(lvl=0) = function
 
-    | ArgumentIsType t ->
+    | JudgementIsType t ->
        let t = abstraction is_type e0 ~lvl t in
-       ArgumentIsType t
+       JudgementIsType t
 
-    | ArgumentIsTerm e ->
+    | JudgementIsTerm e ->
        let e = abstraction is_term e0 ~lvl e in
-       ArgumentIsTerm e
+       JudgementIsTerm e
 
-    | ArgumentEqType asmp ->
+    | JudgementEqType asmp ->
        let asmp = abstraction eq_type e0 ~lvl asmp in
-       ArgumentEqType asmp
+       JudgementEqType asmp
 
-    | ArgumentEqTerm asmp ->
+    | JudgementEqTerm asmp ->
        let asmp = abstraction eq_term e0 ~lvl asmp in
-       ArgumentEqTerm asmp
+       JudgementEqTerm asmp
 
 
 (* [instantiate_fully ?lvl es t] replaces bound variables [k] for
@@ -182,21 +182,21 @@ and term_arguments_fully ?(lvl=0) es args =
   List.map (is_term_fully ~lvl es) args
 
 and argument_fully ?(lvl=0) es = function
-  | ArgumentIsType abstr ->
+  | JudgementIsType abstr ->
      let abstr = abstraction_fully is_type_fully ~lvl es abstr in
-     ArgumentIsType abstr
+     JudgementIsType abstr
 
-  | ArgumentIsTerm abstr ->
+  | JudgementIsTerm abstr ->
      let abstr = abstraction_fully is_term_fully ~lvl es abstr in
-     ArgumentIsTerm abstr
+     JudgementIsTerm abstr
 
-  | ArgumentEqType abstr ->
+  | JudgementEqType abstr ->
      let abstr = abstraction_fully eq_type_fully ~lvl es abstr in
-     ArgumentEqType abstr
+     JudgementEqType abstr
 
-  | ArgumentEqTerm abstr ->
+  | JudgementEqTerm abstr ->
      let abstr = abstraction_fully eq_term_fully ~lvl es abstr in
-     ArgumentEqTerm abstr
+     JudgementEqTerm abstr
 
 let is_type_boundary _ ?(lvl=0) () = ()
 

--- a/src/nucleus/instantiate_meta.ml
+++ b/src/nucleus/instantiate_meta.ml
@@ -17,14 +17,11 @@ let fully_apply_abstraction_no_typechecks inst_u abstr args =
   fold [] abstr args
 
 let lookup_term_meta k metas =
-  match Indices.nth metas k with
-  | JudgementIsTerm e_abstr -> e_abstr
-  | JudgementIsType _ | JudgementEqType _ | JudgementEqTerm _ -> Error.raise TermExpected
+  match Judgement.as_is_term_abstraction (Indices.nth metas k) with
+  | None -> Error.raise TermExpected
+  | Some abstr -> abstr
 
-let lookup_type_meta k metas =
-  match Indices.nth metas k with
-  | JudgementIsType t_abstr -> t_abstr
-  | JudgementIsTerm _ | JudgementEqType _ | JudgementEqTerm _ -> Error.raise TypeExpected
+let lookup_type_meta k metas = Judgement.as_is_type_abstraction (Indices.nth metas k)
 
 (** [instantiate ~lvl metas] instantiates  *)
 
@@ -62,31 +59,27 @@ and eq_term ~lvl metas (Rule.EqTerm (e1, e2, t)) =
   Mk.eq_term Assumption.empty e1 e2 t
 
 and arguments ~lvl metas args =
-  List.map (argument ~lvl metas) args
+  List.map (abstraction argument ~lvl metas) args
 
 and argument ~lvl metas = function
-  | Rule.JudgementIsType abstr ->
-     let abstr = abstraction is_type ~lvl metas abstr
-     in Mk.arg_is_type abstr
+  | Rule.JudgementIsType t ->
+     Mk.arg_is_type (is_type ~lvl metas t)
 
-  | Rule.JudgementIsTerm abstr ->
-     let abstr = abstraction is_term ~lvl metas abstr
-     in Mk.arg_is_term abstr
+  | Rule.JudgementIsTerm e ->
+     Mk.arg_is_term (is_term ~lvl metas e)
 
-  | Rule.JudgementEqType abstr ->
+  | Rule.JudgementEqType eq ->
      (* XXX could do this lazily so that it's discarded when it's an
-            argument in a premise, and computed only when it's an argument in
-            a constructor in the output of a rule *)
-     let abstr = abstraction eq_type ~lvl metas abstr
-     in Mk.arg_eq_type abstr
+        argument in a premise, and computed only when it's an argument in
+        a constructor in the output of a rule *)
+     Mk.arg_eq_type (eq_type ~lvl metas eq)
 
-  | Rule.JudgementEqTerm abstr ->
-     let abstr = abstraction eq_term ~lvl metas abstr
-     in Mk.arg_eq_term abstr
+  | Rule.JudgementEqTerm eq ->
+     Mk.arg_eq_term (eq_term ~lvl metas eq)
 
 and abstraction
-  : 'a 'b . (lvl:int -> indices -> 'a -> 'b) ->
-    lvl:int -> indices -> 'a Rule.abstraction -> 'b abstraction
+  : 'a 'b . (lvl:int -> judgement_abstraction indices -> 'a -> 'b) ->
+    lvl:int -> judgement_abstraction indices -> 'a Rule.abstraction -> 'b abstraction
   = fun inst_u ~lvl metas -> function
 
     | Rule.NotAbstract u ->

--- a/src/nucleus/instantiate_meta.ml
+++ b/src/nucleus/instantiate_meta.ml
@@ -19,12 +19,12 @@ let fully_apply_abstraction_no_typechecks inst_u abstr args =
 let lookup_term_meta k metas =
   match Judgement.as_is_term_abstraction (Indices.nth metas k) with
   | Some abstr -> abstr
-  | None -> Error.raise TermExpected
+  | None -> Error.raise IsTermExpected
 
 let lookup_type_meta k metas =
   match Judgement.as_is_type_abstraction (Indices.nth metas k) with
   | Some abstr -> abstr
-  | None -> Error.raise TypeExpected
+  | None -> Error.raise IsTypeExpected
 
 (** [instantiate ~lvl metas] instantiates  *)
 

--- a/src/nucleus/instantiate_meta.ml
+++ b/src/nucleus/instantiate_meta.ml
@@ -18,13 +18,13 @@ let fully_apply_abstraction_no_typechecks inst_u abstr args =
 
 let lookup_term_meta k metas =
   match Indices.nth metas k with
-  | ArgumentIsTerm e_abstr -> e_abstr
-  | ArgumentIsType _ | ArgumentEqType _ | ArgumentEqTerm _ -> Error.raise TermExpected
+  | JudgementIsTerm e_abstr -> e_abstr
+  | JudgementIsType _ | JudgementEqType _ | JudgementEqTerm _ -> Error.raise TermExpected
 
 let lookup_type_meta k metas =
   match Indices.nth metas k with
-  | ArgumentIsType t_abstr -> t_abstr
-  | ArgumentIsTerm _ | ArgumentEqType _ | ArgumentEqTerm _ -> Error.raise TypeExpected
+  | JudgementIsType t_abstr -> t_abstr
+  | JudgementIsTerm _ | JudgementEqType _ | JudgementEqTerm _ -> Error.raise TypeExpected
 
 (** [instantiate ~lvl metas] instantiates  *)
 
@@ -65,22 +65,22 @@ and arguments ~lvl metas args =
   List.map (argument ~lvl metas) args
 
 and argument ~lvl metas = function
-  | Rule.ArgumentIsType abstr ->
+  | Rule.JudgementIsType abstr ->
      let abstr = abstraction is_type ~lvl metas abstr
      in Mk.arg_is_type abstr
 
-  | Rule.ArgumentIsTerm abstr ->
+  | Rule.JudgementIsTerm abstr ->
      let abstr = abstraction is_term ~lvl metas abstr
      in Mk.arg_is_term abstr
 
-  | Rule.ArgumentEqType abstr ->
+  | Rule.JudgementEqType abstr ->
      (* XXX could do this lazily so that it's discarded when it's an
             argument in a premise, and computed only when it's an argument in
             a constructor in the output of a rule *)
      let abstr = abstraction eq_type ~lvl metas abstr
      in Mk.arg_eq_type abstr
 
-  | Rule.ArgumentEqTerm abstr ->
+  | Rule.JudgementEqTerm abstr ->
      let abstr = abstraction eq_term ~lvl metas abstr
      in Mk.arg_eq_term abstr
 

--- a/src/nucleus/instantiate_meta.ml
+++ b/src/nucleus/instantiate_meta.ml
@@ -18,10 +18,13 @@ let fully_apply_abstraction_no_typechecks inst_u abstr args =
 
 let lookup_term_meta k metas =
   match Judgement.as_is_term_abstraction (Indices.nth metas k) with
-  | None -> Error.raise TermExpected
   | Some abstr -> abstr
+  | None -> Error.raise TermExpected
 
-let lookup_type_meta k metas = Judgement.as_is_type_abstraction (Indices.nth metas k)
+let lookup_type_meta k metas =
+  match Judgement.as_is_type_abstraction (Indices.nth metas k) with
+  | Some abstr -> abstr
+  | None -> Error.raise TypeExpected
 
 (** [instantiate ~lvl metas] instantiates  *)
 

--- a/src/nucleus/invert.ml
+++ b/src/nucleus/invert.ml
@@ -35,6 +35,10 @@ let as_not_abstract = function
   | Abstract _ -> None
   | NotAbstract v -> Some v
 
+let as_abstract = function
+  | Abstract (atm, abstr) -> Some (atm, abstr)
+  | NotAbstract _ -> None
+
 let invert_abstraction ?name inst_v = function
   | Abstract ({atom_nonce=x; atom_type=t}, abstr) ->
      let x = (match name with None -> Nonce.name x | Some y -> y) in

--- a/src/nucleus/invert.ml
+++ b/src/nucleus/invert.ml
@@ -5,10 +5,10 @@ let atom_name {atom_nonce=x;_} = Nonce.name x
 (** Destructors *)
 
 let invert_argument = function
-  | ArgumentIsTerm abstr -> ArgumentIsTerm abstr
-  | ArgumentIsType abstr -> ArgumentIsType abstr
-  | ArgumentEqType abstr -> ArgumentEqType abstr
-  | ArgumentEqTerm abstr -> ArgumentEqTerm abstr
+  | JudgementIsTerm abstr -> JudgementIsTerm abstr
+  | JudgementIsType abstr -> JudgementIsType abstr
+  | JudgementEqType abstr -> JudgementEqType abstr
+  | JudgementEqTerm abstr -> JudgementEqTerm abstr
 
 let invert_arguments args = List.map invert_argument args
 

--- a/src/nucleus/invert.ml
+++ b/src/nucleus/invert.ml
@@ -4,14 +4,6 @@ let atom_name {atom_nonce=x;_} = Nonce.name x
 
 (** Destructors *)
 
-let invert_argument = function
-  | JudgementIsTerm abstr -> JudgementIsTerm abstr
-  | JudgementIsType abstr -> JudgementIsType abstr
-  | JudgementEqType abstr -> JudgementEqType abstr
-  | JudgementEqTerm abstr -> JudgementEqTerm abstr
-
-let invert_arguments args = List.map invert_argument args
-
 let invert_is_term sgn = function
 
   | TermAtom a -> Stump_TermAtom a
@@ -19,8 +11,7 @@ let invert_is_term sgn = function
   | TermBound _ -> assert false
 
   | TermConstructor (c, args) ->
-     let arguments = invert_arguments args in
-     Stump_TermConstructor (c, arguments)
+     Stump_TermConstructor (c, args)
 
   | TermMeta (mv, args) ->
      Stump_TermMeta (mv, args)
@@ -32,8 +23,8 @@ let invert_is_term sgn = function
 
 let invert_is_type = function
   | TypeConstructor (c, args) ->
-     let arguments = invert_arguments args in
-     Stump_TypeConstructor (c, arguments)
+     Stump_TypeConstructor (c, args)
+
   | TypeMeta (mv, args) -> Stump_TypeMeta (mv, args)
 
 let invert_eq_type (EqType (asmp, t1, t2)) = Stump_EqType (asmp, t1, t2)

--- a/src/nucleus/invert.ml
+++ b/src/nucleus/invert.ml
@@ -63,3 +63,15 @@ let invert_eq_type_abstraction ?name eq =
 
 let invert_eq_term_abstraction ?name eq =
   invert_abstraction ?name Instantiate_bound.eq_term eq
+
+let invert_is_type_boundary ?name bdry =
+  invert_abstraction ?name Instantiate_bound.is_type_boundary bdry
+
+let invert_is_term_boundary ?name bdry =
+  invert_abstraction ?name Instantiate_bound.is_term_boundary bdry
+
+let invert_eq_type_boundary ?name bdry =
+  invert_abstraction ?name Instantiate_bound.eq_type_boundary bdry
+
+let invert_eq_term_boundary ?name bdry =
+  invert_abstraction ?name Instantiate_bound.eq_term_boundary bdry

--- a/src/nucleus/judgement.ml
+++ b/src/nucleus/judgement.ml
@@ -30,6 +30,28 @@ let as_is_term_abstraction abstr =
   with
   | ConversionError -> None
 
+let as_eq_type_abstraction abstr =
+  try
+    Some
+      (convert
+         (function
+          | JudgementEqType eq -> eq
+          | JudgementIsType _ | JudgementIsTerm _ | JudgementEqTerm _ -> raise ConversionError)
+         abstr)
+  with
+  | ConversionError -> None
+
+let as_eq_term_abstraction abstr =
+  try
+    Some
+      (convert
+         (function
+          | JudgementEqTerm eq -> eq
+          | JudgementIsType _ | JudgementIsTerm _ | JudgementEqType _ -> raise ConversionError)
+         abstr)
+  with
+  | ConversionError -> None
+
 let from_is_type_abstraction abstr =
   convert (fun t -> JudgementIsType t) abstr
 

--- a/src/nucleus/judgement.ml
+++ b/src/nucleus/judgement.ml
@@ -8,6 +8,22 @@ let rec convert f = function
   | NotAbstract a -> NotAbstract (f a)
   | Abstract (atm, abstr) -> Abstract (atm, convert f abstr)
 
+let as_is_type = function
+  | JudgementIsType t -> Some t
+  | JudgementIsTerm _ | JudgementEqType _ | JudgementEqTerm _ -> None
+
+let as_is_term = function
+  | JudgementIsTerm e -> Some e
+  | JudgementIsType _ | JudgementEqType _ | JudgementEqTerm _ -> None
+
+let as_eq_type = function
+  | JudgementEqType eq -> Some eq
+  | JudgementIsType _ | JudgementIsTerm _ | JudgementEqTerm _ -> None
+
+let as_eq_term = function
+  | JudgementEqTerm eq -> Some eq
+  | JudgementIsType _ | JudgementIsTerm _ | JudgementEqType _ -> None
+
 let as_is_type_abstraction abstr =
   try
     Some

--- a/src/nucleus/judgement.ml
+++ b/src/nucleus/judgement.ml
@@ -1,0 +1,43 @@
+open Nucleus_types
+
+(** Conversion from abstracted general judgements to abstracted particular judgements. *)
+
+exception ConversionError
+
+let rec convert f = function
+  | NotAbstract a -> NotAbstract (f a)
+  | Abstract (atm, abstr) -> Abstract (atm, convert f abstr)
+
+let as_is_type_abstraction abstr =
+  try
+    Some
+      (convert
+         (function
+          | JudgementIsType t -> t
+          | JudgementIsTerm _ | JudgementEqType _ | JudgementEqTerm _ -> raise ConversionError)
+         abstr)
+  with
+  | ConversionError -> None
+
+let as_is_term_abstraction abstr =
+  try
+    Some
+      (convert
+         (function
+          | JudgementIsTerm e -> e
+          | JudgementIsType _ | JudgementEqType _ | JudgementEqTerm _ -> raise ConversionError)
+         abstr)
+  with
+  | ConversionError -> None
+
+let from_is_type_abstraction abstr =
+  convert (fun t -> JudgementIsType t) abstr
+
+let from_is_term_abstraction abstr =
+  convert (fun t -> JudgementIsTerm t) abstr
+
+let from_eq_type_abstraction abstr =
+  convert (fun t -> JudgementEqType t) abstr
+
+let from_eq_term_abstraction abstr =
+  convert (fun t -> JudgementEqTerm t) abstr

--- a/src/nucleus/meta.ml
+++ b/src/nucleus/meta.ml
@@ -54,7 +54,9 @@ let form_eq_term_meta sgn {meta_nonce; meta_type} args =
   in
   Mk.eq_term asmp lhs rhs t
 
-let meta_eta_expanded instantiate_meta form_meta abstract_meta mv =
+let form_judgement_meta sgn mv args = failwith "form_judgement_meta not implemented"
+
+let meta_eta_expanded' instantiate_meta form_meta abstract_meta mv =
   let rec fold args = function
 
     | NotAbstract u ->
@@ -70,19 +72,19 @@ let meta_eta_expanded instantiate_meta form_meta abstract_meta mv =
   in fold [] mv.meta_type
 
 let is_type_meta_eta_expanded sgn =
-  meta_eta_expanded
+  meta_eta_expanded'
     (fun _e0 ?lvl () -> ())
     (form_is_type_meta sgn)
     Abstract.is_type
 
 let is_term_meta_eta_expanded sgn =
-  meta_eta_expanded
+  meta_eta_expanded'
     Instantiate_bound.is_type
     (form_is_term_meta sgn)
     Abstract.is_term
 
 let eq_type_meta_eta_expanded sgn =
-  meta_eta_expanded
+  meta_eta_expanded'
     (fun e0 ?lvl (lhs, rhs) ->
        Instantiate_bound.is_type e0 ?lvl lhs,
        Instantiate_bound.is_type e0 ?lvl rhs)
@@ -90,10 +92,16 @@ let eq_type_meta_eta_expanded sgn =
     Abstract.eq_type
 
 let eq_term_meta_eta_expanded sgn =
-  meta_eta_expanded
+  meta_eta_expanded'
     (fun e0 ?lvl (lhs, rhs, t) ->
        Instantiate_bound.is_term e0 ?lvl lhs,
        Instantiate_bound.is_term e0 ?lvl rhs,
        Instantiate_bound.is_type e0 ?lvl t)
     (form_eq_term_meta sgn)
     Abstract.eq_term
+
+let meta_eta_expanded sgn =
+  meta_eta_expanded'
+    Instantiate_bound.boundary
+    (form_judgement_meta sgn)
+    Abstract.judgement

--- a/src/nucleus/meta.ml
+++ b/src/nucleus/meta.ml
@@ -29,30 +29,30 @@ let form_is_term_meta sgn m args =
   check_term_arguments sgn m.meta_type args ;
   Mk.term_meta m args
 
-let form_eq_type_meta sgn {meta_nonce; meta_type} args =
-  let asmp = Assumption.add_eq_type_meta meta_nonce meta_type Assumption.empty in
-  let (lhs, rhs) =
-    let inst_eq_type_boundary e0 ?lvl (lhs, rhs) =
-      let lhs = Instantiate_bound.is_type e0 ?lvl lhs
-      and rhs = Instantiate_bound.is_type e0 ?lvl rhs
-      in (lhs, rhs)
-    in
-    Apply_abstraction.fully_apply_abstraction inst_eq_type_boundary sgn meta_type args
-  in
-  Mk.eq_type asmp lhs rhs
+(* let form_eq_type_meta sgn {meta_nonce; meta_type} args = *)
+(*   let asmp = Assumption.add_eq_type_meta meta_nonce meta_type Assumption.empty in *)
+(*   let (lhs, rhs) = *)
+(*     let inst_eq_type_boundary e0 ?lvl (lhs, rhs) = *)
+(*       let lhs = Instantiate_bound.is_type e0 ?lvl lhs *)
+(*       and rhs = Instantiate_bound.is_type e0 ?lvl rhs *)
+(*       in (lhs, rhs) *)
+(*     in *)
+(*     Apply_abstraction.fully_apply_abstraction inst_eq_type_boundary sgn meta_type args *)
+(*   in *)
+(*   Mk.eq_type asmp lhs rhs *)
 
-let form_eq_term_meta sgn {meta_nonce; meta_type} args =
-  let asmp = Assumption.add_eq_term_meta meta_nonce meta_type Assumption.empty in
-  let (lhs, rhs, t) =
-    let inst_eq_term_boundary e0 ?lvl (lhs, rhs, t) =
-      let lhs = Instantiate_bound.is_term e0 ?lvl lhs
-      and rhs = Instantiate_bound.is_term e0 ?lvl rhs
-      and t = Instantiate_bound.is_type e0 ?lvl t
-      in (lhs, rhs, t)
-    in
-    Apply_abstraction.fully_apply_abstraction inst_eq_term_boundary sgn meta_type args
-  in
-  Mk.eq_term asmp lhs rhs t
+(* let form_eq_term_meta sgn {meta_nonce; meta_type} args = *)
+(*   let asmp = Assumption.add_eq_term_meta meta_nonce meta_type Assumption.empty in *)
+(*   let (lhs, rhs, t) = *)
+(*     let inst_eq_term_boundary e0 ?lvl (lhs, rhs, t) = *)
+(*       let lhs = Instantiate_bound.is_term e0 ?lvl lhs *)
+(*       and rhs = Instantiate_bound.is_term e0 ?lvl rhs *)
+(*       and t = Instantiate_bound.is_type e0 ?lvl t *)
+(*       in (lhs, rhs, t) *)
+(*     in *)
+(*     Apply_abstraction.fully_apply_abstraction inst_eq_term_boundary sgn meta_type args *)
+(*   in *)
+(*   Mk.eq_term asmp lhs rhs t *)
 
 let form_judgement_meta sgn mv args = failwith "form_judgement_meta not implemented"
 
@@ -70,35 +70,6 @@ let meta_eta_expanded' instantiate_meta form_meta abstract_meta mv =
        Mk.abstract atm abstr
 
   in fold [] mv.meta_type
-
-let is_type_meta_eta_expanded sgn =
-  meta_eta_expanded'
-    (fun _e0 ?lvl () -> ())
-    (form_is_type_meta sgn)
-    Abstract.is_type
-
-let is_term_meta_eta_expanded sgn =
-  meta_eta_expanded'
-    Instantiate_bound.is_type
-    (form_is_term_meta sgn)
-    Abstract.is_term
-
-let eq_type_meta_eta_expanded sgn =
-  meta_eta_expanded'
-    (fun e0 ?lvl (lhs, rhs) ->
-       Instantiate_bound.is_type e0 ?lvl lhs,
-       Instantiate_bound.is_type e0 ?lvl rhs)
-    (form_eq_type_meta sgn)
-    Abstract.eq_type
-
-let eq_term_meta_eta_expanded sgn =
-  meta_eta_expanded'
-    (fun e0 ?lvl (lhs, rhs, t) ->
-       Instantiate_bound.is_term e0 ?lvl lhs,
-       Instantiate_bound.is_term e0 ?lvl rhs,
-       Instantiate_bound.is_type e0 ?lvl t)
-    (form_eq_term_meta sgn)
-    Abstract.eq_term
 
 let judgement_meta_eta_expanded sgn =
   meta_eta_expanded'

--- a/src/nucleus/meta.ml
+++ b/src/nucleus/meta.ml
@@ -100,7 +100,7 @@ let eq_term_meta_eta_expanded sgn =
     (form_eq_term_meta sgn)
     Abstract.eq_term
 
-let meta_eta_expanded sgn =
+let judgement_meta_eta_expanded sgn =
   meta_eta_expanded'
     Instantiate_bound.boundary
     (form_judgement_meta sgn)

--- a/src/nucleus/meta.ml
+++ b/src/nucleus/meta.ml
@@ -54,11 +54,11 @@ let form_eq_term_meta sgn {meta_nonce; meta_type} args =
   in
   Mk.eq_term asmp lhs rhs t
 
-let meta_eta_expanded instantiate_meta form_meta abstract_meta sgn mv =
+let meta_eta_expanded instantiate_meta form_meta abstract_meta mv =
   let rec fold args = function
 
     | NotAbstract u ->
-       Mk.not_abstract (form_meta sgn mv (List.rev args))
+       Mk.not_abstract (form_meta mv (List.rev args))
 
     | Abstract (atm, abstr) ->
        let a, abstr =
@@ -69,31 +69,31 @@ let meta_eta_expanded instantiate_meta form_meta abstract_meta sgn mv =
 
   in fold [] mv.meta_type
 
-let is_type_meta_eta_expanded =
+let is_type_meta_eta_expanded sgn =
   meta_eta_expanded
     (fun _e0 ?lvl () -> ())
-    form_is_type_meta
+    (form_is_type_meta sgn)
     Abstract.is_type
 
-let is_term_meta_eta_expanded =
+let is_term_meta_eta_expanded sgn =
   meta_eta_expanded
     Instantiate_bound.is_type
-    form_is_term_meta
+    (form_is_term_meta sgn)
     Abstract.is_term
 
-let eq_type_meta_eta_expanded =
+let eq_type_meta_eta_expanded sgn =
   meta_eta_expanded
     (fun e0 ?lvl (lhs, rhs) ->
        Instantiate_bound.is_type e0 ?lvl lhs,
        Instantiate_bound.is_type e0 ?lvl rhs)
-    form_eq_type_meta
+    (form_eq_type_meta sgn)
     Abstract.eq_type
 
-let eq_term_meta_eta_expanded =
+let eq_term_meta_eta_expanded sgn =
   meta_eta_expanded
     (fun e0 ?lvl (lhs, rhs, t) ->
        Instantiate_bound.is_term e0 ?lvl lhs,
        Instantiate_bound.is_term e0 ?lvl rhs,
        Instantiate_bound.is_type e0 ?lvl t)
-    form_eq_term_meta
+    (form_eq_term_meta sgn)
     Abstract.eq_term

--- a/src/nucleus/mk.ml
+++ b/src/nucleus/mk.ml
@@ -11,6 +11,7 @@ let fresh_type_meta = fresh_meta
 let fresh_term_meta = fresh_meta
 let fresh_eq_type_meta = fresh_meta
 let fresh_eq_term_meta = fresh_meta
+let fresh_judgement_meta = fresh_meta
 
 let bound k = TermBound k
 

--- a/src/nucleus/mk.ml
+++ b/src/nucleus/mk.ml
@@ -29,10 +29,10 @@ let term_convert e asmp t =
   | TermConvert _ -> assert false
   | _ -> TermConvert (e, asmp, t)
 
-let arg_is_type t = ArgumentIsType t
-let arg_is_term e = ArgumentIsTerm e
-let arg_eq_type s = ArgumentEqType s
-let arg_eq_term s = ArgumentEqTerm s
+let arg_is_type t = JudgementIsType t
+let arg_is_term e = JudgementIsTerm e
+let arg_eq_type s = JudgementEqType s
+let arg_eq_term s = JudgementEqTerm s
 
 let eq_type asmp t1 t2 = EqType (asmp, t1, t2)
 

--- a/src/nucleus/nucleus.ml
+++ b/src/nucleus/nucleus.ml
@@ -7,7 +7,7 @@ let eq_term_meta_eta_expanded = Meta.eq_term_meta_eta_expanded
 let eq_type_meta_eta_expanded = Meta.eq_type_meta_eta_expanded
 let is_term_meta_eta_expanded = Meta.is_term_meta_eta_expanded
 let is_type_meta_eta_expanded = Meta.is_type_meta_eta_expanded
-let meta_eta_expanded = Meta.meta_eta_expanded
+let judgement_meta_eta_expanded = Meta.judgement_meta_eta_expanded
 
 let form_eq_term_meta = Meta.form_eq_term_meta
 let form_eq_type_meta = Meta.form_eq_type_meta
@@ -30,7 +30,7 @@ let fresh_is_term_meta = Mk.fresh_term_meta
 let fresh_eq_type_meta = Mk.fresh_eq_type_meta
 let fresh_eq_term_meta = Mk.fresh_eq_term_meta
 
-let fresh_meta = Mk.fresh_meta
+let fresh_judgement_meta = Mk.fresh_judgement_meta
 
 let alpha_equal_term = Alpha_equal.is_term
 let alpha_equal_type = Alpha_equal.is_type

--- a/src/nucleus/nucleus.ml
+++ b/src/nucleus/nucleus.ml
@@ -7,6 +7,8 @@ let eq_term_meta_eta_expanded = Meta.eq_term_meta_eta_expanded
 let eq_type_meta_eta_expanded = Meta.eq_type_meta_eta_expanded
 let is_term_meta_eta_expanded = Meta.is_term_meta_eta_expanded
 let is_type_meta_eta_expanded = Meta.is_type_meta_eta_expanded
+let meta_eta_expanded = Meta.meta_eta_expanded
+
 let form_eq_term_meta = Meta.form_eq_term_meta
 let form_eq_type_meta = Meta.form_eq_type_meta
 let form_is_term_meta = Meta.form_is_term_meta
@@ -27,6 +29,8 @@ let fresh_is_type_meta = Mk.fresh_type_meta
 let fresh_is_term_meta = Mk.fresh_term_meta
 let fresh_eq_type_meta = Mk.fresh_eq_type_meta
 let fresh_eq_term_meta = Mk.fresh_eq_term_meta
+
+let fresh_meta = Mk.fresh_meta
 
 let alpha_equal_term = Alpha_equal.is_term
 let alpha_equal_type = Alpha_equal.is_type
@@ -60,14 +64,14 @@ let form_rule = Form_rule.form_rule
 (* let abstract_boundary_is_term = Abstract.boundary_is_term_abstraction *)
 (* let abstract_boundary_is_type = Abstract.boundary_is_type_abstraction *)
 
-let abstract_boundary = Abstract.boundary
+let abstract_boundary = Abstract.boundary_abstraction
 
 (* let abstract_eq_term = Abstract.eq_term_abstraction *)
 (* let abstract_eq_type = Abstract.eq_type_abstraction *)
 let abstract_is_term = Abstract.is_term_abstraction
 (* let abstract_is_type = Abstract.is_type_abstraction *)
 
-let abstract_judgement = Abstract.judgement
+let abstract_judgement = Abstract.judgement_abstraction
 
 let abstract_not_abstract = Abstract.not_abstract
 
@@ -115,6 +119,7 @@ let occurs_is_type_abstraction = occurs_abstraction Collect_assumptions.is_type
 let occurs_is_term_abstraction = occurs_abstraction Collect_assumptions.is_term
 let occurs_eq_type_abstraction = occurs_abstraction Collect_assumptions.eq_type
 let occurs_eq_term_abstraction = occurs_abstraction Collect_assumptions.eq_term
+let occurs_judgement_abstraction = occurs_abstraction Collect_assumptions.judgement
 
 let congruence_term_constructor = Congruence.congruence_term_constructor
 let congruence_type_constructor = Congruence.congruence_type_constructor

--- a/src/nucleus/nucleus.ml
+++ b/src/nucleus/nucleus.ml
@@ -96,6 +96,10 @@ let invert_eq_term_boundary = Invert.invert_eq_term_boundary
 let as_not_abstract = Invert.as_not_abstract
 let atom_name = Invert.atom_name
 
+let as_is_type_abstraction = Judgement.as_is_type_abstraction
+let as_is_term_abstraction = Judgement.as_is_term_abstraction
+let as_eq_type_abstraction = Judgement.as_eq_type_abstraction
+let as_eq_term_abstraction = Judgement.as_eq_term_abstraction
 
 let context_is_type_abstraction = Collect_assumptions.context_of_abstraction Collect_assumptions.is_type
 let context_is_term_abstraction = Collect_assumptions.context_of_abstraction Collect_assumptions.is_term
@@ -128,6 +132,8 @@ let print_is_term_abstraction = Nucleus_print.is_term_abstraction
 let print_is_type_abstraction = Nucleus_print.is_type_abstraction
 let print_eq_term_abstraction = Nucleus_print.eq_term_abstraction
 let print_eq_type_abstraction = Nucleus_print.eq_type_abstraction
+let print_judgement = Nucleus_print.judgement
+let print_boundary = Nucleus_print.boundary
 let print_judgement_abstraction = Nucleus_print.judgement_abstraction
 let print_boundary_abstraction = Nucleus_print.boundary_abstraction
 let print_error = Nucleus_print.error

--- a/src/nucleus/nucleus.ml
+++ b/src/nucleus/nucleus.ml
@@ -24,6 +24,7 @@ let check_is_type_boundary = Alpha_equal.check_is_type_boundary
 let check_is_term_boundary = Alpha_equal.check_is_term_boundary
 let check_eq_type_boundary = Alpha_equal.check_eq_type_boundary
 let check_eq_term_boundary = Alpha_equal.check_eq_term_boundary
+let check_judgement_boundary = Alpha_equal.check_judgement_boundary
 
 let fresh_atom = Mk.fresh_atom
 let fresh_is_type_meta = Mk.fresh_type_meta

--- a/src/nucleus/nucleus.ml
+++ b/src/nucleus/nucleus.ml
@@ -25,7 +25,6 @@ let check_is_term_boundary = Alpha_equal.check_is_term_boundary
 let check_eq_type_boundary = Alpha_equal.check_eq_type_boundary
 let check_eq_term_boundary = Alpha_equal.check_eq_term_boundary
 
-
 let fresh_atom = Mk.fresh_atom
 let fresh_is_type_meta = Mk.fresh_type_meta
 let fresh_is_term_meta = Mk.fresh_term_meta
@@ -75,10 +74,18 @@ let invert_eq_term_abstraction = Invert.invert_eq_term_abstraction
 let invert_eq_type_abstraction = Invert.invert_eq_type_abstraction
 let invert_is_type_abstraction = Invert.invert_is_type_abstraction
 let invert_is_term_abstraction = Invert.invert_is_term_abstraction
-let invert_eq_term = Invert.invert_eq_term
-let invert_eq_type = Invert.invert_eq_type
+
 let invert_is_term = Invert.invert_is_term
 let invert_is_type = Invert.invert_is_type
+let invert_eq_type = Invert.invert_eq_type
+let invert_eq_term = Invert.invert_eq_term
+
+
+let invert_is_type_boundary = Invert.invert_is_type_boundary
+let invert_is_term_boundary = Invert.invert_is_term_boundary
+let invert_eq_type_boundary = Invert.invert_eq_type_boundary
+let invert_eq_term_boundary = Invert.invert_eq_term_boundary
+
 let as_not_abstract = Invert.as_not_abstract
 let atom_name = Invert.atom_name
 

--- a/src/nucleus/nucleus.ml
+++ b/src/nucleus/nucleus.ml
@@ -40,10 +40,7 @@ let alpha_equal_boundary = Alpha_equal.boundary
 let form_alpha_equal_term = Form.form_alpha_equal_term
 let form_alpha_equal_type = Form.form_alpha_equal_type
 let form_alpha_equal_abstraction = Form.form_alpha_equal_abstraction
-let form_rap_is_type = Form.form_rap_is_type
-let form_rap_is_term = Form.form_rap_is_term
-let form_rap_eq_type = Form.form_rap_eq_type
-let form_rap_eq_term = Form.form_rap_eq_term
+let form_rap = Form.form_rap
 let rap_apply = Form.rap_apply
 let rap_boundary = Form.rap_boundary
 
@@ -56,10 +53,7 @@ let symmetry_type = Form.symmetry_type
 let symmetry_term = Form.symmetry_term
 
 (** Creation of rules of inference from judgements. *)
-let form_rule_eq_term = Form_rule.form_rule_eq_term
-let form_rule_eq_type = Form_rule.form_rule_eq_type
-let form_rule_is_term = Form_rule.form_rule_is_term
-let form_rule_is_type = Form_rule.form_rule_is_type
+let form_rule = Form_rule.form_rule
 
 (* let abstract_boundary_eq_term = Abstract.boundary_eq_term_abstraction *)
 (* let abstract_boundary_eq_type = Abstract.boundary_eq_type_abstraction *)
@@ -94,6 +88,7 @@ let invert_eq_type_boundary = Invert.invert_eq_type_boundary
 let invert_eq_term_boundary = Invert.invert_eq_term_boundary
 
 let as_not_abstract = Invert.as_not_abstract
+let as_abstract = Invert.as_abstract
 let atom_name = Invert.atom_name
 
 let as_is_type_abstraction = Judgement.as_is_type_abstraction

--- a/src/nucleus/nucleus.ml
+++ b/src/nucleus/nucleus.ml
@@ -50,6 +50,12 @@ let transitivity_term = Form.transitivity_term
 let symmetry_type = Form.symmetry_type
 let symmetry_term = Form.symmetry_term
 
+(** Form a boundary *)
+let form_is_type_boundary = Form.form_is_type_boundary
+let form_is_term_boundary = Form.form_is_term_bondary
+let form_eq_type_boundary = Form.form_eq_type_boundary
+let form_eq_term_boundary = Form.form_eq_term_boundary
+
 (** Creation of rules of inference from judgements. *)
 let form_rule = Form_rule.form_rule
 
@@ -94,6 +100,12 @@ let as_is_term_abstraction = Judgement.as_is_term_abstraction
 let as_eq_type_abstraction = Judgement.as_eq_type_abstraction
 let as_eq_term_abstraction = Judgement.as_eq_term_abstraction
 
+let as_is_type = Judgement.as_is_type
+let as_is_term = Judgement.as_is_term
+let as_eq_type = Judgement.as_eq_type
+let as_eq_term = Judgement.as_eq_term
+
+
 let context_is_type_abstraction = Collect_assumptions.context_of_abstraction Collect_assumptions.is_type
 let context_is_term_abstraction = Collect_assumptions.context_of_abstraction Collect_assumptions.is_term
 let context_eq_type_abstraction = Collect_assumptions.context_of_abstraction Collect_assumptions.eq_type
@@ -114,6 +126,10 @@ let occurs_is_term_abstraction = occurs_abstraction Collect_assumptions.is_term
 let occurs_eq_type_abstraction = occurs_abstraction Collect_assumptions.eq_type
 let occurs_eq_term_abstraction = occurs_abstraction Collect_assumptions.eq_term
 let occurs_judgement_abstraction = occurs_abstraction Collect_assumptions.judgement
+
+let convert_term_abstraction = Convert.term_abstraction
+let convert_eq_term_abstraction = Convert.eq_term_abstraction
+let convert_judgement_abstraction = Convert.judgement_abstraction
 
 let congruence_term_constructor = Congruence.congruence_term_constructor
 let congruence_type_constructor = Congruence.congruence_type_constructor

--- a/src/nucleus/nucleus.ml
+++ b/src/nucleus/nucleus.ml
@@ -35,6 +35,10 @@ let alpha_equal_term = Alpha_equal.is_term
 let alpha_equal_type = Alpha_equal.is_type
 let alpha_equal_abstraction = Alpha_equal.abstraction
 
+let alpha_equal_judgement = Alpha_equal.judgement
+let alpha_equal_boundary = Alpha_equal.boundary
+
+
 (** Construct judgements *)
 let form_alpha_equal_term = Form.form_alpha_equal_term
 let form_alpha_equal_type = Form.form_alpha_equal_type
@@ -60,14 +64,20 @@ let form_rule_eq_type = Form_rule.form_rule_eq_type
 let form_rule_is_term = Form_rule.form_rule_is_term
 let form_rule_is_type = Form_rule.form_rule_is_type
 
-let abstract_boundary_eq_term = Abstract.boundary_eq_term_abstraction
-let abstract_boundary_eq_type = Abstract.boundary_eq_type_abstraction
-let abstract_boundary_is_term = Abstract.boundary_is_term_abstraction
-let abstract_boundary_is_type = Abstract.boundary_is_type_abstraction
-let abstract_eq_term = Abstract.eq_term_abstraction
-let abstract_eq_type = Abstract.eq_type_abstraction
+(* let abstract_boundary_eq_term = Abstract.boundary_eq_term_abstraction *)
+(* let abstract_boundary_eq_type = Abstract.boundary_eq_type_abstraction *)
+(* let abstract_boundary_is_term = Abstract.boundary_is_term_abstraction *)
+(* let abstract_boundary_is_type = Abstract.boundary_is_type_abstraction *)
+
+let abstract_boundary = Abstract.boundary
+
+(* let abstract_eq_term = Abstract.eq_term_abstraction *)
+(* let abstract_eq_type = Abstract.eq_type_abstraction *)
 let abstract_is_term = Abstract.is_term_abstraction
-let abstract_is_type = Abstract.is_type_abstraction
+(* let abstract_is_type = Abstract.is_type_abstraction *)
+
+let abstract_judgement = Abstract.judgement
+
 let abstract_not_abstract = Abstract.not_abstract
 
 let invert_eq_term_abstraction = Invert.invert_eq_term_abstraction
@@ -120,6 +130,8 @@ let print_is_term_abstraction = Nucleus_print.is_term_abstraction
 let print_is_type_abstraction = Nucleus_print.is_type_abstraction
 let print_eq_term_abstraction = Nucleus_print.eq_term_abstraction
 let print_eq_type_abstraction = Nucleus_print.eq_type_abstraction
+let print_judgement = Nucleus_print.judgement
+let print_boundary = Nucleus_print.boundary
 let print_error = Nucleus_print.error
 
 module Json = Nucleus_json

--- a/src/nucleus/nucleus.ml
+++ b/src/nucleus/nucleus.ml
@@ -79,20 +79,21 @@ let invert_eq_term_abstraction = Invert.invert_eq_term_abstraction
 let invert_eq_type_abstraction = Invert.invert_eq_type_abstraction
 let invert_is_type_abstraction = Invert.invert_is_type_abstraction
 let invert_is_term_abstraction = Invert.invert_is_term_abstraction
+let invert_judgement_abstraction = Invert.invert_judgement_abstraction
 
 let invert_is_term = Invert.invert_is_term
 let invert_is_type = Invert.invert_is_type
 let invert_eq_type = Invert.invert_eq_type
 let invert_eq_term = Invert.invert_eq_term
 
-
 let invert_is_type_boundary = Invert.invert_is_type_boundary
 let invert_is_term_boundary = Invert.invert_is_term_boundary
 let invert_eq_type_boundary = Invert.invert_eq_type_boundary
 let invert_eq_term_boundary = Invert.invert_eq_term_boundary
 
+let invert_boundary_abstraction = Invert.invert_boundary_abstraction
+
 let as_not_abstract = Invert.as_not_abstract
-let as_abstract = Invert.as_abstract
 let atom_name = Invert.atom_name
 
 let as_is_type_abstraction = Judgement.as_is_type_abstraction

--- a/src/nucleus/nucleus.ml
+++ b/src/nucleus/nucleus.ml
@@ -3,14 +3,8 @@ include Nucleus_types
 module Signature = Signature
 
 let meta_nonce = Meta.nonce
-let eq_term_meta_eta_expanded = Meta.eq_term_meta_eta_expanded
-let eq_type_meta_eta_expanded = Meta.eq_type_meta_eta_expanded
-let is_term_meta_eta_expanded = Meta.is_term_meta_eta_expanded
-let is_type_meta_eta_expanded = Meta.is_type_meta_eta_expanded
 let judgement_meta_eta_expanded = Meta.judgement_meta_eta_expanded
 
-let form_eq_term_meta = Meta.form_eq_term_meta
-let form_eq_type_meta = Meta.form_eq_type_meta
 let form_is_term_meta = Meta.form_is_term_meta
 let form_is_type_meta = Meta.form_is_type_meta
 

--- a/src/nucleus/nucleus.ml
+++ b/src/nucleus/nucleus.ml
@@ -16,7 +16,7 @@ let type_at_abstraction = Sanity.type_at_abstraction
 let type_of_atom = Sanity.type_of_atom
 let natural_type_eq = Sanity.natural_type_eq
 
-let check_judgement_boundary_abstraction = Alpha_equal.check_judgement_boundary_abstraction
+let check_judgement_boundary_abstraction = Check.judgement_boundary_abstraction
 
 let fresh_atom = Mk.fresh_atom
 let fresh_is_type_meta = Mk.fresh_type_meta

--- a/src/nucleus/nucleus.ml
+++ b/src/nucleus/nucleus.ml
@@ -20,11 +20,7 @@ let type_at_abstraction = Sanity.type_at_abstraction
 let type_of_atom = Sanity.type_of_atom
 let natural_type_eq = Sanity.natural_type_eq
 
-let check_is_type_boundary = Alpha_equal.check_is_type_boundary
-let check_is_term_boundary = Alpha_equal.check_is_term_boundary
-let check_eq_type_boundary = Alpha_equal.check_eq_type_boundary
-let check_eq_term_boundary = Alpha_equal.check_eq_term_boundary
-let check_judgement_boundary = Alpha_equal.check_judgement_boundary
+let check_judgement_boundary_abstraction = Alpha_equal.check_judgement_boundary_abstraction
 
 let fresh_atom = Mk.fresh_atom
 let fresh_is_type_meta = Mk.fresh_type_meta
@@ -110,6 +106,7 @@ let apply_eq_term_abstraction = Apply_abstraction.apply_eq_term_abstraction
 let apply_eq_type_abstraction = Apply_abstraction.apply_eq_type_abstraction
 let apply_is_term_abstraction = Apply_abstraction.apply_is_term_abstraction
 let apply_is_type_abstraction = Apply_abstraction.apply_is_type_abstraction
+let apply_judgement_abstraction = Apply_abstraction.apply_judgement_abstraction
 
 let occurs_abstraction assumptions_u a abstr =
   let asmp = Collect_assumptions.abstraction assumptions_u abstr in
@@ -131,8 +128,11 @@ let print_is_term_abstraction = Nucleus_print.is_term_abstraction
 let print_is_type_abstraction = Nucleus_print.is_type_abstraction
 let print_eq_term_abstraction = Nucleus_print.eq_term_abstraction
 let print_eq_type_abstraction = Nucleus_print.eq_type_abstraction
-let print_judgement = Nucleus_print.judgement
-let print_boundary = Nucleus_print.boundary
+let print_judgement_abstraction = Nucleus_print.judgement_abstraction
+let print_boundary_abstraction = Nucleus_print.boundary_abstraction
 let print_error = Nucleus_print.error
+
+let name_of_judgement = Nucleus_print.name_of_judgement
+let name_of_boundary = Nucleus_print.name_of_boundary
 
 module Json = Nucleus_json

--- a/src/nucleus/nucleus.mli
+++ b/src/nucleus/nucleus.mli
@@ -160,19 +160,15 @@ val form_eq_term_meta : signature -> eq_term_meta -> is_term list -> eq_term
 (** Form a non-abstracted abstraction *)
 val abstract_not_abstract : 'a -> 'a abstraction
 
-(** Form an abstracted judgement *)
+(** Abstract a judgement abstraction *)
 (* val abstract_is_type : is_atom -> is_type_abstraction -> is_type_abstraction *)
 val abstract_is_term : is_atom -> is_term_abstraction -> is_term_abstraction
 (* val abstract_eq_type : is_atom -> eq_type_abstraction -> eq_type_abstraction *)
 (* val abstract_eq_term : is_atom -> eq_term_abstraction -> eq_term_abstraction *)
-val abstract_judgement : is_atom -> judgement -> judgement
+val abstract_judgement : is_atom -> judgement_abstraction -> judgement_abstraction
 
-(** Form an abstracted boundary *)
-(* val abstract_boundary_is_type : is_atom -> is_type_boundary -> is_type_boundary *)
-(* val abstract_boundary_is_term : is_atom -> is_term_boundary -> is_term_boundary *)
-(* val abstract_boundary_eq_type : is_atom -> eq_type_boundary -> eq_type_boundary *)
-(* val abstract_boundary_eq_term : is_atom -> eq_term_boundary -> eq_term_boundary *)
-val abstract_boundary : is_atom -> boundary -> boundary
+(** Abstract a boundary abstraction *)
+val abstract_boundary : is_atom -> boundary_abstraction -> boundary_abstraction
 
 (** [fresh_atom x t] Create a fresh atom from name [x] with type [t] *)
 val fresh_atom : Name.t -> is_type -> is_atom
@@ -183,10 +179,14 @@ val fresh_is_term_meta : Name.t -> is_term_boundary abstraction -> is_term_meta
 val fresh_eq_type_meta : Name.t -> eq_type_boundary abstraction -> eq_type_meta
 val fresh_eq_term_meta : Name.t -> eq_term_boundary abstraction -> eq_term_meta
 
+(** [fresh_meta x bdry] creates a fresh meta-variable with the given boundary *)
+val fresh_meta : Name.t -> boundary_abstraction -> boundary_abstraction meta
+
 val is_type_meta_eta_expanded : signature -> is_type_meta -> is_type_abstraction
 val is_term_meta_eta_expanded : signature -> is_term_meta -> is_term_abstraction
 val eq_type_meta_eta_expanded : signature -> eq_type_meta -> eq_type_abstraction
 val eq_term_meta_eta_expanded : signature -> eq_term_meta -> eq_term_abstraction
+val meta_eta_expanded : signature -> boundary_abstraction meta -> judgement_abstraction
 
 (** Verify that an abstraction is in fact not abstract *)
 val as_not_abstract : 'a abstraction -> 'a option
@@ -263,6 +263,7 @@ val occurs_is_type_abstraction : is_atom -> is_type_abstraction -> bool
 val occurs_is_term_abstraction : is_atom -> is_term_abstraction -> bool
 val occurs_eq_type_abstraction : is_atom -> eq_type_abstraction -> bool
 val occurs_eq_term_abstraction : is_atom -> eq_term_abstraction -> bool
+val occurs_judgement_abstraction : is_atom -> judgement_abstraction -> bool
 
 val apply_is_type_abstraction :
   signature -> is_type_abstraction -> is_term -> is_type_abstraction

--- a/src/nucleus/nucleus.mli
+++ b/src/nucleus/nucleus.mli
@@ -207,6 +207,11 @@ val eq_term_meta_eta_expanded : signature -> eq_term_meta -> eq_term_abstraction
 (** Verify that an abstraction is in fact not abstract *)
 val as_not_abstract : 'a abstraction -> 'a option
 
+val as_is_type_abstraction : judgement_abstraction -> is_type abstraction option
+val as_is_term_abstraction : judgement_abstraction -> is_term abstraction option
+val as_eq_type_abstraction : judgement_abstraction -> eq_type abstraction option
+val as_eq_term_abstraction : judgement_abstraction -> eq_term abstraction option
+
 (** Inversion principles *)
 
 val invert_is_type : is_type -> stump_is_type
@@ -371,6 +376,12 @@ val print_eq_term_abstraction :
 
 val print_eq_type_abstraction :
   ?max_level:Level.t -> penv:print_environment -> eq_type_abstraction -> Format.formatter -> unit
+
+val print_judgement :
+  ?max_level:Level.t -> penv:print_environment -> judgement -> Format.formatter -> unit
+
+val print_boundary :
+  ?max_level:Level.t -> penv:print_environment -> boundary -> Format.formatter -> unit
 
 val print_judgement_abstraction :
   ?max_level:Level.t -> penv:print_environment -> judgement_abstraction -> Format.formatter -> unit

--- a/src/nucleus/nucleus.mli
+++ b/src/nucleus/nucleus.mli
@@ -32,13 +32,12 @@ type is_type_abstraction = is_type abstraction
 type eq_type_abstraction = eq_type abstraction
 type eq_term_abstraction = eq_term abstraction
 
-
-(** An argument to a term or type constructor *)
-type argument =
-  | ArgumentIsType of is_type_abstraction
-  | ArgumentIsTerm of is_term_abstraction
-  | ArgumentEqType of eq_type_abstraction
-  | ArgumentEqTerm of eq_term_abstraction
+(** Judgement *)
+type judgement =
+  | JudgementIsType of is_type_abstraction
+  | JudgementIsTerm of is_term_abstraction
+  | JudgementEqType of eq_type_abstraction
+  | JudgementEqTerm of eq_term_abstraction
 
 (** Boundary of a type judgement *)
 type is_type_boundary = unit abstraction
@@ -70,12 +69,12 @@ type eq_term_meta = eq_term_boundary meta
 (** A stump is obtained when we invert a judgement. *)
 
 type nonrec stump_is_type =
-  | Stump_TypeConstructor of Ident.t * argument list
+  | Stump_TypeConstructor of Ident.t * judgement list
   | Stump_TypeMeta of is_type_meta * is_term list
 
 and stump_is_term =
   | Stump_TermAtom of is_atom
-  | Stump_TermConstructor of Ident.t * argument list
+  | Stump_TermConstructor of Ident.t * judgement list
   | Stump_TermMeta of is_term_meta * is_term list
   | Stump_TermConvert of is_term * eq_type
 
@@ -144,7 +143,7 @@ val form_rap_eq_type : signature -> Ident.t -> eq_type rule_application
 val form_rap_eq_term : signature -> Ident.t -> eq_term rule_application
 
 (** Apply a rap to one more argument *)
-val rap_apply : signature -> 'a rule_application_status -> argument -> 'a rule_application
+val rap_apply : signature -> 'a rule_application_status -> judgement -> 'a rule_application
 
 (** Give the boundary of a rap status, i.e., the boundary of the next argument. *)
 val rap_boundary : 'a rule_application_status -> boundary

--- a/src/nucleus/nucleus.mli
+++ b/src/nucleus/nucleus.mli
@@ -179,14 +179,14 @@ val fresh_is_term_meta : Name.t -> is_term_boundary abstraction -> is_term_meta
 val fresh_eq_type_meta : Name.t -> eq_type_boundary abstraction -> eq_type_meta
 val fresh_eq_term_meta : Name.t -> eq_term_boundary abstraction -> eq_term_meta
 
-(** [fresh_meta x bdry] creates a fresh meta-variable with the given boundary *)
-val fresh_meta : Name.t -> boundary_abstraction -> boundary_abstraction meta
+(** [fresh_judgement_meta x bdry] creates a fresh meta-variable with the given boundary *)
+val fresh_judgement_meta : Name.t -> boundary_abstraction -> boundary_abstraction meta
 
 val is_type_meta_eta_expanded : signature -> is_type_meta -> is_type_abstraction
 val is_term_meta_eta_expanded : signature -> is_term_meta -> is_term_abstraction
 val eq_type_meta_eta_expanded : signature -> eq_type_meta -> eq_type_abstraction
 val eq_term_meta_eta_expanded : signature -> eq_term_meta -> eq_term_abstraction
-val meta_eta_expanded : signature -> boundary_abstraction meta -> judgement_abstraction
+val judgement_meta_eta_expanded : signature -> boundary_abstraction meta -> judgement_abstraction
 
 (** Verify that an abstraction is in fact not abstract *)
 val as_not_abstract : 'a abstraction -> 'a option

--- a/src/nucleus/nucleus.mli
+++ b/src/nucleus/nucleus.mli
@@ -208,6 +208,8 @@ val invert_is_term : signature -> is_term -> stump_is_term
 
 val invert_eq_type : eq_type -> stump_eq_type
 
+val invert_eq_term : eq_term -> stump_eq_term
+
 val atom_name : is_atom -> Name.t
 
 val meta_nonce : 'a meta -> Nonce.t
@@ -225,16 +227,16 @@ val invert_eq_term_abstraction :
   ?name:Name.t -> eq_term_abstraction -> eq_term stump_abstraction
 
 val invert_is_term_boundary :
-  ?name:Name.t -> is_term_boundary -> is_term stump_abstraction
+  ?name:Name.t -> is_term_boundary -> is_type stump_abstraction
 
 val invert_is_type_boundary :
-  ?name:Name.t -> is_type_boundary -> is_type stump_abstraction
+  ?name:Name.t -> is_type_boundary -> unit stump_abstraction
 
 val invert_eq_type_boundary :
-  ?name:Name.t -> eq_type_boundary -> eq_type stump_abstraction
+  ?name:Name.t -> eq_type_boundary -> (is_type * is_type) stump_abstraction
 
 val invert_eq_term_boundary :
-  ?name:Name.t -> eq_term_boundary -> eq_term stump_abstraction
+  ?name:Name.t -> eq_term_boundary -> (is_term * is_term * is_type) stump_abstraction
 
 val context_is_type_abstraction : is_type_abstraction -> is_atom list
 val context_is_term_abstraction : is_term_abstraction -> is_atom list

--- a/src/nucleus/nucleus.mli
+++ b/src/nucleus/nucleus.mli
@@ -153,10 +153,6 @@ val form_is_term_meta : signature -> is_term_meta -> is_term list -> is_term
 
 val form_is_term_convert : signature -> is_term -> eq_type -> is_term
 
-val form_eq_type_meta : signature -> eq_type_meta -> is_term list -> eq_type
-
-val form_eq_term_meta : signature -> eq_term_meta -> is_term list -> eq_term
-
 (** Form a non-abstracted abstraction *)
 val abstract_not_abstract : 'a -> 'a abstraction
 
@@ -182,10 +178,6 @@ val fresh_eq_term_meta : Name.t -> eq_term_boundary abstraction -> eq_term_meta
 (** [fresh_judgement_meta x bdry] creates a fresh meta-variable with the given boundary *)
 val fresh_judgement_meta : Name.t -> boundary_abstraction -> boundary_abstraction meta
 
-val is_type_meta_eta_expanded : signature -> is_type_meta -> is_type_abstraction
-val is_term_meta_eta_expanded : signature -> is_term_meta -> is_term_abstraction
-val eq_type_meta_eta_expanded : signature -> eq_type_meta -> eq_type_abstraction
-val eq_term_meta_eta_expanded : signature -> eq_term_meta -> eq_term_abstraction
 val judgement_meta_eta_expanded : signature -> boundary_abstraction meta -> judgement_abstraction
 
 (** Verify that an abstraction is in fact not abstract *)

--- a/src/nucleus/nucleus.mli
+++ b/src/nucleus/nucleus.mli
@@ -208,8 +208,6 @@ val invert_is_term : signature -> is_term -> stump_is_term
 
 val invert_eq_type : eq_type -> stump_eq_type
 
-val invert_eq_term : eq_term -> stump_eq_term
-
 val atom_name : is_atom -> Name.t
 
 val meta_nonce : 'a meta -> Nonce.t
@@ -225,6 +223,18 @@ val invert_eq_type_abstraction :
 
 val invert_eq_term_abstraction :
   ?name:Name.t -> eq_term_abstraction -> eq_term stump_abstraction
+
+val invert_is_term_boundary :
+  ?name:Name.t -> is_term_boundary -> is_term stump_abstraction
+
+val invert_is_type_boundary :
+  ?name:Name.t -> is_type_boundary -> is_type stump_abstraction
+
+val invert_eq_type_boundary :
+  ?name:Name.t -> eq_type_boundary -> eq_type stump_abstraction
+
+val invert_eq_term_boundary :
+  ?name:Name.t -> eq_term_boundary -> eq_term stump_abstraction
 
 val context_is_type_abstraction : is_type_abstraction -> is_atom list
 val context_is_term_abstraction : is_term_abstraction -> is_atom list

--- a/src/nucleus/nucleus.mli
+++ b/src/nucleus/nucleus.mli
@@ -171,16 +171,18 @@ val form_eq_term_meta : signature -> eq_term_meta -> is_term list -> eq_term
 val abstract_not_abstract : 'a -> 'a abstraction
 
 (** Form an abstracted judgement *)
-val abstract_is_type : is_atom -> is_type_abstraction -> is_type_abstraction
+(* val abstract_is_type : is_atom -> is_type_abstraction -> is_type_abstraction *)
 val abstract_is_term : is_atom -> is_term_abstraction -> is_term_abstraction
-val abstract_eq_type : is_atom -> eq_type_abstraction -> eq_type_abstraction
-val abstract_eq_term : is_atom -> eq_term_abstraction -> eq_term_abstraction
+(* val abstract_eq_type : is_atom -> eq_type_abstraction -> eq_type_abstraction *)
+(* val abstract_eq_term : is_atom -> eq_term_abstraction -> eq_term_abstraction *)
+val abstract_judgement : is_atom -> judgement -> judgement
 
 (** Form an abstracted boundary *)
-val abstract_boundary_is_type : is_atom -> is_type_boundary -> is_type_boundary
-val abstract_boundary_is_term : is_atom -> is_term_boundary -> is_term_boundary
-val abstract_boundary_eq_type : is_atom -> eq_type_boundary -> eq_type_boundary
-val abstract_boundary_eq_term : is_atom -> eq_term_boundary -> eq_term_boundary
+(* val abstract_boundary_is_type : is_atom -> is_type_boundary -> is_type_boundary *)
+(* val abstract_boundary_is_term : is_atom -> is_term_boundary -> is_term_boundary *)
+(* val abstract_boundary_eq_type : is_atom -> eq_type_boundary -> eq_type_boundary *)
+(* val abstract_boundary_eq_term : is_atom -> eq_term_boundary -> eq_term_boundary *)
+val abstract_boundary : is_atom -> boundary -> boundary
 
 (** [fresh_atom x t] Create a fresh atom from name [x] with type [t] *)
 val fresh_atom : Name.t -> is_type -> is_atom
@@ -304,6 +306,12 @@ val alpha_equal_type : is_type -> is_type -> bool
 val alpha_equal_abstraction
   : ('a -> 'a -> bool) -> 'a abstraction -> 'a abstraction -> bool
 
+(** Test whether two judgements are alpha-equal. *)
+val alpha_equal_judgement : judgement -> judgement -> bool
+
+(** Test whether two boundaries are alpha-equal. *)
+val alpha_equal_boundary : boundary -> boundary -> bool
+
 (** If [e1 == e2 : A] then [e2 == e1 : A] *)
 val symmetry_term : eq_term -> eq_term
 
@@ -353,6 +361,12 @@ val print_eq_term_abstraction :
 val print_eq_type_abstraction :
   ?max_level:Level.t -> penv:print_environment -> eq_type_abstraction -> Format.formatter -> unit
 
+val print_judgement :
+  ?max_level:Level.t -> penv:print_environment -> judgement -> Format.formatter -> unit
+
+val print_boundary :
+  ?max_level:Level.t -> penv:print_environment -> boundary -> Format.formatter -> unit
+
 (** An error emitted by the nucleus *)
 type error
 
@@ -363,13 +377,7 @@ val print_error : penv:print_environment -> error -> Format.formatter -> unit
 
 module Json :
 sig
-  val abstraction : ('a -> Json.t) -> 'a abstraction -> Json.t
+  val judgement : judgement -> Json.t
 
-  val is_term : is_term -> Json.t
-
-  val is_type : is_type -> Json.t
-
-  val eq_term : eq_term -> Json.t
-
-  val eq_type : eq_type -> Json.t
+  val boundary : boundary -> Json.t
 end

--- a/src/nucleus/nucleus.mli
+++ b/src/nucleus/nucleus.mli
@@ -185,11 +185,8 @@ val fresh_judgement_meta : Name.t -> boundary_abstraction -> boundary_abstractio
 
 val judgement_meta_eta_expanded : signature -> boundary_abstraction meta -> judgement_abstraction
 
-(** Verify that an abstraction is in fact not abstract *)
+(** Verify that an abstraction is in fact not abstract. *)
 val as_not_abstract : 'a abstraction -> 'a option
-
-(** Verify that an abstraction is in fact abstract *)
-val as_abstract : 'a abstraction -> (is_atom * 'a abstraction) option
 
 val as_is_type_abstraction : judgement_abstraction -> is_type abstraction option
 val as_is_term_abstraction : judgement_abstraction -> is_term abstraction option
@@ -233,6 +230,9 @@ val invert_eq_type_abstraction :
 val invert_eq_term_abstraction :
   ?name:Name.t -> eq_term_abstraction -> eq_term stump_abstraction
 
+val invert_judgement_abstraction :
+  ?name:Name.t -> judgement_abstraction -> judgement stump_abstraction
+
 val invert_is_term_boundary :
   ?name:Name.t -> is_term_boundary abstraction -> is_type stump_abstraction
 
@@ -244,6 +244,9 @@ val invert_eq_type_boundary :
 
 val invert_eq_term_boundary :
   ?name:Name.t -> eq_term_boundary abstraction -> (is_term * is_term * is_type) stump_abstraction
+
+val invert_boundary_abstraction :
+  ?name:Name.t -> boundary_abstraction -> boundary stump_abstraction
 
 val context_is_type_abstraction : is_type_abstraction -> is_atom list
 val context_is_term_abstraction : is_term_abstraction -> is_atom list

--- a/src/nucleus/nucleus.mli
+++ b/src/nucleus/nucleus.mli
@@ -259,6 +259,7 @@ val check_is_type_boundary : is_type_abstraction -> is_type_boundary -> bool
 val check_is_term_boundary : signature -> is_term_abstraction -> is_term_boundary -> bool
 val check_eq_type_boundary : eq_type_abstraction -> eq_type_boundary -> bool
 val check_eq_term_boundary : eq_term_abstraction -> eq_term_boundary -> bool
+val check_judgement_boundary : signature -> judgement -> boundary -> bool
 
 (** Typeof for atoms *)
 val type_of_atom : is_atom -> is_type

--- a/src/nucleus/nucleus.mli
+++ b/src/nucleus/nucleus.mli
@@ -34,22 +34,25 @@ type eq_term_abstraction = eq_term abstraction
 
 (** Judgement *)
 type judgement =
-  | JudgementIsType of is_type_abstraction
-  | JudgementIsTerm of is_term_abstraction
-  | JudgementEqType of eq_type_abstraction
-  | JudgementEqTerm of eq_term_abstraction
+  | JudgementIsType of is_type
+  | JudgementIsTerm of is_term
+  | JudgementEqType of eq_type
+  | JudgementEqTerm of eq_term
+
+(** A shorthand abstracted judgement *)
+type judgement_abstraction = judgement abstraction
 
 (** Boundary of a type judgement *)
-type is_type_boundary = unit abstraction
+type is_type_boundary = unit
 
 (** Boundary of a term judgement *)
-type is_term_boundary = is_type abstraction
+type is_term_boundary = is_type
 
 (** Boundary of a type equality judgement *)
-type eq_type_boundary = (is_type * is_type) abstraction
+type eq_type_boundary = (is_type * is_type)
 
 (** Boundary of a term equality judgement *)
-type eq_term_boundary = (is_term * is_term * is_type) abstraction
+type eq_term_boundary = (is_term * is_term * is_type)
 
 (** Boundary of a judgement *)
 type boundary =
@@ -58,23 +61,26 @@ type boundary =
     | BoundaryEqType of eq_type_boundary
     | BoundaryEqTerm of eq_term_boundary
 
+(** A shorthand for abstracted boundary *)
+type boundary_abstraction = boundary abstraction
+
 type assumption
 
 type 'a meta
-type is_type_meta = is_type_boundary meta
-type is_term_meta = is_term_boundary meta
-type eq_type_meta = eq_type_boundary meta
-type eq_term_meta = eq_term_boundary meta
+type is_type_meta = is_type_boundary abstraction meta
+type is_term_meta = is_term_boundary abstraction meta
+type eq_type_meta = eq_type_boundary abstraction meta
+type eq_term_meta = eq_term_boundary abstraction meta
 
 (** A stump is obtained when we invert a judgement. *)
 
 type nonrec stump_is_type =
-  | Stump_TypeConstructor of Ident.t * judgement list
+  | Stump_TypeConstructor of Ident.t * judgement_abstraction list
   | Stump_TypeMeta of is_type_meta * is_term list
 
 and stump_is_term =
   | Stump_TermAtom of is_atom
-  | Stump_TermConstructor of Ident.t * judgement list
+  | Stump_TermConstructor of Ident.t * judgement_abstraction list
   | Stump_TermMeta of is_term_meta * is_term list
   | Stump_TermConvert of is_term * eq_type
 
@@ -110,16 +116,16 @@ module Signature : sig
 end
 
 val form_rule_is_type :
-  (Nonce.t * boundary) list -> Rule.rule_is_type
+  (Nonce.t * boundary_abstraction) list -> Rule.rule_is_type
 
 val form_rule_is_term :
-  (Nonce.t * boundary) list -> is_type -> Rule.rule_is_term
+  (Nonce.t * boundary_abstraction) list -> is_type -> Rule.rule_is_term
 
 val form_rule_eq_type :
-  (Nonce.t * boundary) list -> is_type * is_type -> Rule.rule_eq_type
+  (Nonce.t * boundary_abstraction) list -> is_type * is_type -> Rule.rule_eq_type
 
 val form_rule_eq_term :
-  (Nonce.t * boundary) list -> is_term * is_term * is_type -> Rule.rule_eq_term
+  (Nonce.t * boundary_abstraction) list -> is_term * is_term * is_type -> Rule.rule_eq_term
 
 (** A partially applied rule is a rule with an initial part of the premises
    applied already. We need to represent such partial applications in order to
@@ -143,10 +149,10 @@ val form_rap_eq_type : signature -> Ident.t -> eq_type rule_application
 val form_rap_eq_term : signature -> Ident.t -> eq_term rule_application
 
 (** Apply a rap to one more argument *)
-val rap_apply : signature -> 'a rule_application_status -> judgement -> 'a rule_application
+val rap_apply : signature -> 'a rule_application_status -> judgement_abstraction -> 'a rule_application
 
 (** Give the boundary of a rap status, i.e., the boundary of the next argument. *)
-val rap_boundary : 'a rule_application_status -> boundary
+val rap_boundary : 'a rule_application_status -> boundary_abstraction
 
 (** Convert atom judgement to term judgement *)
 val form_is_term_atom : is_atom -> is_term
@@ -188,10 +194,10 @@ val abstract_boundary : is_atom -> boundary -> boundary
 val fresh_atom : Name.t -> is_type -> is_atom
 
 (** [fresh_is_type_meta x abstr] creates a fresh type meta-variable of type [abstr] *)
-val fresh_is_type_meta : Name.t -> is_type_boundary -> is_type_meta
-val fresh_is_term_meta : Name.t -> is_term_boundary -> is_term_meta
-val fresh_eq_type_meta : Name.t -> eq_type_boundary -> eq_type_meta
-val fresh_eq_term_meta : Name.t -> eq_term_boundary -> eq_term_meta
+val fresh_is_type_meta : Name.t -> is_type_boundary abstraction -> is_type_meta
+val fresh_is_term_meta : Name.t -> is_term_boundary abstraction -> is_term_meta
+val fresh_eq_type_meta : Name.t -> eq_type_boundary abstraction -> eq_type_meta
+val fresh_eq_term_meta : Name.t -> eq_term_boundary abstraction -> eq_term_meta
 
 val is_type_meta_eta_expanded : signature -> is_type_meta -> is_type_abstraction
 val is_term_meta_eta_expanded : signature -> is_term_meta -> is_term_abstraction
@@ -228,16 +234,16 @@ val invert_eq_term_abstraction :
   ?name:Name.t -> eq_term_abstraction -> eq_term stump_abstraction
 
 val invert_is_term_boundary :
-  ?name:Name.t -> is_term_boundary -> is_type stump_abstraction
+  ?name:Name.t -> is_term_boundary abstraction -> is_type stump_abstraction
 
 val invert_is_type_boundary :
-  ?name:Name.t -> is_type_boundary -> unit stump_abstraction
+  ?name:Name.t -> is_type_boundary abstraction -> unit stump_abstraction
 
 val invert_eq_type_boundary :
-  ?name:Name.t -> eq_type_boundary -> (is_type * is_type) stump_abstraction
+  ?name:Name.t -> eq_type_boundary abstraction -> (is_type * is_type) stump_abstraction
 
 val invert_eq_term_boundary :
-  ?name:Name.t -> eq_term_boundary -> (is_term * is_term * is_type) stump_abstraction
+  ?name:Name.t -> eq_term_boundary abstraction -> (is_term * is_term * is_type) stump_abstraction
 
 val context_is_type_abstraction : is_type_abstraction -> is_atom list
 val context_is_term_abstraction : is_term_abstraction -> is_atom list
@@ -255,11 +261,7 @@ val type_of_term_abstraction : signature -> is_term_abstraction -> is_type_abstr
 val type_at_abstraction : 'a abstraction -> is_type option
 
 (** Checking that an abstracted judgement has the desired boundary *)
-val check_is_type_boundary : is_type_abstraction -> is_type_boundary -> bool
-val check_is_term_boundary : signature -> is_term_abstraction -> is_term_boundary -> bool
-val check_eq_type_boundary : eq_type_abstraction -> eq_type_boundary -> bool
-val check_eq_term_boundary : eq_term_abstraction -> eq_term_boundary -> bool
-val check_judgement_boundary : signature -> judgement -> boundary -> bool
+val check_judgement_boundary_abstraction : signature -> judgement_abstraction -> boundary_abstraction -> bool
 
 (** Typeof for atoms *)
 val type_of_atom : is_atom -> is_type
@@ -281,6 +283,9 @@ val apply_eq_type_abstraction :
 
 val apply_eq_term_abstraction :
   signature -> eq_term_abstraction -> is_term -> eq_term_abstraction
+
+val apply_judgement_abstraction :
+  signature -> judgement_abstraction -> is_term -> judgement_abstraction
 
 (** If [e1 == e2 : A] and [A == B] then [e1 == e2 : B] *)
 val form_eq_term_convert : eq_term -> eq_type -> eq_term
@@ -336,6 +341,11 @@ val congruence_type_constructor :
 val congruence_term_constructor :
   signature -> Ident.t -> congruence_argument list -> eq_term
 
+(** Give human names to things *)
+
+val name_of_judgement : judgement_abstraction -> string
+val name_of_boundary : boundary_abstraction -> string
+
 (** Printing routines *)
 
 val print_is_term :
@@ -362,11 +372,11 @@ val print_eq_term_abstraction :
 val print_eq_type_abstraction :
   ?max_level:Level.t -> penv:print_environment -> eq_type_abstraction -> Format.formatter -> unit
 
-val print_judgement :
-  ?max_level:Level.t -> penv:print_environment -> judgement -> Format.formatter -> unit
+val print_judgement_abstraction :
+  ?max_level:Level.t -> penv:print_environment -> judgement_abstraction -> Format.formatter -> unit
 
-val print_boundary :
-  ?max_level:Level.t -> penv:print_environment -> boundary -> Format.formatter -> unit
+val print_boundary_abstraction :
+  ?max_level:Level.t -> penv:print_environment -> boundary_abstraction -> Format.formatter -> unit
 
 (** An error emitted by the nucleus *)
 type error

--- a/src/nucleus/nucleus.mli
+++ b/src/nucleus/nucleus.mli
@@ -43,23 +43,23 @@ type judgement =
 type judgement_abstraction = judgement abstraction
 
 (** Boundary of a type judgement *)
-type is_type_boundary = unit
+type is_type_boundary
 
 (** Boundary of a term judgement *)
-type is_term_boundary = is_type
+type is_term_boundary
 
 (** Boundary of a type equality judgement *)
-type eq_type_boundary = (is_type * is_type)
+type eq_type_boundary
 
 (** Boundary of a term equality judgement *)
-type eq_term_boundary = (is_term * is_term * is_type)
+type eq_term_boundary
 
 (** Boundary of a judgement *)
 type boundary =
-    | BoundaryIsType of is_type_boundary
-    | BoundaryIsTerm of is_term_boundary
-    | BoundaryEqType of eq_type_boundary
-    | BoundaryEqTerm of eq_term_boundary
+  | BoundaryIsType of is_type_boundary
+  | BoundaryIsTerm of is_term_boundary
+  | BoundaryEqType of eq_type_boundary
+  | BoundaryEqTerm of eq_term_boundary
 
 (** A shorthand for abstracted boundary *)
 type boundary_abstraction = boundary abstraction
@@ -134,7 +134,6 @@ val form_rap : signature -> Ident.t -> rule_application
 (** Apply a rap to one more argument *)
 val rap_apply : signature -> rule_application_status -> judgement_abstraction -> rule_application
 
-
 (** Give the boundary of a rap status, i.e., the boundary of the next argument. *)
 val rap_boundary : rule_application_status -> boundary_abstraction
 
@@ -152,6 +151,12 @@ val form_is_type_meta : signature -> is_type_meta -> is_term list -> is_type
 val form_is_term_meta : signature -> is_term_meta -> is_term list -> is_term
 
 val form_is_term_convert : signature -> is_term -> eq_type -> is_term
+
+(** Form a boundary *)
+val form_is_type_boundary : boundary
+val form_is_term_boundary : is_type -> boundary
+val form_eq_type_boundary : is_type -> is_type -> boundary
+val form_eq_term_boundary : signature -> is_term -> is_term -> boundary
 
 (** Form a non-abstracted abstraction *)
 val abstract_not_abstract : 'a -> 'a abstraction
@@ -190,6 +195,17 @@ val as_is_type_abstraction : judgement_abstraction -> is_type abstraction option
 val as_is_term_abstraction : judgement_abstraction -> is_term abstraction option
 val as_eq_type_abstraction : judgement_abstraction -> eq_type abstraction option
 val as_eq_term_abstraction : judgement_abstraction -> eq_term abstraction option
+
+val as_is_type : judgement -> is_type option
+val as_is_term : judgement -> is_term option
+val as_eq_type : judgement -> eq_type option
+val as_eq_term : judgement -> eq_term option
+
+val convert_term_abstraction : signature -> is_term abstraction -> eq_type abstraction -> is_term abstraction option
+
+val convert_eq_term_abstraction : eq_term abstraction -> eq_type abstraction -> eq_term abstraction option
+
+val convert_judgement_abstraction : signature -> judgement_abstraction -> eq_type_abstraction -> judgement_abstraction option
 
 (** Inversion principles *)
 

--- a/src/nucleus/nucleus_json.ml
+++ b/src/nucleus/nucleus_json.ml
@@ -84,3 +84,7 @@ let boundary = function
 
   | BoundaryEqTerm (e1, e2, t) ->
      Json.tag "BoundaryEqTerm" [is_term e1; is_term e2; is_type t]
+
+let judgement_abstraction abstr = Json.List (abstraction judgement [] abstr)
+
+let boundary_abstraction abstr = Json.List (abstraction boundary [] abstr)

--- a/src/nucleus/nucleus_json.ml
+++ b/src/nucleus/nucleus_json.ml
@@ -2,33 +2,21 @@
 
 open Nucleus_types
 
-let assumptions { free ; is_type_meta ; is_term_meta ; eq_type_meta ; eq_term_meta ; bound } =
+let assumptions { free ; meta ; bound } =
   let free =
     if Nonce.map_is_empty free
     then []
     else [("free", Nonce.Json.map free)]
-  and is_type_meta =
-    if Nonce.map_is_empty is_type_meta
+  and meta =
+    if Nonce.map_is_empty meta
     then []
-    else [("is_type_meta", Nonce.Json.map is_type_meta)]
-  and is_term_meta =
-    if Nonce.map_is_empty is_term_meta
-    then []
-    else [("is_term_meta", Nonce.Json.map is_term_meta)]
-  and eq_type_meta =
-    if Nonce.map_is_empty eq_type_meta
-    then []
-    else [("eq_type_meta", Nonce.Json.map eq_type_meta)]
-  and eq_term_meta =
-    if Nonce.map_is_empty eq_term_meta
-    then []
-    else [("eq_term_meta", Nonce.Json.map eq_term_meta)]
+    else [("meta", Nonce.Json.map meta)]
   and bound =
     if Bound_set.is_empty bound
     then []
     else [("bound", Json.List (List.map (fun k -> Json.Int k) (Bound_set.elements bound)))]
   in
-  Json.record (free @ is_type_meta @ is_term_meta @ eq_type_meta @ eq_term_meta @ bound)
+  Json.record (free @ meta @ bound)
 
 let rec is_term e =
   let e =

--- a/src/nucleus/nucleus_json.ml
+++ b/src/nucleus/nucleus_json.ml
@@ -59,10 +59,10 @@ and is_type t =
 and args lst =
   (List.map
      (function
-       | ArgumentIsTerm abstr -> Json.tag "ArgumentIsTerm" (abstraction is_term [] abstr)
-       | ArgumentIsType abstr -> Json.tag "ArgumentIsType" (abstraction is_type [] abstr)
-       | ArgumentEqType _ -> Json.tag "ArgumentIsType" []
-       | ArgumentEqTerm _ -> Json.tag "ArgumentEqTerm" [])
+       | JudgementIsTerm abstr -> Json.tag "JudgementIsTerm" (abstraction is_term [] abstr)
+       | JudgementIsType abstr -> Json.tag "JudgementIsType" (abstraction is_type [] abstr)
+       | JudgementEqType _ -> Json.tag "JudgementIsType" []
+       | JudgementEqTerm _ -> Json.tag "JudgementEqTerm" [])
      lst)
 
 and abstraction : 'a . ('a -> Json.t) -> (Name.t * is_type) list -> 'a abstraction -> Json.t list =

--- a/src/nucleus/nucleus_print.ml
+++ b/src/nucleus/nucleus_print.ml
@@ -122,13 +122,13 @@ and abstraction
 
 and argument ~penv arg ppf =
   match arg with
-  | ArgumentIsType abstr ->
+  | JudgementIsType abstr ->
      abstraction Occurs.is_type thesis_ty ~max_level:Level.constructor_arg ~penv abstr ppf
-  | ArgumentIsTerm abstr ->
+  | JudgementIsTerm abstr ->
      abstraction Occurs.is_term thesis_term ~max_level:Level.constructor_arg ~penv abstr ppf
-  | ArgumentEqType abstr ->
+  | JudgementEqType abstr ->
      abstraction Occurs.eq_type thesis_eq_type ~max_level:Level.constructor_arg ~penv abstr ppf
-  | ArgumentEqTerm abstr ->
+  | JudgementEqTerm abstr ->
      abstraction Occurs.eq_term thesis_eq_term ~max_level:Level.constructor_arg ~penv abstr ppf
 
 

--- a/src/nucleus/nucleus_print.ml
+++ b/src/nucleus/nucleus_print.ml
@@ -220,9 +220,9 @@ let error ~penv err ppf =
 
   | TooManyArguments -> Format.fprintf ppf "too many arguments"
 
-  | TermExpected -> Format.fprintf ppf "term expected"
+  | IsTermExpected -> Format.fprintf ppf "term expected"
 
-  | TypeExpected -> Format.fprintf ppf "type expected"
+  | IsTypeExpected -> Format.fprintf ppf "type expected"
 
   | ExtraAssumptions -> Format.fprintf ppf "extra assumptions"
 

--- a/src/nucleus/nucleus_types.ml
+++ b/src/nucleus/nucleus_types.ml
@@ -81,25 +81,30 @@ type eq_term_abstraction = eq_term abstraction
    whereas the [invert_XYZ] functions do the opposite. We can think of stumps
    as "stumps", i.e., the lowest level of a derivation tree. *)
 
-type nonrec stump_is_type =
+type stump_is_type =
   | Stump_TypeConstructor of Ident.t * judgement_abstraction list
   | Stump_TypeMeta of is_type_meta * is_term list
 
-and stump_is_term =
+type stump_is_term =
   | Stump_TermAtom of is_atom
   | Stump_TermConstructor of Ident.t * judgement_abstraction list
   | Stump_TermMeta of is_term_meta * is_term list
   | Stump_TermConvert of is_term * eq_type
 
-and stump_eq_type =
+type stump_eq_type =
   | Stump_EqType of assumption * is_type * is_type
 
-and stump_eq_term =
+type stump_eq_term =
   | Stump_EqTerm of assumption * is_term * is_term * is_type
 
-and 'a stump_abstraction =
+type 'a stump_abstraction =
   | Stump_NotAbstract of 'a
   | Stump_Abstract of is_atom * 'a abstraction
+
+(** A stump for inverting two abstractions at the same time. *)
+type ('a, 'b) stump_abstractions =
+  | Stumps_NotAbstract of 'a * 'b
+  | Stumps_Abstract of is_atom * 'a abstraction * 'b abstraction
 
 type congruence_argument =
   | CongrIsType of is_type abstraction * is_type abstraction * eq_type abstraction

--- a/src/nucleus/nucleus_types.ml
+++ b/src/nucleus/nucleus_types.ml
@@ -25,6 +25,7 @@ and is_type_meta = is_type_boundary abstraction meta
 and is_term_meta = is_term_boundary abstraction meta
 and eq_type_meta = eq_type_boundary abstraction meta
 and eq_term_meta = eq_term_boundary abstraction meta
+and judgement_meta = boundary_abstraction meta
 
 and assumption =
   { free : is_type Nonce.map

--- a/src/nucleus/nucleus_types.ml
+++ b/src/nucleus/nucleus_types.ml
@@ -29,10 +29,7 @@ and judgement_meta = boundary_abstraction meta
 
 and assumption =
   { free : is_type Nonce.map
-  ; is_type_meta : is_type_boundary abstraction Nonce.map
-  ; is_term_meta : is_term_boundary abstraction Nonce.map
-  ; eq_type_meta : eq_type_boundary abstraction Nonce.map
-  ; eq_term_meta : eq_term_boundary abstraction Nonce.map
+  ; meta : boundary_abstraction Nonce.map
   ; bound : Bound_set.t }
 
 and 'a abstraction =

--- a/src/nucleus/nucleus_types.ml
+++ b/src/nucleus/nucleus_types.ml
@@ -102,7 +102,7 @@ type 'a stump_abstraction =
   | Stump_Abstract of is_atom * 'a abstraction
 
 (** A stump for inverting two abstractions at the same time. *)
-type ('a, 'b) stump_abstractions =
+type ('a, 'b) stumps_abstraction =
   | Stumps_NotAbstract of 'a * 'b
   | Stumps_Abstract of is_atom * 'a abstraction * 'b abstraction
 

--- a/src/nucleus/nucleus_types.ml
+++ b/src/nucleus/nucleus_types.ml
@@ -123,8 +123,8 @@ type error =
   | InvalidAbstraction
   | TooFewArguments
   | TooManyArguments
-  | TermExpected
-  | TypeExpected
+  | IsTermExpected
+  | IsTypeExpected
   | ExtraAssumptions
   | InvalidApplication
   | InvalidArgument

--- a/src/nucleus/nucleus_types.ml
+++ b/src/nucleus/nucleus_types.ml
@@ -4,13 +4,13 @@ type bound = int
 
 type is_type =
   | TypeMeta of is_type_meta * is_term list
-  | TypeConstructor of Ident.t * argument list
+  | TypeConstructor of Ident.t * judgement list
 
 and is_term =
   | TermBound of bound
   | TermAtom of is_atom
   | TermMeta of is_term_meta * is_term list
-  | TermConstructor of Ident.t * argument list
+  | TermConstructor of Ident.t * judgement list
   | TermConvert of is_term * assumption * is_type
 
 and eq_type = EqType of assumption * is_type * is_type
@@ -38,11 +38,11 @@ and 'a abstraction =
   | NotAbstract of 'a
   | Abstract of is_atom * 'a abstraction
 
-and argument =
-  | ArgumentIsType of is_type abstraction
-  | ArgumentIsTerm of is_term abstraction
-  | ArgumentEqType of eq_type abstraction
-  | ArgumentEqTerm of eq_term abstraction
+and judgement =
+  | JudgementIsType of is_type abstraction
+  | JudgementIsTerm of is_term abstraction
+  | JudgementEqType of eq_type abstraction
+  | JudgementEqTerm of eq_term abstraction
 
 and is_type_boundary = unit abstraction
 and is_term_boundary = is_type abstraction
@@ -56,10 +56,10 @@ and boundary =
     | BoundaryEqTerm of eq_term_boundary
 
 type 'a rule_application_status =
-  { rap_arguments : argument list (* the arguments collected so far *)
+  { rap_arguments : judgement list (* the arguments collected so far *)
   ; rap_boundary : boundary (* the boundary of the next argument *)
   ; rap_premises : Rule.premise list (* the remaining premises to be applied *)
-  ; rap_constructor : argument list -> 'a (* the function which makes the final result *)
+  ; rap_constructor : judgement list -> 'a (* the function which makes the final result *)
   }
 
 (* A partial rule application *)
@@ -85,12 +85,12 @@ type eq_term_abstraction = eq_term abstraction
    as "stumps", i.e., the lowest level of a derivation tree. *)
 
 type nonrec stump_is_type =
-  | Stump_TypeConstructor of Ident.t * argument list
+  | Stump_TypeConstructor of Ident.t * judgement list
   | Stump_TypeMeta of is_type_meta * is_term list
 
 and stump_is_term =
   | Stump_TermAtom of is_atom
-  | Stump_TermConstructor of Ident.t * argument list
+  | Stump_TermConstructor of Ident.t * judgement list
   | Stump_TermMeta of is_term_meta * is_term list
   | Stump_TermConvert of is_term * eq_type
 
@@ -119,7 +119,7 @@ type congruence_argument =
 
    Used by module Indices
 *)
-type indices = argument list
+type indices = judgement list
 
 type error =
   | InvalidInstantiation

--- a/src/nucleus/nucleus_types.ml
+++ b/src/nucleus/nucleus_types.ml
@@ -59,24 +59,19 @@ and boundary =
 
 and boundary_abstraction = boundary abstraction
 
-type 'a rule_application_status =
+type rule_application_status =
   { rap_arguments : judgement_abstraction list (* the arguments collected so far *)
   ; rap_boundary : boundary_abstraction (* the boundary of the next argument *)
-  ; rap_premises : Rule.premise_abstraction list (* the remaining premises to be applied *)
-  ; rap_constructor : judgement_abstraction list -> 'a (* the function which makes the final result *)
+  ; rap_premises : Rule.boundary_abstraction list (* the remaining premises to be applied *)
+  ; rap_constructor : judgement_abstraction list -> judgement (* the function which makes the final result *)
   }
 
 (* A partial rule application *)
-type 'a rule_application =
-  | RapDone of 'a
-  | RapMore of 'a rule_application_status
+type rule_application =
+  | RapDone of judgement
+  | RapMore of rule_application_status
 
-type signature =
-  { is_type : Rule.rule_is_type Ident.map
-  ; is_term : Rule.rule_is_term Ident.map
-  ; eq_type : Rule.rule_eq_type Ident.map
-  ; eq_term : Rule.rule_eq_term Ident.map
-  }
+type signature = Rule.rule Ident.map
 
 type is_term_abstraction = is_term abstraction
 type is_type_abstraction = is_type abstraction

--- a/src/nucleus/nucleus_types.ml
+++ b/src/nucleus/nucleus_types.ml
@@ -4,13 +4,13 @@ type bound = int
 
 type is_type =
   | TypeMeta of is_type_meta * is_term list
-  | TypeConstructor of Ident.t * judgement list
+  | TypeConstructor of Ident.t * judgement_abstraction list
 
 and is_term =
   | TermBound of bound
   | TermAtom of is_atom
   | TermMeta of is_term_meta * is_term list
-  | TermConstructor of Ident.t * judgement list
+  | TermConstructor of Ident.t * judgement_abstraction list
   | TermConvert of is_term * assumption * is_type
 
 and eq_type = EqType of assumption * is_type * is_type
@@ -21,17 +21,17 @@ and is_atom = { atom_nonce : Nonce.t ; atom_type : is_type }
 
 and 't meta = { meta_nonce : Nonce.t ; meta_type : 't }
 
-and is_type_meta = is_type_boundary meta
-and is_term_meta = is_term_boundary meta
-and eq_type_meta = eq_type_boundary meta
-and eq_term_meta = eq_term_boundary meta
+and is_type_meta = is_type_boundary abstraction meta
+and is_term_meta = is_term_boundary abstraction meta
+and eq_type_meta = eq_type_boundary abstraction meta
+and eq_term_meta = eq_term_boundary abstraction meta
 
 and assumption =
   { free : is_type Nonce.map
-  ; is_type_meta : is_type_boundary Nonce.map
-  ; is_term_meta : is_term_boundary Nonce.map
-  ; eq_type_meta : eq_type_boundary Nonce.map
-  ; eq_term_meta : eq_term_boundary Nonce.map
+  ; is_type_meta : is_type_boundary abstraction Nonce.map
+  ; is_term_meta : is_term_boundary abstraction Nonce.map
+  ; eq_type_meta : eq_type_boundary abstraction Nonce.map
+  ; eq_term_meta : eq_term_boundary abstraction Nonce.map
   ; bound : Bound_set.t }
 
 and 'a abstraction =
@@ -39,27 +39,31 @@ and 'a abstraction =
   | Abstract of is_atom * 'a abstraction
 
 and judgement =
-  | JudgementIsType of is_type abstraction
-  | JudgementIsTerm of is_term abstraction
-  | JudgementEqType of eq_type abstraction
-  | JudgementEqTerm of eq_term abstraction
+  | JudgementIsType of is_type
+  | JudgementIsTerm of is_term
+  | JudgementEqType of eq_type
+  | JudgementEqTerm of eq_term
 
-and is_type_boundary = unit abstraction
-and is_term_boundary = is_type abstraction
-and eq_type_boundary = (is_type * is_type) abstraction
-and eq_term_boundary = (is_term * is_term * is_type) abstraction
+and judgement_abstraction = judgement abstraction
+
+and is_type_boundary = unit
+and is_term_boundary = is_type
+and eq_type_boundary = is_type * is_type
+and eq_term_boundary = is_term * is_term * is_type
 
 and boundary =
-    | BoundaryIsType of is_type_boundary
-    | BoundaryIsTerm of is_term_boundary
-    | BoundaryEqType of eq_type_boundary
-    | BoundaryEqTerm of eq_term_boundary
+  | BoundaryIsType of is_type_boundary
+  | BoundaryIsTerm of is_term_boundary
+  | BoundaryEqType of eq_type_boundary
+  | BoundaryEqTerm of eq_term_boundary
+
+and boundary_abstraction = boundary abstraction
 
 type 'a rule_application_status =
-  { rap_arguments : judgement list (* the arguments collected so far *)
-  ; rap_boundary : boundary (* the boundary of the next argument *)
-  ; rap_premises : Rule.premise list (* the remaining premises to be applied *)
-  ; rap_constructor : judgement list -> 'a (* the function which makes the final result *)
+  { rap_arguments : judgement_abstraction list (* the arguments collected so far *)
+  ; rap_boundary : boundary_abstraction (* the boundary of the next argument *)
+  ; rap_premises : Rule.premise_abstraction list (* the remaining premises to be applied *)
+  ; rap_constructor : judgement_abstraction list -> 'a (* the function which makes the final result *)
   }
 
 (* A partial rule application *)
@@ -85,12 +89,12 @@ type eq_term_abstraction = eq_term abstraction
    as "stumps", i.e., the lowest level of a derivation tree. *)
 
 type nonrec stump_is_type =
-  | Stump_TypeConstructor of Ident.t * judgement list
+  | Stump_TypeConstructor of Ident.t * judgement_abstraction list
   | Stump_TypeMeta of is_type_meta * is_term list
 
 and stump_is_term =
   | Stump_TermAtom of is_atom
-  | Stump_TermConstructor of Ident.t * judgement list
+  | Stump_TermConstructor of Ident.t * judgement_abstraction list
   | Stump_TermMeta of is_term_meta * is_term list
   | Stump_TermConvert of is_term * eq_type
 
@@ -119,7 +123,7 @@ type congruence_argument =
 
    Used by module Indices
 *)
-type indices = judgement list
+type 'a indices = 'a list
 
 type error =
   | InvalidInstantiation

--- a/src/nucleus/occurs.ml
+++ b/src/nucleus/occurs.ml
@@ -38,7 +38,7 @@ and term_arguments k = function
   | arg :: args -> is_term k arg || term_arguments k args
 
 and argument k = function
-  | ArgumentIsType t  -> abstraction is_type k t
-  | ArgumentIsTerm e  -> abstraction is_term k e
-  | ArgumentEqType abstr -> abstraction eq_type k abstr
-  | ArgumentEqTerm abstr -> abstraction eq_term k abstr
+  | JudgementIsType t  -> abstraction is_type k t
+  | JudgementIsTerm e  -> abstraction is_term k e
+  | JudgementEqType abstr -> abstraction eq_type k abstr
+  | JudgementEqTerm abstr -> abstraction eq_term k abstr

--- a/src/nucleus/occurs.ml
+++ b/src/nucleus/occurs.ml
@@ -31,14 +31,20 @@ and abstraction
 
 and arguments k = function
   | [] -> false
-  | arg :: args -> argument k arg || arguments k args
+  | arg :: args -> abstraction judgement k arg || arguments k args
 
 and term_arguments k = function
   | [] -> false
   | arg :: args -> is_term k arg || term_arguments k args
 
-and argument k = function
-  | JudgementIsType t  -> abstraction is_type k t
-  | JudgementIsTerm e  -> abstraction is_term k e
-  | JudgementEqType abstr -> abstraction eq_type k abstr
-  | JudgementEqTerm abstr -> abstraction eq_term k abstr
+and judgement k = function
+  | JudgementIsType t  -> is_type k t
+  | JudgementIsTerm e  -> is_term k e
+  | JudgementEqType eq -> eq_type k eq
+  | JudgementEqTerm eq -> eq_term k eq
+
+let boundary k = function
+  | BoundaryIsType ()  -> false
+  | BoundaryIsTerm t  -> is_type k t
+  | BoundaryEqType (t1, t2) -> is_type k t1 || is_type k t2
+  | BoundaryEqTerm (e1, e2, t) -> is_type k t || is_term k e1  || is_term k e2

--- a/src/nucleus/rule.mli
+++ b/src/nucleus/rule.mli
@@ -6,12 +6,12 @@ type meta = int
 type bound = int
 
 type ty =
-  | TypeConstructor of Ident.t * argument list
+  | TypeConstructor of Ident.t * argument_abstraction list
   | TypeMeta of meta * term list
 
 and term =
   | TermBound of bound
-  | TermConstructor of Ident.t * argument list
+  | TermConstructor of Ident.t * argument_abstraction list
   | TermMeta of meta * term list
 
 and eq_type = EqType of ty * ty
@@ -19,22 +19,26 @@ and eq_type = EqType of ty * ty
 and eq_term = EqTerm of term * term * ty
 
 and argument =
-  | JudgementIsType of ty abstraction
-  | JudgementIsTerm of term abstraction
-  | JudgementEqType of eq_type abstraction
-  | JudgementEqTerm of eq_term abstraction
+  | JudgementIsType of ty
+  | JudgementIsTerm of term
+  | JudgementEqType of eq_type
+  | JudgementEqTerm of eq_term
+
+and argument_abstraction = argument abstraction
 
 and 'a abstraction =
   | NotAbstract of 'a
   | Abstract of Name.t * ty * 'a abstraction
 
 type premise =
-  | PremiseIsType of unit abstraction
-  | PremiseIsTerm of ty abstraction
-  | PremiseEqType of (ty * ty) abstraction
-  | PremiseEqTerm of (term * term * ty) abstraction
+  | PremiseIsType of unit
+  | PremiseIsTerm of ty
+  | PremiseEqType of ty * ty
+  | PremiseEqTerm of term * term * ty
 
-type rule_is_type = premise list * unit
-type rule_is_term = premise list * ty
-type rule_eq_type = premise list * (ty * ty)
-type rule_eq_term = premise list * (term * term * ty)
+and premise_abstraction = premise abstraction
+
+type rule_is_type = premise_abstraction list * unit
+type rule_is_term = premise_abstraction list * ty
+type rule_eq_type = premise_abstraction list * (ty * ty)
+type rule_eq_term = premise_abstraction list * (term * term * ty)

--- a/src/nucleus/rule.mli
+++ b/src/nucleus/rule.mli
@@ -19,10 +19,10 @@ and eq_type = EqType of ty * ty
 and eq_term = EqTerm of term * term * ty
 
 and argument =
-  | ArgumentIsType of ty abstraction
-  | ArgumentIsTerm of term abstraction
-  | ArgumentEqType of eq_type abstraction
-  | ArgumentEqTerm of eq_term abstraction
+  | JudgementIsType of ty abstraction
+  | JudgementIsTerm of term abstraction
+  | JudgementEqType of eq_type abstraction
+  | JudgementEqTerm of eq_term abstraction
 
 and 'a abstraction =
   | NotAbstract of 'a

--- a/src/nucleus/rule.mli
+++ b/src/nucleus/rule.mli
@@ -6,39 +6,36 @@ type meta = int
 type bound = int
 
 type ty =
-  | TypeConstructor of Ident.t * argument_abstraction list
+  | TypeConstructor of Ident.t * judgement_abstraction list
   | TypeMeta of meta * term list
 
 and term =
   | TermBound of bound
-  | TermConstructor of Ident.t * argument_abstraction list
+  | TermConstructor of Ident.t * judgement_abstraction list
   | TermMeta of meta * term list
 
 and eq_type = EqType of ty * ty
 
 and eq_term = EqTerm of term * term * ty
 
-and argument =
+and judgement =
   | JudgementIsType of ty
   | JudgementIsTerm of term
   | JudgementEqType of eq_type
   | JudgementEqTerm of eq_term
 
-and argument_abstraction = argument abstraction
+and judgement_abstraction = judgement abstraction
 
 and 'a abstraction =
   | NotAbstract of 'a
   | Abstract of Name.t * ty * 'a abstraction
 
-type premise =
-  | PremiseIsType of unit
-  | PremiseIsTerm of ty
-  | PremiseEqType of ty * ty
-  | PremiseEqTerm of term * term * ty
+type boundary =
+  | BoundaryIsType of unit
+  | BoundaryIsTerm of ty
+  | BoundaryEqType of ty * ty
+  | BoundaryEqTerm of term * term * ty
 
-and premise_abstraction = premise abstraction
+and boundary_abstraction = boundary abstraction
 
-type rule_is_type = premise_abstraction list * unit
-type rule_is_term = premise_abstraction list * ty
-type rule_eq_type = premise_abstraction list * (ty * ty)
-type rule_eq_term = premise_abstraction list * (term * term * ty)
+type rule = boundary_abstraction list * boundary

--- a/src/nucleus/sanity.ml
+++ b/src/nucleus/sanity.ml
@@ -16,7 +16,13 @@ let type_of_term sgn = function
      assert false
 
   | TermConstructor (c, args) ->
-     let (_premises, t_schema) = Signature.lookup_rule_is_term c sgn in
+     let (_premises, concl) = Signature.lookup_rule c sgn in
+     let t_schema =
+       match concl with
+       | Rule.BoundaryIsTerm t_schema -> t_schema
+       | Rule.BoundaryIsType _ | Rule.BoundaryEqType _ | Rule.BoundaryEqTerm _ ->
+          assert false
+     in
      (* we need not re-check that the premises match the arguments because
         we are computing the type of a term that was previously determined
         to be valid. *)

--- a/src/nucleus/shift.ml
+++ b/src/nucleus/shift.ml
@@ -77,18 +77,18 @@ and arguments ~lvl k args =
   List.map (argument ~lvl k) args
 
 and argument ~lvl k = function
-   | ArgumentIsTerm abstr ->
+   | JudgementIsTerm abstr ->
       let abstr = abstraction is_term ~lvl k abstr in
-      ArgumentIsTerm abstr
+      JudgementIsTerm abstr
 
-   | ArgumentIsType abstr ->
+   | JudgementIsType abstr ->
       let abstr = abstraction is_type ~lvl k abstr in
-      ArgumentIsType abstr
+      JudgementIsType abstr
 
-   | ArgumentEqType abstr ->
+   | JudgementEqType abstr ->
       let abstr = abstraction eq_type ~lvl k abstr in
-      ArgumentEqType abstr
+      JudgementEqType abstr
 
-   | ArgumentEqTerm abstr ->
+   | JudgementEqTerm abstr ->
       let abstr = abstraction eq_term ~lvl k abstr in
-      ArgumentEqTerm abstr
+      JudgementEqTerm abstr

--- a/src/nucleus/shift.ml
+++ b/src/nucleus/shift.ml
@@ -74,21 +74,13 @@ and term_arguments ~lvl k args =
   List.map (is_term ~lvl k) args
 
 and arguments ~lvl k args =
-  List.map (argument ~lvl k) args
+  List.map (abstraction argument ~lvl k) args
 
 and argument ~lvl k = function
-   | JudgementIsTerm abstr ->
-      let abstr = abstraction is_term ~lvl k abstr in
-      JudgementIsTerm abstr
+   | JudgementIsType t -> JudgementIsType (is_type ~lvl k t)
 
-   | JudgementIsType abstr ->
-      let abstr = abstraction is_type ~lvl k abstr in
-      JudgementIsType abstr
+   | JudgementIsTerm e -> JudgementIsTerm (is_term ~lvl k e)
 
-   | JudgementEqType abstr ->
-      let abstr = abstraction eq_type ~lvl k abstr in
-      JudgementEqType abstr
+   | JudgementEqType eq -> JudgementEqType (eq_type ~lvl k eq)
 
-   | JudgementEqTerm abstr ->
-      let abstr = abstraction eq_term ~lvl k abstr in
-      JudgementEqTerm abstr
+   | JudgementEqTerm eq -> JudgementEqTerm (eq_term ~lvl k eq)

--- a/src/nucleus/signature.ml
+++ b/src/nucleus/signature.ml
@@ -1,20 +1,5 @@
-open Nucleus_types
+let empty : Rule.rule Ident.map = Ident.empty
 
-let empty =
-  { is_type = Ident.empty
-  ; is_term = Ident.empty
-  ; eq_type = Ident.empty
-  ; eq_term = Ident.empty
-  }
+let add_rule c rule (sgn : Rule.rule Ident.map) = assert (not (Ident.mem c sgn)) ; Ident.add c rule sgn
 
-let add_new c rule map = assert (not (Ident.mem c map)) ; Ident.add c rule map
-
-let add_rule_is_type c rule sgn = { sgn with is_type = add_new c rule sgn.is_type }
-let add_rule_is_term c rule sgn = { sgn with is_term = add_new c rule sgn.is_term }
-let add_rule_eq_type c rule sgn = { sgn with eq_type = add_new c rule sgn.eq_type }
-let add_rule_eq_term c rule sgn = { sgn with eq_term = add_new c rule sgn.eq_term }
-
-let lookup_rule_is_type c sgn = Ident.find c sgn.is_type
-let lookup_rule_is_term c sgn = Ident.find c sgn.is_term
-let lookup_rule_eq_type c sgn = Ident.find c sgn.eq_type
-let lookup_rule_eq_term c sgn = Ident.find c sgn.eq_term
+let lookup_rule c (sgn : Rule.rule Ident.map) = Ident.find c sgn

--- a/src/parser/builtin.ml
+++ b/src/parser/builtin.ml
@@ -7,8 +7,6 @@ let unloc x = Location.locate x Location.unknown
 
 let builtin_ml_types =
   let ty_alpha = unloc (Input.ML_TyApply (Name.PName name_alpha, [])) in
-  let un_ml_is_term = unloc (Input.ML_Judgement (Input.ML_NotAbstract Input.ML_IsTerm)) in
-  let un_ml_eq_type = unloc (Input.ML_Judgement (Input.ML_NotAbstract Input.ML_EqType)) in
   let decl_bool = Input.DefMLType [Name.Builtin.bool_name, ([],
     Input.ML_Sum [
     (Name.Builtin.mlfalse_name, []);
@@ -20,13 +18,6 @@ let builtin_ml_types =
     (Name.Builtin.some_name, [ty_alpha])
     ])]
 
-  and decl_coercible = Input.DefMLType [Name.Builtin.coercible_ty_name, ([],
-    Input.ML_Sum [
-    (Name.Builtin.notcoercible_name, []) ;
-    (Name.Builtin.convertible_name, [un_ml_eq_type]);
-    (Name.Builtin.coercible_constructor_name, [un_ml_is_term])
-    ])]
-
   and decl_order = Input.DefMLType [Name.Builtin.mlorder_name, ([],
     Input.ML_Sum [
       (Name.Builtin.mlless_name, []) ;
@@ -34,36 +25,34 @@ let builtin_ml_types =
       (Name.Builtin.mlgreater_name, [])
       ])]
   in
-  [unloc decl_bool; unloc decl_option; unloc decl_coercible; unloc decl_order]
+  [unloc decl_bool; unloc decl_option; unloc decl_order]
 
 let builtin_ops =
-  let un_ml_is_type = unloc (Input.ML_Judgement (Input.ML_NotAbstract Input.ML_IsType)) in
-  let un_ml_is_term = unloc (Input.ML_Judgement (Input.ML_NotAbstract Input.ML_IsTerm)) in
-  let un_ml_eq_type = unloc (Input.ML_Judgement (Input.ML_NotAbstract Input.ML_EqType)) in
-  let un_ml_eq_term = unloc (Input.ML_Judgement (Input.ML_NotAbstract Input.ML_EqTerm)) in
+  let un_ml_judgement = unloc (Input.ML_Judgement) in
+  let un_ml_boundary = unloc (Input.ML_Boundary) in
   let decl_equal_term =
     Input.DeclOperation
       (Name.Builtin.equal_term_name,
-       ([un_ml_is_term; un_ml_is_term],
-        unloc (Input.ML_TyApply (Name.PName Name.Builtin.option_name, [un_ml_eq_term]))))
+       ([un_ml_judgement; un_ml_judgement],
+        unloc (Input.ML_TyApply (Name.PName Name.Builtin.option_name, [un_ml_judgement]))))
   and decl_equal_type =
     Input.DeclOperation
       (Name.Builtin.equal_type_name,
-       ([un_ml_is_type; un_ml_is_type],
-        unloc (Input.ML_TyApply (Name.PName Name.Builtin.option_name, [un_ml_eq_type]))))
+       ([un_ml_judgement; un_ml_judgement],
+        unloc (Input.ML_TyApply (Name.PName Name.Builtin.option_name, [un_ml_judgement]))))
   and decl_coerce =
     Input.DeclOperation
       (Name.Builtin.coerce_name,
-       ([un_ml_is_term; un_ml_is_type],
-        unloc (Input.ML_TyApply (Name.PName Name.Builtin.coercible_ty_name, []))))
+       ([un_ml_judgement; un_ml_boundary],
+        unloc (Input.ML_TyApply (Name.PName Name.Builtin.option_name, [un_ml_judgement]))))
   in
   [unloc decl_equal_term;
    unloc decl_equal_type;
    unloc decl_coerce]
 
 let builtin_ml_values =
-  let un_ml_is_term = unloc (Input.ML_Judgement (Input.ML_NotAbstract Input.ML_IsTerm)) in
-  let hyps_annot = unloc (Input.ML_TyApply (Name.PName Name.Builtin.list_name, [un_ml_is_term])) in
+  let un_ml_judgement = unloc (Input.ML_Judgement) in
+  let hyps_annot = unloc (Input.ML_TyApply (Name.PName Name.Builtin.list_name, [un_ml_judgement])) in
   let empty_list = unloc (Input.Spine (unloc (Input.Name (Name.PName Name.Builtin.nil_name)), [])) in
   let decl_hyps = Input.TopDynamic
                     (Name.Builtin.hypotheses_name, Input.Arg_annot_ty hyps_annot, empty_list) in

--- a/src/parser/desugar.ml
+++ b/src/parser/desugar.ml
@@ -1400,7 +1400,8 @@ let premise ctx {Location.thing=prem;loc} =
   | Input.PremiseIsType (mvar, local_ctx) ->
      let (), local_ctx = local_context ctx local_ctx (fun _ -> ()) in
      let ctx = (match mvar with None -> ctx | Some x -> Ctx.add_bound x ctx) in
-     ctx, locate (Dsyntax.PremiseIsType (mvar, local_ctx)) loc
+     let bdry = Dsyntax.BoundaryIsType in
+     ctx, locate (Dsyntax.Premise (mvar, local_ctx, bdry)) loc
 
   | Input.PremiseIsTerm (mvar, local_ctx, c) ->
      let c, local_ctx =
@@ -1409,10 +1410,11 @@ let premise ctx {Location.thing=prem;loc} =
          (fun ctx -> comp ctx c)
      in
      let ctx = (match mvar with None -> ctx | Some x -> Ctx.add_bound x ctx) in
-     ctx, locate (Dsyntax.PremiseIsTerm (mvar, local_ctx, c)) loc
+     let bdry = Dsyntax.BoundaryIsTerm c in
+     ctx, locate (Dsyntax.Premise (mvar, local_ctx, bdry)) loc
 
   | Input.PremiseEqType (mvar, local_ctx, (c1, c2)) ->
-     let c12, local_ctx =
+     let (c1, c2), local_ctx =
        local_context
          ctx local_ctx
          (fun ctx ->
@@ -1420,10 +1422,11 @@ let premise ctx {Location.thing=prem;loc} =
            comp ctx c2)
      in
      let ctx = (match mvar with None -> ctx | Some x -> Ctx.add_bound x ctx) in
-     ctx, locate (Dsyntax.PremiseEqType (mvar, local_ctx, c12)) loc
+     let bdry = Dsyntax.BoundaryEqType (c1, c2) in
+     ctx, locate (Dsyntax.Premise (mvar, local_ctx, bdry)) loc
 
   | Input.PremiseEqTerm (mvar, local_ctx, (c1, c2, c3)) ->
-     let c123, local_ctx =
+     let (c1, c2, c3), local_ctx =
        local_context ctx local_ctx
        (fun ctx ->
          comp ctx c1,
@@ -1431,7 +1434,8 @@ let premise ctx {Location.thing=prem;loc} =
          comp ctx c3)
      in
      let ctx = (match mvar with None -> ctx | Some x -> Ctx.add_bound x ctx) in
-     ctx, locate (Dsyntax.PremiseEqTerm (mvar, local_ctx, c123)) loc
+     let bdry = Dsyntax.BoundaryEqTerm (c1, c2, c3) in
+     ctx, locate (Dsyntax.Premise (mvar, local_ctx, bdry)) loc
 
 let premises ctx prems m =
   let rec fold ctx prems_out = function
@@ -1454,7 +1458,8 @@ let rec toplevel' ~loading ~basedir ctx {Location.thing=cmd; loc} =
   | Input.RuleIsType (rname, prems) ->
      let (), prems = premises ctx prems (fun _ -> ()) in
      let pth, ctx = Ctx.add_tt_constructor ~loc rname (List.length prems) ctx in
-     (ctx, locate1 (Dsyntax.RuleIsType (pth, prems)))
+     let bdry = Dsyntax.BoundaryIsType in
+     (ctx, locate1 (Dsyntax.Rule (pth, prems, bdry)))
 
   | Input.RuleIsTerm (rname, prems, c) ->
      let c, prems =
@@ -1463,10 +1468,11 @@ let rec toplevel' ~loading ~basedir ctx {Location.thing=cmd; loc} =
          (fun ctx -> comp ctx c)
      in
      let pth, ctx = Ctx.add_tt_constructor ~loc rname (List.length prems) ctx in
-     (ctx, locate1 (Dsyntax.RuleIsTerm (pth, prems, c)))
+     let bdry = Dsyntax.BoundaryIsTerm c in
+     (ctx, locate1 (Dsyntax.Rule (pth, prems, bdry)))
 
   | Input.RuleEqType (rname, prems, (c1, c2)) ->
-     let c12, prems =
+     let (c1, c2), prems =
        premises
          ctx prems
          (fun ctx ->
@@ -1474,10 +1480,11 @@ let rec toplevel' ~loading ~basedir ctx {Location.thing=cmd; loc} =
            comp ctx c2)
      in
      let pth, ctx = Ctx.add_tt_constructor ~loc rname (List.length prems) ctx in
-     (ctx, locate1 (Dsyntax.RuleEqType (pth, prems, c12)))
+     let bdry = Dsyntax.BoundaryEqType (c1, c2) in
+     (ctx, locate1 (Dsyntax.Rule (pth, prems, bdry)))
 
   | Input.RuleEqTerm (rname, prems, (c1, c2, c3)) ->
-     let c123, prems =
+     let (c1, c2, c3), prems =
        premises
          ctx prems
          (fun ctx ->
@@ -1486,7 +1493,8 @@ let rec toplevel' ~loading ~basedir ctx {Location.thing=cmd; loc} =
           comp ctx c3)
      in
      let pth, ctx = Ctx.add_tt_constructor ~loc rname (List.length prems) ctx in
-     (ctx, locate1 (Dsyntax.RuleEqTerm (pth, prems, c123)))
+     let bdry = Dsyntax.BoundaryEqTerm (c1, c2, c3) in
+     (ctx, locate1 (Dsyntax.Rule (pth, prems, bdry)))
 
   | Input.DeclOperation (op, (args, res)) ->
      let args, res = decl_operation ~loc ctx args res in

--- a/src/parser/desugar.ml
+++ b/src/parser/desugar.ml
@@ -1420,7 +1420,8 @@ let premise ctx {Location.thing=prem;loc} =
   match prem with
   | Input.PremiseIsType (mvar, local_ctx) ->
      let (), local_ctx = local_context ctx local_ctx (fun _ -> ()) in
-     let ctx = (match mvar with None -> ctx | Some x -> Ctx.add_bound x ctx) in
+     let mvar = (match mvar with Some mvar -> mvar | None -> Name.anonymous ()) in
+     let ctx = Ctx.add_bound mvar ctx in
      let bdry = Dsyntax.BoundaryIsType in
      ctx, locate (Dsyntax.Premise (mvar, local_ctx, bdry)) loc
 
@@ -1430,7 +1431,8 @@ let premise ctx {Location.thing=prem;loc} =
          ctx local_ctx
          (fun ctx -> comp ctx c)
      in
-     let ctx = (match mvar with None -> ctx | Some x -> Ctx.add_bound x ctx) in
+     let mvar = (match mvar with Some mvar -> mvar | None -> Name.anonymous ()) in
+     let ctx = Ctx.add_bound mvar ctx in
      let bdry = Dsyntax.BoundaryIsTerm c in
      ctx, locate (Dsyntax.Premise (mvar, local_ctx, bdry)) loc
 
@@ -1442,7 +1444,8 @@ let premise ctx {Location.thing=prem;loc} =
            comp ctx c1,
            comp ctx c2)
      in
-     let ctx = (match mvar with None -> ctx | Some x -> Ctx.add_bound x ctx) in
+     let mvar = (match mvar with Some mvar -> mvar | None -> Name.anonymous ()) in
+     let ctx = Ctx.add_bound mvar ctx in
      let bdry = Dsyntax.BoundaryEqType (c1, c2) in
      ctx, locate (Dsyntax.Premise (mvar, local_ctx, bdry)) loc
 
@@ -1454,7 +1457,8 @@ let premise ctx {Location.thing=prem;loc} =
          comp ctx c2,
          comp ctx c3)
      in
-     let ctx = (match mvar with None -> ctx | Some x -> Ctx.add_bound x ctx) in
+     let mvar = (match mvar with Some mvar -> mvar | None -> Name.anonymous ()) in
+     let ctx = Ctx.add_bound mvar ctx in
      let bdry = Dsyntax.BoundaryEqTerm (c1, c2, c3) in
      ctx, locate (Dsyntax.Premise (mvar, local_ctx, bdry)) loc
 

--- a/src/parser/desugar.ml
+++ b/src/parser/desugar.ml
@@ -947,7 +947,6 @@ let rec comp ctx {Location.thing=c';loc} =
      and c = comp ctx c in
      locate (Dsyntax.Ascribe (c, t)) loc
 
-
   | Input.Abstract (xs, c) ->
      let rec fold ctx ys = function
        | [] ->
@@ -1046,10 +1045,32 @@ let rec comp ctx {Location.thing=c';loc} =
      and c2 = comp ctx c2 in
      locate (Dsyntax.Occurs (c1,c2)) loc
 
+  | Input.Convert (c1,c2) ->
+     let c1 = comp ctx c1
+     and c2 = comp ctx c2 in
+     locate (Dsyntax.Convert (c1,c2)) loc
+
   | Input.Natural c ->
      let c = comp ctx c in
      locate (Dsyntax.Natural c) loc
 
+  | Input.MLBoundaryIsType ->
+     locate Dsyntax.(MLBoundary BoundaryIsType) loc
+
+  | Input.MLBoundaryIsTerm c ->
+     let c = comp ctx c in
+     locate Dsyntax.(MLBoundary (BoundaryIsTerm c)) loc
+
+  | Input.MLBoundaryEqType (c1, c2) ->
+     let c1 = comp ctx c1
+     and c2 = comp ctx c2 in
+     locate Dsyntax.(MLBoundary (BoundaryEqType (c1, c2))) loc
+
+  | Input.MLBoundaryEqTerm (c1, c2, c3) ->
+     let c1 = comp ctx c1
+     and c2 = comp ctx c2
+     and c3 = comp ctx c3 in
+     locate Dsyntax.(MLBoundary (BoundaryEqTerm (c1, c2, c3))) loc
 
 and let_clauses ~loc ~toplevel ctx lst =
   let add = if toplevel then Ctx.add_ml_value ~loc else Ctx.add_bound in

--- a/src/parser/desugar.ml
+++ b/src/parser/desugar.ml
@@ -532,22 +532,6 @@ let check_arity ~loc pth used expected =
 
 let locate = Location.locate
 
-let mlty_judgement = function
-  | Input.ML_IsType -> Dsyntax.ML_IsType
-  | Input.ML_IsTerm -> Dsyntax.ML_IsTerm
-  | Input.ML_EqType -> Dsyntax.ML_EqType
-  | Input.ML_EqTerm -> Dsyntax.ML_EqTerm
-
-let rec mlty_abstracted_judgement = function
-
-  | Input.ML_NotAbstract frm ->
-     let frm = mlty_judgement frm in
-     Dsyntax.ML_NotAbstract frm
-
-  | Input.ML_Abstract abstr ->
-     let abstr = mlty_abstracted_judgement abstr in
-     Dsyntax.ML_Abstract abstr
-
 (* Desugar an ML type, with the given list of known type parameters *)
 let mlty ctx params ty =
   let rec mlty ({Location.thing=ty';loc}) =
@@ -612,9 +596,11 @@ let mlty ctx params ty =
       | Input.ML_Anonymous ->
          Dsyntax.ML_Anonymous
 
-      | Input.ML_Judgement abstr ->
-         let abstr = mlty_abstracted_judgement abstr
-         in Dsyntax.ML_Judgement abstr
+      | Input.ML_Judgement ->
+         Dsyntax.ML_Judgement
+
+      | Input.ML_Boundary ->
+         Dsyntax.ML_Boundary
 
       | Input.ML_String -> Dsyntax.ML_String
       end

--- a/src/parser/desugar.ml
+++ b/src/parser/desugar.ml
@@ -1655,10 +1655,6 @@ struct
   let none = fst (Ctx.get_ml_constructor Name.Builtin.none initial_context)
   let some = fst (Ctx.get_ml_constructor Name.Builtin.some initial_context)
 
-  let notcoercible = fst (Ctx.get_ml_constructor Name.Builtin.notcoercible initial_context)
-  let convertible = fst (Ctx.get_ml_constructor Name.Builtin.convertible initial_context)
-  let coercible_constructor = fst (Ctx.get_ml_constructor Name.Builtin.coercible_constructor initial_context)
-
   let mlless = fst (Ctx.get_ml_constructor Name.Builtin.mlless initial_context)
   let mlequal = fst (Ctx.get_ml_constructor Name.Builtin.mlequal initial_context)
   let mlgreater = fst (Ctx.get_ml_constructor Name.Builtin.mlgreater initial_context)

--- a/src/parser/desugar.mli
+++ b/src/parser/desugar.mli
@@ -51,10 +51,6 @@ sig
   val none : Path.ml_constructor
   val some : Path.ml_constructor
 
-  val notcoercible : Path.ml_constructor
-  val convertible : Path.ml_constructor
-  val coercible_constructor : Path.ml_constructor
-
   val mlless : Path.ml_constructor
   val mlequal : Path.ml_constructor
   val mlgreater : Path.ml_constructor

--- a/src/parser/input.mli
+++ b/src/parser/input.mli
@@ -95,8 +95,13 @@ and comp' =
   | Yield of comp
   | String of string
   | Context of comp
+  | Convert of comp * comp
   | Occurs of comp * comp
   | Natural of comp
+  | MLBoundaryIsType
+  | MLBoundaryIsTerm of comp
+  | MLBoundaryEqType of comp * comp
+  | MLBoundaryEqTerm of comp * comp * comp
 
 and let_clause =
   | Let_clause_ML of (Name.t * ml_arg list) option * let_annotation * comp

--- a/src/parser/input.mli
+++ b/src/parser/input.mli
@@ -12,16 +12,6 @@ type bound = int
 
 type path = Name.path
 
-type ml_judgement =
-  | ML_IsType
-  | ML_IsTerm
-  | ML_EqType
-  | ML_EqTerm
-
-type ml_abstracted_judgement =
-  | ML_NotAbstract of ml_judgement
-  | ML_Abstract of ml_abstracted_judgement
-
 type ml_ty = ml_ty' located
 and ml_ty' =
   | ML_Arrow of ml_ty * ml_ty
@@ -30,7 +20,8 @@ and ml_ty' =
   | ML_Handler of ml_ty * ml_ty
   | ML_Ref of ml_ty
   | ML_Dynamic of ml_ty
-  | ML_Judgement of ml_abstracted_judgement
+  | ML_Judgement
+  | ML_Boundary
   | ML_String
   | ML_Anonymous
 

--- a/src/parser/lexer.ml
+++ b/src/parser/lexer.ml
@@ -9,6 +9,7 @@ let reserved = [
   ("assume", ASSUME) ;
   ("boundary", MLBOUNDARY) ;
   ("context", CONTEXT) ;
+  ("convert", CONVERT) ;
   ("current", CURRENT) ;
   ("dynamic", DYNAMIC) ;
   ("end", END) ;
@@ -122,6 +123,7 @@ and token_aux ({ Ulexbuf.stream;_ } as lexbuf) =
   | ';'                      -> f (); SEMI
   (* We record the location of operators here because menhir cannot handle %infix and
      mark_location simultaneously, it seems. *)
+  | '?'                      -> f (); QUESTIONMARK (Name.mk_name ~fixity:Name.Prefix "?", loc_of lexbuf)
   | prefixop                 -> f (); PREFIXOP (let s = Ulexbuf.lexeme lexbuf in
                                                 Name.mk_name ~fixity:Name.Prefix s, loc_of lexbuf)
   (* Comes before infixop0 because it also matches infixop0. *)

--- a/src/parser/lexer.ml
+++ b/src/parser/lexer.ml
@@ -2,15 +2,12 @@
 open Parser
 
 let reserved = [
-  ("is_type", MLISTYPE) ;
-  ("is_term", MLISTERM) ;
-  ("eq_type", MLEQTYPE) ;
-  ("eq_term", MLEQTERM) ;
   ("_", UNDERSCORE) ;
   ("_atom", UATOM) ;
   ("and", AND) ;
   ("as", AS) ;
   ("assume", ASSUME) ;
+  ("boundary", MLBOUNDARY) ;
   ("context", CONTEXT) ;
   ("current", CURRENT) ;
   ("dynamic", DYNAMIC) ;
@@ -22,6 +19,7 @@ let reserved = [
   ("handler", HANDLER) ;
   ("in", IN) ;
   ("include", INCLUDE) ;
+  ("judgement", MLJUDGEMENT) ;
   ("let", LET) ;
   ("match", MATCH) ;
   ("mlforall", MLFORALL) ;

--- a/src/parser/parser.mly
+++ b/src/parser/parser.mly
@@ -47,7 +47,7 @@
 
 (* Meta types *)
 %token MLUNIT MLSTRING
-%token MLISTYPE MLISTERM MLEQTYPE MLEQTERM
+%token MLJUDGEMENT MLBOUNDARY
 %token MLTYPE
 %token MLFORALL
 %token OF
@@ -501,21 +501,12 @@ plain_app_mlty:
 simple_mlty: mark_location(plain_simple_mlty) { $1 }
 plain_simple_mlty:
   | LPAREN t=plain_mlty RPAREN          { t }
-  | c=long(ml_name)                    { ML_TyApply (c, []) }
-  | abstr=mlty_abstracted_judgement     { ML_Judgement abstr }
+  | c=long(ml_name)                     { ML_TyApply (c, []) }
+  | MLJUDGEMENT                         { ML_Judgement }
+  | MLBOUNDARY                          { ML_Boundary }
   | MLUNIT                              { ML_Prod [] }
   | MLSTRING                            { ML_String }
   | UNDERSCORE                          { ML_Anonymous }
-
-mlty_judgement:
-  | MLISTYPE { ML_IsType }
-  | MLISTERM { ML_IsTerm }
-  | MLEQTYPE { ML_EqType }
-  | MLEQTERM { ML_EqTerm }
-
-mlty_abstracted_judgement:
-  | frm=mlty_judgement                                      { ML_NotAbstract frm }
-  | LBRACE RBRACE abstr=mlty_abstracted_judgement           { ML_Abstract abstr }
 
 mlty_defs:
   | lst=separated_nonempty_list(AND, mlty_def) { lst }

--- a/src/parser/parser.mly
+++ b/src/parser/parser.mly
@@ -3,7 +3,7 @@
 %}
 
 (* Infix operations *)
-%token <Name.t * Location.t> PREFIXOP EQ INFIXOP0 INFIXOP1 INFIXCONS INFIXOP2 STAR INFIXOP3 INFIXOP4
+%token <Name.t * Location.t> QUESTIONMARK PREFIXOP EQ INFIXOP0 INFIXOP1 INFIXCONS INFIXOP2 STAR INFIXOP3 INFIXOP4
 
 (* Names and numerals *)
 %token UNDERSCORE
@@ -59,7 +59,7 @@
 %token FUNCTION
 
 (* Assumptions *)
-%token ASSUME CONTEXT OCCURS
+%token ASSUME CONVERT CONTEXT OCCURS
 
 (* Toplevel directives *)
 %token VERBOSITY
@@ -173,26 +173,31 @@ plain_term:
                                                                  { LetRec (lst, c) }
   | NOW x=app_term EQ c1=term IN c2=term                         { Now (x,c1,c2) }
   | CURRENT c=term                                               { Current c }
-  | ASSUME x=opt_name(ml_name) COLON t=ty_term IN c=term        { Assume ((x, t), c) }
+  | ASSUME x=opt_name(ml_name) COLON t=ty_term IN c=term         { Assume ((x, t), c) }
   | MATCH e=term WITH lst=match_cases END                        { Match (e, lst) }
   | HANDLE c=term WITH hcs=handler_cases END                     { Handle (c, hcs) }
+  | FUNCTION xs=ml_arg+ DARROW e=term                            { Function (xs, e) }
   | WITH h=term HANDLE c=term                                    { With (h, c) }
   | HANDLER hcs=handler_cases END                                { Handler (hcs) }
   | e=app_term COLON t=ty_term                                   { Ascribe (e, t) }
   | e1=binop_term SEMI e2=term                                   { Sequence (e1, e2) }
   | CONTEXT c=prefix_term                                        { Context c }
-  | OCCURS c1=prefix_term c2=prefix_term                         { Occurs (c1,c2) }
+  | CONVERT c1=prefix_term c2=prefix_term                        { Convert (c1, c2) }
+  | OCCURS c1=prefix_term c2=prefix_term                         { Occurs (c1, c2) }
 
 ty_term: mark_location(plain_ty_term) { $1 }
 plain_ty_term:
   | e=plain_binop_term                               { e }
   | a=abstraction e=binop_term                       { Abstract (a, e) }
-  | FUNCTION xs=ml_arg+ DARROW e=term                { Function (xs, e) }
 
 binop_term: mark_location(plain_binop_term) { $1 }
 plain_binop_term:
   | e=plain_app_term                                { e }
   | e1=app_term COLONEQ e2=binop_term               { Update (e1, e2) }
+  | QUESTIONMARK TYPE                                            { MLBoundaryIsType }
+  | QUESTIONMARK COLON t=app_term                                { MLBoundaryIsTerm t }
+  | l=app_term EQEQ r=app_term AS QUESTIONMARK                   { MLBoundaryEqType (l, r) }
+  | l=app_term EQEQ r=app_term COLON ty=term AS QUESTIONMARK     { MLBoundaryEqTerm (l, r, ty) }
   | e1=binop_term oploc=infix e2=binop_term
     { let (op, loc) = oploc in
       let op = Location.locate (Name (Name.PName op)) loc in
@@ -285,7 +290,7 @@ module_path:
 
 (* Prefix operators *)
 %inline prefix:
-  | op=PREFIXOP { op }
+  | op=PREFIXOP     { op }
 
 (* A name or optionally _ *)
 opt_name(X):

--- a/src/parser/ulexbuf.ml
+++ b/src/parser/ulexbuf.ml
@@ -15,7 +15,7 @@ type error =
 
 let print_error err ppf = match err with
   | SysError s -> Format.fprintf ppf "system error %s" s
-  | Unexpected s -> Format.fprintf ppf "unexpected %s" s
+  | Unexpected s -> Format.fprintf ppf "unexpected %s" (if String.equal s "" then "end of input" else s)
   | MalformedUTF8 -> Format.fprintf ppf "malformed UTF8"
   | BadNumeral s -> Format.fprintf ppf "bad numeral %s" s
   | UnclosedComment -> Format.fprintf ppf "input ended inside unclosed comment"

--- a/src/rsyntax.mli
+++ b/src/rsyntax.mli
@@ -118,7 +118,7 @@ type ml_tydef =
 type local_context = (Name.t * comp) list
 
 type premise = premise' located
-and premise' = Premise of Name.t option * local_context * boundary
+and premise' = Premise of Name.t * local_context * boundary
 
 (** Toplevel commands *)
 type toplevel = toplevel' located

--- a/src/rsyntax.mli
+++ b/src/rsyntax.mli
@@ -65,10 +65,7 @@ and comp' =
   | Assume of (Name.t option * comp) * comp
   | Match of comp * match_case list
   | Ascribe of comp * comp
-  | IsTypeConstructor of tt_constructor * comp list
-  | IsTermConstructor of tt_constructor * comp list
-  | EqTypeConstructor of tt_constructor * comp list
-  | EqTermConstructor of tt_constructor * comp list
+  | TTConstructor of tt_constructor * comp list
   | Apply of comp * comp
   | Abstract of Name.t * comp option * comp
   | Substitute of comp * comp

--- a/src/rsyntax.mli
+++ b/src/rsyntax.mli
@@ -74,10 +74,7 @@ and comp' =
   | Substitute of comp * comp
   | Yield of comp
   | String of string
-  | OccursIsTypeAbstraction of comp * comp
-  | OccursIsTermAbstraction of comp * comp
-  | OccursEqTypeAbstraction of comp * comp
-  | OccursEqTermAbstraction of comp * comp
+  | Occurs of comp * comp
   | Context of comp
   | Natural of comp
 

--- a/src/rsyntax.mli
+++ b/src/rsyntax.mli
@@ -75,8 +75,17 @@ and comp' =
   | Yield of comp
   | String of string
   | Occurs of comp * comp
+  | Convert of comp * comp
   | Context of comp
   | Natural of comp
+  | MLBoundary of boundary
+
+(** The boundary of the conclusion of a premise or a rule *)
+and boundary =
+   | BoundaryIsType
+   | BoundaryIsTerm of comp
+   | BoundaryEqType of comp * comp
+   | BoundaryEqTerm of comp * comp * comp
 
 (** A let-clause is given by a list of names with their types, a pattern that
    binds these variables (so the variables list needs to match the pattern!),
@@ -107,13 +116,6 @@ type ml_tydef =
   | ML_Alias of Mlty.ty
 
 type local_context = (Name.t * comp) list
-
-(** The boundary of the conclusion of a premise or a rule *)
-type boundary =
-   | BoundaryIsType
-   | BoundaryIsTerm of comp
-   | BoundaryEqType of comp * comp
-   | BoundaryEqTerm of comp * comp * comp
 
 type premise = premise' located
 and premise' = Premise of Name.t option * local_context * boundary

--- a/src/rsyntax.mli
+++ b/src/rsyntax.mli
@@ -5,7 +5,7 @@ type ml_constructor = Ident.t
 (** An operation is referred to by a unique identifier *)
 type operation = Ident.t
 
-(** A TT constructor is referred to by a unique identifier *)
+(** A rule/constructor is referred to by a unique identifier *)
 type tt_constructor = Ident.t
 
 (** Runtime code keeps around locations of the source code that it was generated
@@ -31,6 +31,9 @@ sig
   and is_type = judgement
   and is_term = judgement
   and argument = judgement
+
+  (** Boundary pattern *)
+  type boundary = Boundary_Pattern_Not_Implemented
 
   (** ML pattern *)
   type aml = aml' located
@@ -95,7 +98,7 @@ and handler = {
 and match_case = Pattern.aml * comp option * comp
 
 (** Match multiple patterns at once, with shared pattern variables *)
-and match_op_case = Pattern.aml list * Pattern.judgement option * comp
+and match_op_case = Pattern.aml list * Pattern.boundary option * comp
 
 (** Type definitions are needed during runtime so that we can print them
     at the toplevel. *)
@@ -105,20 +108,20 @@ type ml_tydef =
 
 type local_context = (Name.t * comp) list
 
+(** The boundary of the conclusion of a premise or a rule *)
+type boundary =
+   | BoundaryIsType
+   | BoundaryIsTerm of comp
+   | BoundaryEqType of comp * comp
+   | BoundaryEqTerm of comp * comp * comp
+
 type premise = premise' located
-and premise' =
-  | PremiseIsType of Name.t option * local_context
-  | PremiseIsTerm of Name.t option * local_context * comp
-  | PremiseEqType of Name.t option * local_context * (comp * comp)
-  | PremiseEqTerm of Name.t option * local_context * (comp * comp * comp)
+and premise' = Premise of Name.t option * local_context * boundary
 
 (** Toplevel commands *)
 type toplevel = toplevel' located
 and toplevel' =
-  | RuleIsType of tt_constructor * premise list
-  | RuleIsTerm of tt_constructor * premise list * comp
-  | RuleEqType of tt_constructor * premise list * (comp * comp)
-  | RuleEqTerm of tt_constructor * premise list * (comp * comp * comp)
+  | Rule of tt_constructor * premise list * boundary
   | DefMLType of Path.t list (* we only need the names *)
   | DefMLTypeRec of Path.t list
   | DeclOperation of Path.t * (Mlty.ty list * Mlty.ty)

--- a/src/runtime/equal.ml
+++ b/src/runtime/equal.ml
@@ -37,14 +37,14 @@ let equal_type ~loc t1 t2 =
            Runtime.(error ~loc (InvalidEqualType (t1, t2)))
 
 let coerce ~loc sgn jdg bdry =
-  if Nucleus.check_judgement_boundary sgn jdg bdry then
+  if Nucleus.check_judgement_boundary_abstraction sgn jdg bdry then
     return (Some jdg)
   else
     Reflect.operation_coerce ~loc jdg bdry >>= function
     | None -> return None
 
     | Some jdg ->
-       if Nucleus.check_judgement_boundary sgn jdg bdry then
+       if Nucleus.check_judgement_boundary_abstraction sgn jdg bdry then
          return (Some jdg)
        else
          Runtime.(error ~loc (InvalidCoerce (jdg, bdry)))

--- a/src/runtime/equal.ml
+++ b/src/runtime/equal.ml
@@ -1,155 +1,50 @@
 (** Equality checking and coercions *)
 
-(** An option monad on top of Runtime.comp, which only uses Runtime.bind when necessary. *)
-module Opt = struct
-  type 'a opt =
-    { k : 'r. ('a -> 'r Runtime.comp) -> 'r Runtime.comp -> 'r Runtime.comp }
+let return = Runtime.return
+let (>>=) = Runtime.bind
 
-  let return x =
-    { k = fun sk _ -> sk x }
-
-  let (>?=) m f =
-    { k = fun sk fk -> m.k (fun x -> (f x).k sk fk) fk }
-
-  let lift (m : 'a Runtime.comp) : 'a opt =
-    { k = fun sk _ -> Runtime.bind m sk }
-
-  let fail =
-    { k = fun _ fk -> fk }
-
-  let run m =
-    m.k (fun x -> Runtime.return (Some x)) (Runtime.return None)
-end
-
-let (>?=) = Opt.(>?=)
-
-let (>!=) m f = (Opt.lift m) >?= f
-
-module Internals = struct
 
 (** Compare two terms *)
-let equal ~loc sgn e1 e2 =
+let equal_term ~loc sgn e1 e2 =
   match Nucleus.form_alpha_equal_term sgn e1 e2 with
-    | Some eq -> Opt.return eq
+    | Some _ as eq -> return eq
     | None ->
-      Reflect.operation_equal_term ~loc e1 e2 >!=
+      Reflect.operation_equal_term ~loc e1 e2 >>=
         begin function
-          | None -> Opt.fail
+          | None -> return None
           | Some eq ->
              let (Nucleus.Stump_EqTerm (_asmp, e1', e2', _)) = Nucleus.invert_eq_term eq in
              begin
                match Nucleus.alpha_equal_term e1 e1' && Nucleus.alpha_equal_term e2 e2' with
-               | false -> Opt.lift (Runtime.(error ~loc (InvalidEqualTerm (e1, e2))))
-               | true -> Opt.return eq
+               | false -> Runtime.(error ~loc (InvalidEqualTerm (e1, e2)))
+               | true -> return (Some eq)
              end
         end
 
 (* Compare two types *)
 let equal_type ~loc t1 t2 =
   match Nucleus.form_alpha_equal_type t1 t2 with
-    | Some eq -> Opt.return eq
+    | Some _ as eq -> return eq
     | None ->
-      Reflect.operation_equal_type ~loc t1 t2 >!=
-        begin function
-          | None -> Opt.fail
-          | Some eq ->
-             let (Nucleus.Stump_EqType (_asmp, t1', t2')) = Nucleus.invert_eq_type eq in
-             begin match Nucleus.alpha_equal_type t1 t1' && Nucleus.alpha_equal_type t2 t2' with
-             | false -> Opt.lift (Runtime.(error ~loc (InvalidEqualType (t1, t2))))
-             | true -> Opt.return eq
-             end
-        end
+      Reflect.operation_equal_type ~loc t1 t2 >>= function
+      | None -> return None
 
-let coerce ~loc sgn e t =
-  let t' = Nucleus.type_of_term_abstraction sgn e in
-  match Nucleus.alpha_equal_abstraction Nucleus.alpha_equal_type t' t with
+      | Some eq ->
+         let (Nucleus.Stump_EqType (_asmp, t1', t2')) = Nucleus.invert_eq_type eq in
+         if Nucleus.alpha_equal_type t1 t1' && Nucleus.alpha_equal_type t2 t2' then
+           return (Some eq)
+         else
+           Runtime.(error ~loc (InvalidEqualType (t1, t2)))
 
-  | true -> Opt.return e
+let coerce ~loc sgn jdg bdry =
+  if Nucleus.check_judgement_boundary sgn jdg bdry then
+    return (Some jdg)
+  else
+    Reflect.operation_coerce ~loc jdg bdry >>= function
+    | None -> return None
 
-  | false ->
-     Reflect.operation_coerce ~loc e t >!=
-       begin function
-
-       | Runtime.NotCoercible -> Opt.fail
-
-       | Runtime.Convertible eq ->
-          (* Have:
-             e  = {x:A₁} … {x:Aₙ} ⊢ s : A
-             t' = {x:A₁} … {x:Aₙ} ⊢ A type
-             t  = {x:B₁} … {x:Bₘ} ⊢ B type
-             eq = {x:C₁} … {x:Cₘ} ⊢ C == D
-
-             Plan:
-             - Invert e to
-                 [a₁, …, aₙ] ⊢ s : A
-             - apply eq to [a₁, …, aₙ] forming
-                 eq' := (⊢ C == D) [ a₁, …, aₙ / x₁, …, xₘ ]
-               This might fail if `n =/= m` or if `∃ i, Aᵢ =/= Cᵢ`
-               We could check for this first and raise a runtime error, or try
-               and leave it to the nucleus to fail.
-             - check that `D' =α= t` to make sure we actually convert to where
-               we want
-             - convert s along eq', which might again fail in the nucleus.
-             - abstract [a₁, …, aₙ]
-          *)
-          let rec fully_apply_abstraction apply_abstr abstr = function
-            | [] -> abstr
-            | arg :: args ->
-               let abstr = apply_abstr sgn abstr arg in
-               fully_apply_abstraction apply_abstr abstr args
-          in
-          let fully_apply_eq_type_abstraction =
-            fully_apply_abstraction Nucleus.apply_eq_type_abstraction in
-          let fully_apply_is_type_abstraction =
-            fully_apply_abstraction Nucleus.apply_is_type_abstraction in
-
-          let rec convert_is_term_abstraction atoms abstr =
-            match Nucleus.invert_is_term_abstraction abstr with
-            | Nucleus.Stump_NotAbstract e ->
-               let atoms = List.rev atoms in
-               let atoms = List.map Nucleus.form_is_term_atom atoms in
-               let eq_app =
-                 let eq_app = fully_apply_eq_type_abstraction eq atoms in
-                 begin match Nucleus.as_not_abstract eq_app with
-                   | None -> Runtime.(error ~loc (InvalidConvertible (t', t, eq)))
-                   | Some eq -> eq
-                 end
-               and t_app =
-                 let t_app = fully_apply_is_type_abstraction t atoms in
-                 begin match Nucleus.as_not_abstract t_app with
-                   | None -> Runtime.(error ~loc (InvalidConvertible (t', t, eq)))
-                   | Some t_app -> t_app
-                 end
-               and t'_app = Nucleus.type_of_term sgn e
-               in
-               let Nucleus.Stump_EqType (_asmp, lhs, rhs) = Nucleus.invert_eq_type eq_app in
-               begin match Nucleus.alpha_equal_type rhs t_app && Nucleus.alpha_equal_type lhs t'_app with
-               | true -> ()
-               | false -> Runtime.(error ~loc (InvalidConvertible (t', t, eq)))
-               end ;
-               let e = Nucleus.form_is_term_convert sgn e eq_app in
-               Nucleus.abstract_not_abstract e
-            | Nucleus.Stump_Abstract (a, abstr) ->
-               let abstr = convert_is_term_abstraction (a::atoms) abstr in
-               Nucleus.abstract_is_term a abstr
-          in
-          Opt.return (convert_is_term_abstraction [] e)
-
-       | Runtime.Coercible e' ->
-          begin
-            let u = Nucleus.type_of_term_abstraction sgn e' in
-            match Nucleus.alpha_equal_abstraction Nucleus.alpha_equal_type t u with
-            | true -> Opt.return e'
-            | false -> Runtime.(error ~loc (InvalidCoerce (t, e')))
-          end
-       end
-
-end
-
-(** Expose without the monad stuff *)
-
-let equal ~loc sgn j1 j2 = Opt.run (Internals.equal ~loc sgn j1 j2)
-
-let equal_type ~loc j1 j2 = Opt.run (Internals.equal_type ~loc j1 j2)
-
-let coerce ~loc sgn je jt = Opt.run (Internals.coerce ~loc sgn je jt)
+    | Some jdg ->
+       if Nucleus.check_judgement_boundary sgn jdg bdry then
+         return (Some jdg)
+       else
+         Runtime.(error ~loc (InvalidCoerce (jdg, bdry)))

--- a/src/runtime/equal.mli
+++ b/src/runtime/equal.mli
@@ -1,7 +1,7 @@
 (** Equality checking *)
 
 (** Compares two terms at alpha-equivalent types *)
-val equal :
+val equal_term :
   loc:Location.t -> Nucleus.signature ->
   Nucleus.is_term -> Nucleus.is_term -> Nucleus.eq_term option Runtime.comp
 
@@ -11,5 +11,5 @@ val equal_type :
 
 (** Coerce the given term to the given type, if possible *)
 val coerce :
-  loc:Location.t -> Nucleus.signature -> Nucleus.is_term_abstraction -> Nucleus.is_type_abstraction ->
-  Nucleus.is_term_abstraction option Runtime.comp
+  loc:Location.t -> Nucleus.signature -> Nucleus.judgement -> Nucleus.boundary ->
+  Nucleus.judgement option Runtime.comp

--- a/src/runtime/equal.mli
+++ b/src/runtime/equal.mli
@@ -11,5 +11,5 @@ val equal_type :
 
 (** Coerce the given term to the given type, if possible *)
 val coerce :
-  loc:Location.t -> Nucleus.signature -> Nucleus.judgement -> Nucleus.boundary ->
-  Nucleus.judgement option Runtime.comp
+  loc:Location.t -> Nucleus.signature -> Nucleus.judgement_abstraction -> Nucleus.boundary_abstraction ->
+  Nucleus.judgement_abstraction option Runtime.comp

--- a/src/runtime/eval.ml
+++ b/src/runtime/eval.ml
@@ -263,7 +263,7 @@ let rec infer {Location.thing=c'; loc} =
        match Nucleus.type_at_abstraction abstr with
        | None -> Runtime.(error ~loc (AbstractionExpected v1))
        | Some t ->
-          check c2 (Nucleus.abstract_not_abstract t) >>= fun v2 ->
+          check c2 (Nucleus.BoundaryIsTerm (Nucleus.abstract_not_abstract t)) >>= fun v2 ->
           begin match Nucleus.as_not_abstract v2 with
           | None -> Runtime.(error ~loc (IsTermExpected (Runtime.mk_is_term v2)))
           | Some v2 ->
@@ -370,15 +370,10 @@ and check_arguments :
 and check_argument c bdry =
   match bdry with
 
-  | Nucleus.BoundaryIsType bdry ->
-    (** XXX we should improve checking mode so that we can check against any boundary *)
-     infer_is_type_abstraction c >>= fun t ->
-     if Nucleus.check_is_type_boundary t bdry then
-       return (Nucleus.ArgumentIsType t)
-     else
-       failwith "type expected, need a good error message here"
+  | Nucleus.BoundaryIsType _ ->
+     check c bdry >>= fun () -> return (Nucleus.ArgumentIsType ())
 
-  | Nucleus.BoundaryIsTerm bdry ->
+  | Nucleus.BoundaryIsTerm _ ->
      check c bdry >>= fun t -> return (Nucleus.ArgumentIsTerm t)
 
   | Nucleus.BoundaryEqType bdry ->

--- a/src/runtime/eval.ml
+++ b/src/runtime/eval.ml
@@ -26,8 +26,7 @@ let as_bool ~loc v =
      else
      Runtime.(error ~loc (BoolExpected v))
 
-  | (Runtime.Tag (_, _::_) | Runtime.IsTerm _ | Runtime.IsType _ | Runtime.EqTerm _ | Runtime.EqType _ |
-     Runtime.Closure _ | Runtime.Handler _ | Runtime.Tuple _ | Runtime.Ref _ | Runtime.Dyn _ | Runtime.String _) ->
+  | Runtime.(Tag (_, _::_) | Judgement _ | Boundary _ | Closure _ | Handler _ | Tuple _ | Ref _ | Dyn _ | String _) ->
      Runtime.(error ~loc (BoolExpected v))
 
 
@@ -216,18 +215,9 @@ let rec infer {Location.thing=c'; loc} =
            (Nucleus.abstract_not_abstract (Nucleus.form_is_term_atom a))
            begin infer c >>=
              function
+             | Runtime.Judgement jdg -> Runtime.return_judgement (Nucleus.abstract_judgement a jdg)
 
-             | Runtime.IsType abstr -> Runtime.return_is_type (Nucleus.abstract_is_type a abstr)
-
-             | Runtime.IsTerm abstr -> Runtime.return_is_term (Nucleus.abstract_is_term a abstr)
-
-             | Runtime.EqType abstr -> Runtime.return_eq_type (Nucleus.abstract_eq_type a abstr)
-
-             | Runtime.EqTerm abstr -> Runtime.return_eq_term (Nucleus.abstract_eq_term a abstr)
-
-             | (Runtime.Closure _ | Runtime.Handler _ | Runtime.Tag _ |
-                Runtime.Tuple _ | Runtime.Ref _ | Runtime.Dyn _ |
-                Runtime.String _) as v ->
+             | Runtime.(Boundary _ | Closure _ | Handler _ | Tag _ | Tuple _ | Ref _ | Dyn _ | String _) as v ->
                 Runtime.(error ~loc (JudgementExpected v))
 
            end)

--- a/src/runtime/eval.ml
+++ b/src/runtime/eval.ml
@@ -603,8 +603,8 @@ let premise {Location.thing=Rsyntax.Premise(xopt, lctx, bdry);_} =
   local_context lctx (eval_boundary bdry) >>= fun bdry ->
   Runtime.lookup_signature >>= fun sgn ->
   let x = (match xopt with Some x -> x | None -> Name.anonymous ()) in
-  let mv = Nucleus.fresh_meta x bdry in
-  let v = Runtime.Judgement (Nucleus.meta_eta_expanded sgn mv) in
+  let mv = Nucleus.fresh_judgement_meta x bdry in
+  let v = Runtime.Judgement (Nucleus.judgement_meta_eta_expanded sgn mv) in
   return ((Nucleus.meta_nonce mv, bdry), Some v)
 
 

--- a/src/runtime/eval.ml
+++ b/src/runtime/eval.ml
@@ -371,22 +371,22 @@ and check_argument c bdry =
   match bdry with
 
   | Nucleus.BoundaryIsType _ ->
-     check c bdry >>= fun () -> return (Nucleus.ArgumentIsType ())
+     check c bdry >>= fun () -> return (Nucleus.JudgementIsType ())
 
   | Nucleus.BoundaryIsTerm _ ->
-     check c bdry >>= fun t -> return (Nucleus.ArgumentIsTerm t)
+     check c bdry >>= fun t -> return (Nucleus.JudgementIsTerm t)
 
   | Nucleus.BoundaryEqType bdry ->
      infer_eq_type_abstraction c >>= fun eq ->
      if Nucleus.check_eq_type_boundary eq bdry then
-       return (Nucleus.ArgumentEqType eq)
+       return (Nucleus.JudgementEqType eq)
      else
        failwith "type equation expected, need a good error message"
 
   | Nucleus.BoundaryEqTerm bdry ->
      infer_eq_term_abstraction c >>= fun eq ->
      if Nucleus.check_eq_term_boundary eq bdry then
-       return (Nucleus.ArgumentEqTerm eq)
+       return (Nucleus.JudgementEqTerm eq)
      else
        failwith "term equation expected, need a good error message"
 

--- a/src/runtime/eval.ml
+++ b/src/runtime/eval.ml
@@ -202,7 +202,7 @@ let rec infer {Location.thing=c'; loc} =
 
   | Rsyntax.Ascribe (c1, c2) ->
      infer_is_type_abstraction c2 >>= fun t ->
-     check c1 t >>=
+     check c1 (Nucleus.BoundaryIsTerm t) >>=
      Runtime.return_is_term
 
   | Rsyntax.Abstract (x, None, _) ->
@@ -410,17 +410,29 @@ and occurs
      return (Reflect.mk_option None)
   end
 
-and check_default ~loc v t_check =
-  let abstr = Runtime.as_is_term_abstraction ~loc v in
-  Runtime.lookup_signature >>= fun sgn ->
-  Equal.coerce ~loc sgn abstr t_check >>=
-    begin function
-      | None -> Runtime.(error ~loc (TypeMismatchCheckingMode (abstr, t_check)))
-      | Some e -> return e
-    end
+(** Coerce the value [v] to the given judgement boundary [bdry] *)
+and coerce ~loc v (bdry : Nucleus.boundary) =
+  match bdry with
+  | Nucleus.BoundaryIsType _ ->
+     failwith "coercion to a type boundary not implemented"
 
-(* Rsyntax.comp -> Nucleus.is_type -> Nucleus.is_term Runtime.comp *)
-and check ({Location.thing=c';loc} as c) t_check =
+  | Nucleus.BoundaryIsTerm bdry ->
+     let abstr = Runtime.as_is_term_abstraction ~loc v in
+     Runtime.lookup_signature >>= fun sgn ->
+     Equal.coerce ~loc sgn abstr bdry >>=
+       begin function
+         | None -> Runtime.(error ~loc (TypeMismatchCheckingMode (abstr, bdry)))
+         | Some e -> return e
+       end
+
+  | Nucleus.BoundaryEqType _ ->
+     failwith "coercion to a type equality boundary not implemented"
+
+  | Nucleus.BoundaryEqTerm _ ->
+     failwith "coercion to a term equality boundary not implemented"
+
+
+and check ({Location.thing=c';loc} as c) bdry =
   match c' with
 
   (* for these we switch to infer mode *)
@@ -450,15 +462,16 @@ and check ({Location.thing=c';loc} as c) t_check =
   | Rsyntax.Substitute _
   | Rsyntax.Context _
   | Rsyntax.Natural _ ->
+
     infer c >>= fun v ->
-    check_default ~loc v t_check
+    coerce ~loc v bdry
 
   | Rsyntax.Operation (op, cs) ->
      let rec fold vs = function
        | [] ->
           let vs = List.rev vs in
-          Runtime.operation op ~checking:t_check vs >>= fun v ->
-          check_default ~loc v t_check
+          Runtime.operation op ~checking:bdry vs >>= fun v ->
+          coerce ~loc v bdry
        | c :: cs ->
           infer c >>= fun v ->
           fold (v :: vs) cs
@@ -466,42 +479,51 @@ and check ({Location.thing=c';loc} as c) t_check =
      fold [] cs
 
   | Rsyntax.Let (xcs, c) ->
-     let_bind ~loc xcs (check c t_check)
+     let_bind ~loc xcs (check c bdry)
 
   | Rsyntax.Sequence (c1,c2) ->
     infer c1 >>= fun v ->
     sequence ~loc v >>= fun () ->
-    check c2 t_check
+    check c2 bdry
 
   | Rsyntax.LetRec (fxcs, c) ->
-     letrec_bind fxcs (check c t_check)
+     letrec_bind fxcs (check c bdry)
 
   | Rsyntax.Now (x,c1,c2) ->
      let xloc = x.Location.loc in
      infer x >>= as_dyn ~loc:xloc >>= fun x ->
      infer c1 >>= fun v ->
-     Runtime.now x v (check c2 t_check)
+     Runtime.now x v (check c2 bdry)
 
   | Rsyntax.Assume ((Some x, t), c) ->
      infer_is_type t >>= fun t ->
      Runtime.add_free x t (fun _ ->
-     check c t_check)
+     check c bdry)
 
   | Rsyntax.Assume ((None, t), c) ->
      infer_is_type t >>= fun _ ->
-     check c t_check
+     check c bdry
 
   | Rsyntax.Match (c, cases) ->
      infer c >>=
-     match_cases ~loc cases (fun c -> check c t_check)
+     match_cases ~loc cases (fun c -> check c bdry)
 
   | Rsyntax.Abstract (xopt, uopt, c) ->
-    check_abstract ~loc t_check xopt uopt c
+    check_abstract ~loc bdry xopt uopt c
 
 
-(** Check that the abstraction [Abstract(x, uopt, c)] has type [t_check]. *)
-and check_abstract ~loc t_check x uopt c =
-  match Nucleus.invert_is_type_abstraction ~name:x t_check with
+(** Run the abstraction [Abstract(x, uopt, c)] in checking mode with boundary [bdry]. *)
+and check_abstract ~loc bdry x uopt c =
+  (* We need to invert the data-structures here, so we set-up the necessary auxliary function first. *)
+  let stump =
+    match bdry with
+    | Nucleus.BoundaryIsType bdry -> Nucleus.invert_is_type_abstraction ~name:x bdry
+    | Nucleus.BoundaryIsTerm bdry -> Nucleus.invert_is_type_abstraction ~name:x bdry
+    | Nucleus.BoundaryEqType _ -> failwith "check_abstract"
+    | Nucleus.BoundaryEqTerm _ -> failwith "check_abstract"
+  in
+
+  match stump with
 
   | Nucleus.Stump_NotAbstract t ->
      Runtime.(error ~loc (UnexpectedAbstraction t))
@@ -514,7 +536,7 @@ and check_abstract ~loc t_check x uopt c =
         Runtime.add_bound
           (Runtime.mk_is_term (Nucleus.abstract_not_abstract (Nucleus.form_is_term_atom a)))
           begin
-            check c t_check' >>= fun e ->
+            check c (Nucleus.BoundaryIsTerm t_check') >>= fun e ->
             return (Nucleus.abstract_is_term a e)
           end
 
@@ -535,13 +557,12 @@ and check_abstract ~loc t_check x uopt c =
                in
                Runtime.add_bound (Runtime.mk_is_term a')
                begin
-                 check c t_check >>= fun e ->
+                 check c bdry >>= fun e ->
                  return (Nucleus.abstract_is_term a e)
                end
           end
      end
 
-(* sequence: loc:Location.t -> Runtime.value -> unit Runtime.comp *)
 and sequence ~loc v =
   match v with
     | Runtime.Tuple [] -> return ()

--- a/src/runtime/matching.ml
+++ b/src/runtime/matching.ml
@@ -26,9 +26,9 @@ let rec collect_judgement sgn xvs {Location.thing=p';loc} jdg =
      collect_judgement sgn xvs p2 jdg
 
   | Rsyntax.Pattern.TTAbstract (xopt, p1, p2) ->
-     begin match Nucleus.as_abstract jdg with
-     | None -> raise Match_fail
-     | Some (a, v2) ->
+     begin match Nucleus.invert_judgement_abstraction jdg with
+     | Nucleus.Stump_NotAbstract _ -> raise Match_fail
+     | Nucleus.Stump_Abstract (a, v2) ->
         let v1 = Nucleus.(abstract_not_abstract (JudgementIsType (type_of_atom a))) in
         let xvs = collect_judgement sgn xvs p1 v1 in
         let xvs =

--- a/src/runtime/matching.ml
+++ b/src/runtime/matching.ml
@@ -225,10 +225,10 @@ and collect_args env xvs ps vs =
   | p::ps, v::vs ->
      let xvs =
        begin match v with
-       | Nucleus.ArgumentIsType t -> collect_is_type env xvs p t
-       | Nucleus.ArgumentIsTerm e -> collect_is_term env xvs p e
-       | Nucleus.ArgumentEqType eq -> collect_eq_type env xvs p eq
-       | Nucleus.ArgumentEqTerm eq -> collect_eq_term env xvs p eq
+       | Nucleus.JudgementIsType t -> collect_is_type env xvs p t
+       | Nucleus.JudgementIsTerm e -> collect_is_term env xvs p e
+       | Nucleus.JudgementEqType eq -> collect_eq_type env xvs p eq
+       | Nucleus.JudgementEqTerm eq -> collect_eq_term env xvs p eq
      end in
      collect_args env xvs ps vs
 

--- a/src/runtime/matching.ml
+++ b/src/runtime/matching.ml
@@ -7,6 +7,18 @@ exception Match_fail
 
 let add_var (v : Runtime.value) vs = v :: vs
 
+let as_is_term jdg =
+  match Nucleus.as_not_abstract jdg with
+  | None -> raise Match_fail
+  | Some (Nucleus.JudgementIsTerm e) -> e
+  | Some Nucleus.(JudgementIsType _ | JudgementEqType _ | JudgementEqTerm _) -> raise Match_fail
+
+let as_is_type jdg =
+  match Nucleus.as_not_abstract jdg with
+  | None -> raise Match_fail
+  | Some (Nucleus.JudgementIsType t) -> t
+  | Some Nucleus.(JudgementIsTerm _ | JudgementEqType _ | JudgementEqTerm _) -> raise Match_fail
+
 (*
 
 (* There is a lot of repetition in the [collect_is_XYZ] functions below,
@@ -226,7 +238,7 @@ and collect_judgement' env xvs p = function
   | Nucleus.JudgementEqTerm eq -> collect_eq_term env xvs p eq
 *)
 
-let rec collect_tt_pattern env xvs {Location.thing=p';loc} jdg =
+let rec collect_tt_pattern sgn xvs {Location.thing=p';loc} jdg =
   match p' with
 
   | Rsyntax.Pattern.TTAnonymous -> xvs
@@ -235,15 +247,15 @@ let rec collect_tt_pattern env xvs {Location.thing=p';loc} jdg =
      add_var (Runtime.Judgement jdg) xvs
 
   | Rsyntax.Pattern.TTAs (p1, p2) ->
-     let xvs = collect_tt_pattern env xvs p1 jdg in
-     collect_tt_pattern env xvs p2 jdg
+     let xvs = collect_tt_pattern sgn xvs p1 jdg in
+     collect_tt_pattern sgn xvs p2 jdg
 
   | Rsyntax.Pattern.TTAbstract (xopt, p1, p2) ->
      begin match Nucleus.as_abstract jdg with
-     | None -> Runtime.(error ~loc (InvalidPatternMatch (Runtime.mk_judgement jdg)))
+     | None -> raise Match_fail
      | Some (a, v2) ->
         let v1 = Nucleus.(abstract_not_abstract (JudgementIsType (type_of_atom a))) in
-        let xvs = collect_tt_pattern env xvs p1 v1 in
+        let xvs = collect_tt_pattern sgn xvs p1 v1 in
         let xvs =
           match xopt with
           | None -> xvs
@@ -251,37 +263,107 @@ let rec collect_tt_pattern env xvs {Location.thing=p';loc} jdg =
              let e = Nucleus.(abstract_not_abstract (JudgementIsTerm (form_is_term_atom a))) in
              add_var (Runtime.mk_judgement e) xvs
         in
-        collect_tt_pattern env xvs p2 v2
+        collect_tt_pattern sgn xvs p2 v2
      end
 
   | Rsyntax.Pattern.TTConstructor (c, ps) ->
      begin match Nucleus.as_not_abstract jdg with
-     | None -> Runtime.(error ~loc (InvalidPatternMatch (Runtime.mk_judgement jdg)))
-     | Some jdg ->
-        begin match Nucleus.as_is_type t with
-        | Nucleus.Stump_TypeConstructor (c', args) when Ident.equal c c' ->
-           begin
-             match collect_args env xvs ps args with
-             | None -> Runtime.(error ~loc (InvalidPatternMatch (mk_is_type v)))
-             | Some vs -> vs
-           end
-        | Nucleus.(Stump_TypeConstructor _ | Stump_TypeMeta _) -> raise Match_fail
-        end
+     | None -> raise Match_fail
+     | Some jdg -> collect_constructor sgn xvs c ps jdg
+     end
+
+  | Rsyntax.Pattern.TTGenAtom p ->
+     let e = as_is_term jdg in
+     begin match Nucleus.invert_is_term sgn e with
+     | Nucleus.Stump_TermAtom a ->
+        collect_tt_pattern sgn xvs p jdg
+     | Nucleus.(Stump_TermConstructor _ | Stump_TermMeta _ | Stump_TermConvert _) ->
+        raise Match_fail
      end
 
 
-and collect_args env xvs ps vs =
+  | Rsyntax.Pattern.TTIsType p ->
+     begin match Nucleus.as_not_abstract jdg with
+     | None -> raise Match_fail
+     | Some (Nucleus.JudgementIsType _) -> collect_tt_pattern sgn xvs p jdg
+     | Some Nucleus.(JudgementIsTerm _ | JudgementEqType _ | JudgementEqTerm _) -> raise Match_fail
+     end
+
+  | Rsyntax.Pattern.TTIsTerm (p1, p2) ->
+     (* By computing [e] first, we make sure that we're actually matching against
+        a term judgement. If you change the order of evaluation, then it could
+        happen that [p1] will match against [jdg] even though [jdg] is not a term
+        judgement. *)
+     let e = as_is_term jdg in
+     let xvs = collect_tt_pattern sgn xvs p1 jdg in
+     begin match p2 with
+     | {Location.thing=Rsyntax.Pattern.TTAnonymous;_} -> xvs
+     | _ ->
+        let t = Nucleus.type_of_term sgn e in
+        collect_tt_pattern sgn xvs p2 (Nucleus.abstract_not_abstract (Nucleus.JudgementIsType t))
+     end
+
+  | Rsyntax.Pattern.TTEqType (pt1, pt2) ->
+     begin match Nucleus.as_not_abstract jdg with
+     | None -> raise Match_fail
+     | Some (Nucleus.JudgementEqType _) -> failwith "todo"
+     | Some Nucleus.(JudgementIsTerm _ | JudgementIsType _ | JudgementEqTerm _) -> raise Match_fail
+     end
+
+  | Rsyntax.Pattern.TTEqTerm (pe1, pe2, pt) ->
+     begin match Nucleus.as_not_abstract jdg with
+     | None -> raise Match_fail
+     | Some (Nucleus.JudgementEqTerm _) -> failwith "todo"
+     | Some Nucleus.(JudgementIsTerm _ | JudgementIsType _ | JudgementEqType _) -> raise Match_fail
+     end
+
+
+and collect_constructor sgn xvs c ps = function
+  | Nucleus.JudgementIsType t ->
+     begin match Nucleus.invert_is_type t with
+     | Nucleus.Stump_TypeConstructor (c', args) ->
+        if Ident.equal c c' then
+          collect_args sgn xvs ps args
+        else
+          raise Match_fail
+     | Nucleus.Stump_TypeMeta _ -> raise Match_fail
+     end
+
+  | Nucleus.JudgementIsTerm e ->
+     let rec collect e =
+       begin match Nucleus.invert_is_term sgn e with
+       | Nucleus.Stump_TermConvert (e, _) ->
+          collect e
+
+       | Nucleus.Stump_TermConstructor (c', args) ->
+          if Ident.equal c c' then
+            collect_args sgn xvs ps args
+          else
+            raise Match_fail
+
+       | Nucleus.(Stump_TermAtom _ | Stump_TermMeta _) ->
+          raise Match_fail
+       end
+     in
+     collect e
+
+  | Nucleus.JudgementEqType _ -> raise Match_fail
+  | Nucleus.JudgementEqTerm _ -> raise Match_fail
+
+and collect_args sgn xvs ps vs =
   match ps, vs with
 
-  | [], [] -> Some xvs
+  | [], [] -> xvs
 
   | p::ps, v::vs ->
-     let xvs = collect_judgement env xvs p v in
-     collect_args env xvs ps vs
+     let xvs = collect_tt_pattern sgn xvs p v in
+     collect_args sgn xvs ps vs
 
-  | [], _::_ | _::_, [] -> None
+  | [], _::_ | _::_, [] ->
+     (* This should never happen because desugaring checks arities of constructors and patterns. *)
+     assert false
 
-let rec collect_pattern env xvs {Location.thing=p';loc} v =
+let rec collect_pattern sgn xvs {Location.thing=p';loc} v =
   match p', v with
   | Rsyntax.Pattern.Anonymous, _ -> xvs
 
@@ -289,11 +371,11 @@ let rec collect_pattern env xvs {Location.thing=p';loc} v =
      add_var v xvs
 
   | Rsyntax.Pattern.As (p1, p2), v ->
-     let xvs = collect_pattern env xvs p1 v in
-     collect_pattern env xvs p2 v
+     let xvs = collect_pattern sgn xvs p1 v in
+     collect_pattern sgn xvs p2 v
 
   | Rsyntax.Pattern.Judgement p, Runtime.Judgement jdg ->
-     collect_judgement env xvs p jdg
+     collect_tt_pattern sgn xvs p jdg
 
   | Rsyntax.Pattern.MLConstructor (tag, ps), Runtime.Tag (tag', vs) ->
      if not (Runtime.equal_tag tag tag')
@@ -301,14 +383,14 @@ let rec collect_pattern env xvs {Location.thing=p';loc} v =
        raise Match_fail
      else
        begin
-         match multicollect_pattern env xvs ps vs with
+         match multicollect_pattern sgn xvs ps vs with
          | None -> Runtime.(error ~loc (InvalidPatternMatch v))
          | Some vs -> vs
        end
 
   | Rsyntax.Pattern.Tuple ps, Runtime.Tuple vs ->
     begin
-      match multicollect_pattern env xvs ps vs with
+      match multicollect_pattern sgn xvs ps vs with
       | None -> Runtime.(error ~loc (InvalidPatternMatch v))
       | Some vs -> vs
     end
@@ -324,20 +406,20 @@ let rec collect_pattern env xvs {Location.thing=p';loc} v =
     Runtime.(Judgement _ | Boundary _ | Closure _ | Handler _ | Tag _ | Ref _ | Dyn _ | String _) ->
      Runtime.(error ~loc (InvalidPatternMatch v))
 
-and multicollect_pattern env xvs ps vs =
+and multicollect_pattern sgn xvs ps vs =
   let rec fold xvs = function
     | [], [] -> Some xvs
     | p::ps, v::vs ->
-      let xvs = collect_pattern env xvs p v in
+      let xvs = collect_pattern sgn xvs p v in
       fold xvs (ps, vs)
     | ([], _::_ | _::_, []) ->
        None
   in
   fold xvs (ps, vs)
 
-let match_pattern_env p v env =
+let match_pattern' sgn p v =
   try
-    let xvs = collect_pattern env [] p v in
+    let xvs = collect_pattern sgn [] p v in
     Some xvs
   with
     Match_fail -> None
@@ -345,23 +427,29 @@ let match_pattern_env p v env =
 let top_match_pattern p v =
   let (>>=) = Runtime.top_bind in
   Runtime.top_get_env >>= fun env ->
-    let r = match_pattern_env p v env  in
-    Runtime.top_return r
+  let sgn = Runtime.get_signature env in
+  let r = match_pattern' sgn p v in
+  Runtime.top_return r
 
 let match_pattern p v =
   (* collect values of pattern variables *)
   Runtime.get_env >>= fun env ->
-  let r = match_pattern_env p v env in
+  let sgn = Runtime.get_signature env in
+  let r = match_pattern' sgn p v in
   return r
+
+let collect_boundary_pattern sgn xvs pttrn bdry =
+  failwith "pattern matching of boundaries not implemented"
 
 let match_op_pattern ~loc ps p_out vs t_out =
   Runtime.get_env >>= fun env ->
+  let sgn = Runtime.get_signature env in
   let r =
     begin
       try
         let xvs =
           begin
-            match multicollect_pattern env [] ps vs with
+            match multicollect_pattern sgn [] ps vs with
             | None -> Runtime.(error ~loc InvalidHandlerMatch)
             | Some xvs -> xvs
           end
@@ -371,7 +459,7 @@ let match_op_pattern ~loc ps p_out vs t_out =
           | None -> xvs
           | Some p ->
              begin match t_out with
-             | Some t -> collect_is_type env xvs p t
+             | Some t -> collect_boundary_pattern sgn xvs p t
              | None -> xvs
              end
         in

--- a/src/runtime/matching.ml
+++ b/src/runtime/matching.ml
@@ -13,232 +13,7 @@ let as_is_term jdg =
   | Some (Nucleus.JudgementIsTerm e) -> e
   | Some Nucleus.(JudgementIsType _ | JudgementEqType _ | JudgementEqTerm _) -> raise Match_fail
 
-let as_is_type jdg =
-  match Nucleus.as_not_abstract jdg with
-  | None -> raise Match_fail
-  | Some (Nucleus.JudgementIsType t) -> t
-  | Some Nucleus.(JudgementIsTerm _ | JudgementEqType _ | JudgementEqTerm _) -> raise Match_fail
-
-(*
-
-(* There is a lot of repetition in the [collect_is_XYZ] functions below,
-   but this seems to be the price to pay for the discrepancy between the
-   syntax of patterns and the structure of runtime values. *)
-
-(* Collect the values of the matched bound variables and return them in a list. The head
-   of the list is the *last* variable found, which means that probably the list should be
-   reversed before we actually put the values onto the environment. *)
-let rec collect_is_term env xvs {Location.thing=p';loc} v =
-  match p' with
-  (* patterns that are generic for all judgement forms *)
-  | Rsyntax.Pattern.TTAnonymous -> xvs
-
-  | Rsyntax.Pattern.TTVar ->
-     add_var (Runtime.mk_is_term v) xvs
-
-  | Rsyntax.Pattern.TTAs (p1, p2) ->
-     let xvs = collect_is_term env xvs p1 v in
-     collect_is_term env xvs p2 v
-
-  (* patterns specific to terms *)
-  | Rsyntax.Pattern.TTConstructor (c, ps) ->
-     begin match Nucleus.as_not_abstract v with
-     | None -> Runtime.(error ~loc (InvalidPatternMatch (Runtime.mk_is_term v)))
-     | Some e ->
-        let sgn = Runtime.get_signature env in
-        begin match Nucleus.invert_is_term sgn e with
-        | Nucleus.Stump_TermConstructor (c', args) when Ident.equal c c' ->
-           begin
-             match collect_args env xvs ps args with
-             | None -> Runtime.(error ~loc (InvalidPatternMatch (mk_is_term v)))
-             | Some vs -> vs
-           end
-        | Nucleus.(Stump_TermConstructor _ | Stump_TermMeta _ | Stump_TermAtom _ | Stump_TermConvert _) ->
-           raise Match_fail
-        end
-     end
-
-  | Rsyntax.Pattern.TTGenAtom p ->
-     begin match Nucleus.as_not_abstract v with
-     | None -> Runtime.(error ~loc (InvalidPatternMatch (Runtime.mk_is_term v)))
-     | Some e ->
-        let sgn = Runtime.get_signature env in
-        begin match Nucleus.invert_is_term sgn e with
-        | Nucleus.Stump_TermAtom a ->
-           collect_is_term env xvs p v
-        | Nucleus.(Stump_TermConstructor _ | Stump_TermMeta _ | Stump_TermConvert _) ->
-           raise Match_fail
-        end
-     end
-
-  | Rsyntax.Pattern.TTIsTerm (p1, p2) ->
-     let xvs = collect_is_term env xvs p1 v in
-     (* TODO optimize for the case when [p2] is [Rsyntax.Pattern.TTAnonymous]
-        because it allows us to avoid calculating the type of [v]. *)
-     let sgn = Runtime.get_signature env in
-     let t = Nucleus.type_of_term_abstraction sgn v in
-     collect_is_type env xvs p2 t
-
-  | Rsyntax.Pattern.TTAbstract (xopt, p1, p2) ->
-     begin match Nucleus.invert_is_term_abstraction v with
-     | Nucleus.Stump_NotAbstract _ -> Runtime.(error ~loc (InvalidPatternMatch (Runtime.mk_is_term v)))
-     | Nucleus.Stump_Abstract (a, v2) ->
-        let v1 = Nucleus.abstract_not_abstract (Nucleus.type_of_atom a) in
-        let xvs = collect_is_type env xvs p1 v1 in
-        let xvs =
-          match xopt with
-          | None -> xvs
-          | Some x ->
-             let e = Nucleus.abstract_not_abstract (Nucleus.form_is_term_atom a) in
-             add_var (Runtime.mk_is_term e) xvs
-        in
-        collect_is_term env xvs p2 v2
-     end
-
-  | (Rsyntax.Pattern.TTEqType _ | Rsyntax.Pattern.TTEqTerm _ | Rsyntax.Pattern.TTIsType _) ->
-     Runtime.(error ~loc (InvalidPatternMatch (Runtime.mk_is_term v)))
-
-and collect_is_type env xvs {Location.thing=p';loc} v =
-  match p' with
-  (* patterns that are generic for all judgement forms *)
-  | Rsyntax.Pattern.TTAnonymous -> xvs
-
-  | Rsyntax.Pattern.TTVar ->
-     add_var (Runtime.mk_is_type v) xvs
-
-  | Rsyntax.Pattern.TTAs (p1, p2) ->
-     let xvs = collect_is_type env xvs p1 v in
-     collect_is_type env xvs p2 v
-
-  (* patterns specific to types *)
-  | Rsyntax.Pattern.TTConstructor (c, ps) ->
-     begin match Nucleus.as_not_abstract v with
-     | None -> Runtime.(error ~loc (InvalidPatternMatch (Runtime.mk_is_type v)))
-     | Some t ->
-        begin match Nucleus.invert_is_type t with
-        | Nucleus.Stump_TypeConstructor (c', args) when Ident.equal c c' ->
-           begin
-             match collect_args env xvs ps args with
-             | None -> Runtime.(error ~loc (InvalidPatternMatch (mk_is_type v)))
-             | Some vs -> vs
-           end
-        | Nucleus.(Stump_TypeConstructor _ | Stump_TypeMeta _) -> raise Match_fail
-        end
-     end
-
-  | Rsyntax.Pattern.TTAbstract (xopt, p1, p2) ->
-     begin match Nucleus.invert_is_type_abstraction v with
-     | Nucleus.Stump_NotAbstract _ -> Runtime.(error ~loc (InvalidPatternMatch (Runtime.mk_is_type v)))
-     | Nucleus.Stump_Abstract (a, v2) ->
-        let v1 = Nucleus.abstract_not_abstract (Nucleus.type_of_atom a) in
-        let xvs = collect_is_type env xvs p1 v1 in
-        let xvs =
-          match xopt with
-          | None -> xvs
-          | Some x ->
-             let e = Nucleus.abstract_not_abstract (Nucleus.form_is_term_atom a) in
-             add_var (Runtime.mk_is_term e) xvs
-        in
-        collect_is_type env xvs p2 v
-     end
-
-  | (Rsyntax.Pattern.TTIsTerm _ | Rsyntax.Pattern.TTGenAtom _ | Rsyntax.Pattern.TTEqType _ |
-     Rsyntax.Pattern.TTEqTerm _ | Rsyntax.Pattern.TTIsType _) ->
-     Runtime.(error ~loc (InvalidPatternMatch (Runtime.mk_is_type v)))
-
-and collect_eq_type env xvs {Location.thing=p';loc} v =
-  match p' with
-  (* patterns that are generic for all judgement forms *)
-  | Rsyntax.Pattern.TTAnonymous -> xvs
-
-  | Rsyntax.Pattern.TTVar ->
-     add_var (Runtime.mk_eq_type v) xvs
-
-  | Rsyntax.Pattern.TTAs (p1, p2) ->
-     let xvs = collect_eq_type env xvs p1 v in
-     collect_eq_type env xvs p2 v
-
-  (* patterns specific to type equations *)
-  | Rsyntax.Pattern.TTAbstract (xopt, p1, p2) ->
-     begin match Nucleus.invert_eq_type_abstraction v with
-     | Nucleus.Stump_NotAbstract _ -> Runtime.(error ~loc (InvalidPatternMatch (Runtime.mk_eq_type v)))
-     | Nucleus.Stump_Abstract (a, v2) ->
-        let v1 = Nucleus.abstract_not_abstract (Nucleus.type_of_atom a) in
-        let xvs = collect_is_type env xvs p1 v1 in
-        let xvs =
-          match xopt with
-          | None -> xvs
-          | Some x ->
-             let e = Nucleus.abstract_not_abstract (Nucleus.form_is_term_atom a) in
-             add_var (Runtime.mk_is_term e) xvs
-        in
-        collect_eq_type env xvs p2 v
-     end
-
-  | Rsyntax.Pattern.TTEqType (p1, p2) ->
-     begin match Nucleus.as_not_abstract v with
-     | None -> Runtime.(error ~loc (InvalidPatternMatch (Runtime.mk_eq_type v)))
-     | Some eq ->
-        let (Nucleus.Stump_EqType (_asmp, t1, t2)) = Nucleus.invert_eq_type eq in
-        let xvs = collect_is_type env xvs p1 (Nucleus.abstract_not_abstract t1) in
-        collect_is_type env xvs p2 (Nucleus.abstract_not_abstract t2)
-     end
-
-  | (Rsyntax.Pattern.TTIsTerm _ | Rsyntax.Pattern.TTGenAtom _ | Rsyntax.Pattern.TTEqTerm _ | Rsyntax.Pattern.TTIsType _ |
-     Rsyntax.Pattern.TTConstructor _) ->
-     Runtime.(error ~loc (InvalidPatternMatch (Runtime.mk_eq_type v)))
-
-and collect_eq_term env xvs {Location.thing=p';loc} v =
-  match p' with
-  (* patterns that are generic for all judgement forms *)
-  | Rsyntax.Pattern.TTAnonymous -> xvs
-
-  | Rsyntax.Pattern.TTVar ->
-     add_var (Runtime.mk_eq_term v) xvs
-
-  | Rsyntax.Pattern.TTAs (p1, p2) ->
-     let xvs = collect_eq_term env xvs p1 v in
-     collect_eq_term env xvs p2 v
-
-  (* patterns specific to term equations *)
-  | Rsyntax.Pattern.TTAbstract (xopt, p1, p2) ->
-     begin match Nucleus.invert_eq_term_abstraction v with
-     | Nucleus.Stump_NotAbstract _ -> Runtime.(error ~loc (InvalidPatternMatch (Runtime.mk_eq_term v)))
-     | Nucleus.Stump_Abstract (a, v2) ->
-        let v1 = Nucleus.abstract_not_abstract (Nucleus.type_of_atom a) in
-        let xvs = collect_is_type env xvs p1 v1 in
-        let xvs =
-          match xopt with
-          | None -> xvs
-          | Some x ->
-             let e = Nucleus.abstract_not_abstract (Nucleus.form_is_term_atom a) in
-             add_var (Runtime.mk_is_term e) xvs
-        in
-        collect_eq_term env xvs p2 v
-     end
-
-  | Rsyntax.Pattern.TTEqTerm (p1, p2, p3) ->
-     begin match Nucleus.as_not_abstract v with
-     | None -> Runtime.(error ~loc (InvalidPatternMatch (Runtime.mk_eq_term v)))
-     | Some eq ->
-        let (Nucleus.Stump_EqTerm (_asmp, e1, e2, t)) = Nucleus.invert_eq_term eq in
-        let xvs = collect_is_term env xvs p1 (Nucleus.abstract_not_abstract e1) in
-        let xvs = collect_is_term env xvs p2 (Nucleus.abstract_not_abstract e2) in
-        collect_is_type env xvs p2 (Nucleus.abstract_not_abstract t)
-     end
-
-  | (Rsyntax.Pattern.TTIsTerm _ | Rsyntax.Pattern.TTGenAtom _ | Rsyntax.Pattern.TTEqType _ | Rsyntax.Pattern.TTIsType _ |
-     Rsyntax.Pattern.TTConstructor _) ->
-     Runtime.(error ~loc (InvalidPatternMatch (Runtime.mk_eq_term v)))
-
-and collect_judgement' env xvs p = function
-  | Nucleus.JudgementIsType t -> collect_is_type env xvs p t
-  | Nucleus.JudgementIsTerm e -> collect_is_term env xvs p e
-  | Nucleus.JudgementEqType eq -> collect_eq_type env xvs p eq
-  | Nucleus.JudgementEqTerm eq -> collect_eq_term env xvs p eq
-*)
-
-let rec collect_tt_pattern sgn xvs {Location.thing=p';loc} jdg =
+let rec collect_judgement sgn xvs {Location.thing=p';loc} jdg =
   match p' with
 
   | Rsyntax.Pattern.TTAnonymous -> xvs
@@ -247,15 +22,15 @@ let rec collect_tt_pattern sgn xvs {Location.thing=p';loc} jdg =
      add_var (Runtime.Judgement jdg) xvs
 
   | Rsyntax.Pattern.TTAs (p1, p2) ->
-     let xvs = collect_tt_pattern sgn xvs p1 jdg in
-     collect_tt_pattern sgn xvs p2 jdg
+     let xvs = collect_judgement sgn xvs p1 jdg in
+     collect_judgement sgn xvs p2 jdg
 
   | Rsyntax.Pattern.TTAbstract (xopt, p1, p2) ->
      begin match Nucleus.as_abstract jdg with
      | None -> raise Match_fail
      | Some (a, v2) ->
         let v1 = Nucleus.(abstract_not_abstract (JudgementIsType (type_of_atom a))) in
-        let xvs = collect_tt_pattern sgn xvs p1 v1 in
+        let xvs = collect_judgement sgn xvs p1 v1 in
         let xvs =
           match xopt with
           | None -> xvs
@@ -263,7 +38,7 @@ let rec collect_tt_pattern sgn xvs {Location.thing=p';loc} jdg =
              let e = Nucleus.(abstract_not_abstract (JudgementIsTerm (form_is_term_atom a))) in
              add_var (Runtime.mk_judgement e) xvs
         in
-        collect_tt_pattern sgn xvs p2 v2
+        collect_judgement sgn xvs p2 v2
      end
 
   | Rsyntax.Pattern.TTConstructor (c, ps) ->
@@ -276,7 +51,7 @@ let rec collect_tt_pattern sgn xvs {Location.thing=p';loc} jdg =
      let e = as_is_term jdg in
      begin match Nucleus.invert_is_term sgn e with
      | Nucleus.Stump_TermAtom a ->
-        collect_tt_pattern sgn xvs p jdg
+        collect_judgement sgn xvs p jdg
      | Nucleus.(Stump_TermConstructor _ | Stump_TermMeta _ | Stump_TermConvert _) ->
         raise Match_fail
      end
@@ -285,7 +60,7 @@ let rec collect_tt_pattern sgn xvs {Location.thing=p';loc} jdg =
   | Rsyntax.Pattern.TTIsType p ->
      begin match Nucleus.as_not_abstract jdg with
      | None -> raise Match_fail
-     | Some (Nucleus.JudgementIsType _) -> collect_tt_pattern sgn xvs p jdg
+     | Some (Nucleus.JudgementIsType _) -> collect_judgement sgn xvs p jdg
      | Some Nucleus.(JudgementIsTerm _ | JudgementEqType _ | JudgementEqTerm _) -> raise Match_fail
      end
 
@@ -295,35 +70,50 @@ let rec collect_tt_pattern sgn xvs {Location.thing=p';loc} jdg =
         happen that [p1] will match against [jdg] even though [jdg] is not a term
         judgement. *)
      let e = as_is_term jdg in
-     let xvs = collect_tt_pattern sgn xvs p1 jdg in
+     let xvs = collect_judgement sgn xvs p1 jdg in
      begin match p2 with
      | {Location.thing=Rsyntax.Pattern.TTAnonymous;_} -> xvs
      | _ ->
         let t = Nucleus.type_of_term sgn e in
-        collect_tt_pattern sgn xvs p2 (Nucleus.abstract_not_abstract (Nucleus.JudgementIsType t))
+        collect_judgement sgn xvs p2 (Nucleus.(abstract_not_abstract (JudgementIsType t)))
      end
 
   | Rsyntax.Pattern.TTEqType (pt1, pt2) ->
      begin match Nucleus.as_not_abstract jdg with
      | None -> raise Match_fail
-     | Some (Nucleus.JudgementEqType _) -> failwith "todo"
      | Some Nucleus.(JudgementIsTerm _ | JudgementIsType _ | JudgementEqTerm _) -> raise Match_fail
+     | Some (Nucleus.JudgementEqType eq) ->
+        begin match Nucleus.invert_eq_type eq with
+        | Nucleus.Stump_EqType (_asmp, t1, t2) ->
+           let jdg1 = Nucleus.(abstract_not_abstract (JudgementIsType t1))
+           and jdg2 = Nucleus.(abstract_not_abstract (JudgementIsType t2)) in
+           let xvs = collect_judgement sgn xvs pt1 jdg1 in
+           collect_judgement sgn xvs pt2 jdg2
+        end
      end
 
   | Rsyntax.Pattern.TTEqTerm (pe1, pe2, pt) ->
      begin match Nucleus.as_not_abstract jdg with
      | None -> raise Match_fail
-     | Some (Nucleus.JudgementEqTerm _) -> failwith "todo"
      | Some Nucleus.(JudgementIsTerm _ | JudgementIsType _ | JudgementEqType _) -> raise Match_fail
+     | Some (Nucleus.JudgementEqTerm eq) ->
+        begin match Nucleus.invert_eq_term eq with
+        | Nucleus.Stump_EqTerm (_asmp, e1, e2, t) ->
+           let jdg_e1 = Nucleus.(abstract_not_abstract (JudgementIsTerm e1))
+           and jdg_e2 = Nucleus.(abstract_not_abstract (JudgementIsTerm e2))
+           and jdg_t = Nucleus.(abstract_not_abstract (JudgementIsType t)) in
+           let xvs = collect_judgement sgn xvs pe1 jdg_e1 in
+           let xvs = collect_judgement sgn xvs pe2 jdg_e2 in
+           collect_judgement sgn xvs pt jdg_t
+        end
      end
-
 
 and collect_constructor sgn xvs c ps = function
   | Nucleus.JudgementIsType t ->
      begin match Nucleus.invert_is_type t with
      | Nucleus.Stump_TypeConstructor (c', args) ->
         if Ident.equal c c' then
-          collect_args sgn xvs ps args
+          collect_arguments sgn xvs ps args
         else
           raise Match_fail
      | Nucleus.Stump_TypeMeta _ -> raise Match_fail
@@ -337,7 +127,7 @@ and collect_constructor sgn xvs c ps = function
 
        | Nucleus.Stump_TermConstructor (c', args) ->
           if Ident.equal c c' then
-            collect_args sgn xvs ps args
+            collect_arguments sgn xvs ps args
           else
             raise Match_fail
 
@@ -347,17 +137,18 @@ and collect_constructor sgn xvs c ps = function
      in
      collect e
 
-  | Nucleus.JudgementEqType _ -> raise Match_fail
+  | Nucleus.(JudgementEqType eq)  -> raise Match_fail
+
   | Nucleus.JudgementEqTerm _ -> raise Match_fail
 
-and collect_args sgn xvs ps vs =
+and collect_arguments sgn xvs ps vs =
   match ps, vs with
 
   | [], [] -> xvs
 
   | p::ps, v::vs ->
-     let xvs = collect_tt_pattern sgn xvs p v in
-     collect_args sgn xvs ps vs
+     let xvs = collect_judgement sgn xvs p v in
+     collect_arguments sgn xvs ps vs
 
   | [], _::_ | _::_, [] ->
      (* This should never happen because desugaring checks arities of constructors and patterns. *)
@@ -375,7 +166,7 @@ let rec collect_pattern sgn xvs {Location.thing=p';loc} v =
      collect_pattern sgn xvs p2 v
 
   | Rsyntax.Pattern.Judgement p, Runtime.Judgement jdg ->
-     collect_tt_pattern sgn xvs p jdg
+     collect_judgement sgn xvs p jdg
 
   | Rsyntax.Pattern.MLConstructor (tag, ps), Runtime.Tag (tag', vs) ->
      if not (Runtime.equal_tag tag tag')
@@ -383,14 +174,14 @@ let rec collect_pattern sgn xvs {Location.thing=p';loc} v =
        raise Match_fail
      else
        begin
-         match multicollect_pattern sgn xvs ps vs with
+         match collect_pattern_list sgn xvs ps vs with
          | None -> Runtime.(error ~loc (InvalidPatternMatch v))
          | Some vs -> vs
        end
 
   | Rsyntax.Pattern.Tuple ps, Runtime.Tuple vs ->
     begin
-      match multicollect_pattern sgn xvs ps vs with
+      match collect_pattern_list sgn xvs ps vs with
       | None -> Runtime.(error ~loc (InvalidPatternMatch v))
       | Some vs -> vs
     end
@@ -406,7 +197,7 @@ let rec collect_pattern sgn xvs {Location.thing=p';loc} v =
     Runtime.(Judgement _ | Boundary _ | Closure _ | Handler _ | Tag _ | Ref _ | Dyn _ | String _) ->
      Runtime.(error ~loc (InvalidPatternMatch v))
 
-and multicollect_pattern sgn xvs ps vs =
+and collect_pattern_list sgn xvs ps vs =
   let rec fold xvs = function
     | [], [] -> Some xvs
     | p::ps, v::vs ->
@@ -441,7 +232,7 @@ let match_pattern p v =
 let collect_boundary_pattern sgn xvs pttrn bdry =
   failwith "pattern matching of boundaries not implemented"
 
-let match_op_pattern ~loc ps p_out vs t_out =
+let match_op_pattern ~loc ps p_bdry vs bdry =
   Runtime.get_env >>= fun env ->
   let sgn = Runtime.get_signature env in
   let r =
@@ -449,16 +240,16 @@ let match_op_pattern ~loc ps p_out vs t_out =
       try
         let xvs =
           begin
-            match multicollect_pattern sgn [] ps vs with
+            match collect_pattern_list sgn [] ps vs with
             | None -> Runtime.(error ~loc InvalidHandlerMatch)
             | Some xvs -> xvs
           end
         in
         let xvs =
-          match p_out with
+          match p_bdry with
           | None -> xvs
           | Some p ->
-             begin match t_out with
+             begin match bdry with
              | Some t -> collect_boundary_pattern sgn xvs p t
              | None -> xvs
              end

--- a/src/runtime/matching.mli
+++ b/src/runtime/matching.mli
@@ -11,6 +11,6 @@ val top_match_pattern : Rsyntax.Pattern.aml -> Runtime.value -> Runtime.value li
     the optional pattern [p_out] against the optional type [t_out]. *)
 val match_op_pattern :
   loc:Location.t ->
-  Rsyntax.Pattern.aml list -> Rsyntax.Pattern.is_type option ->
-  Runtime.value list -> Nucleus.is_type_abstraction option ->
+  Rsyntax.Pattern.aml list -> Rsyntax.Pattern.boundary option ->
+  Runtime.value list -> Nucleus.boundary_abstraction option ->
   Runtime.value list option Runtime.comp

--- a/src/runtime/reflect.ml
+++ b/src/runtime/reflect.ml
@@ -96,14 +96,14 @@ let (>>=) = Runtime.bind
 let return = Runtime.return
 
 let operation_equal_term ~loc e1 e2 =
-  let v1 = Runtime.mk_is_term (Nucleus.abstract_not_abstract e1)
-  and v2 = Runtime.mk_is_term (Nucleus.abstract_not_abstract e2) in
+  let v1 = Runtime.mk_judgement (Nucleus.(abstract_not_abstract (JudgementIsTerm e1)))
+  and v2 = Runtime.mk_judgement (Nucleus.(abstract_not_abstract (JudgementIsTerm e2))) in
   Runtime.operation equal_term [v1;v2] >>= fun v ->
   return (as_eq_term_option ~loc v)
 
 let operation_equal_type ~loc t1 t2 =
-  let v1 = Runtime.mk_is_type (Nucleus.abstract_not_abstract t1)
-  and v2 = Runtime.mk_is_type (Nucleus.abstract_not_abstract t2) in
+  let v1 = Runtime.mk_judgement (Nucleus.(abstract_not_abstract (JudgementIsType t1)))
+  and v2 = Runtime.mk_judgement (Nucleus.(abstract_not_abstract (JudgementIsType t2))) in
   Runtime.operation equal_type [v1;v2] >>= fun v ->
   return (as_eq_type_option ~loc v)
 
@@ -113,9 +113,13 @@ let operation_coerce ~loc jdg bdry =
   Runtime.operation coerce [v1;v2] >>= fun v ->
   return (as_judgement_option ~loc v)
 
-let add_abstracting j m =
-  let v = Runtime.mk_is_term j in             (* The given variable as an ML value *)
-  Runtime.hypotheses >>= fun hyps_dyn ->      (* Get the ML list of [hypotheses] *)
+let add_abstracting e m =
+  (* The given variable as an ML value *)
+  let v = Runtime.mk_judgement (Nucleus.(abstract_not_abstract (JudgementIsTerm e))) in
+  (* Get the ML list of [hypotheses] *)
+  Runtime.hypotheses >>= fun hyps_dyn ->
   Runtime.lookup_dyn hyps_dyn >>= fun hyps ->
-  let hyps = list_cons v hyps in              (* Add v to the front of that ML list *)
-  Runtime.now hyps_dyn hyps m                 (* Run computation m in this dynamic scope *)
+  (* Add v to the front of that ML list *)
+  let hyps = list_cons v hyps in
+  (* Run computation m in this dynamic scope *)
+  Runtime.now hyps_dyn hyps m

--- a/src/runtime/reflect.ml
+++ b/src/runtime/reflect.ml
@@ -42,9 +42,8 @@ let mk_option = function
 let as_option ~loc = function
   | Runtime.Tag (t, []) when (Runtime.equal_tag t tag_none)  -> None
   | Runtime.Tag (t, [x]) when (Runtime.equal_tag t tag_some) -> Some x
-  | (Runtime.IsType _ | Runtime.IsTerm _ | Runtime.EqType _ | Runtime.EqTerm _ |
-     Runtime.Closure _ | Runtime.Handler _ | Runtime.Tag _ | Runtime.Tuple _ |
-     Runtime.Ref _ | Runtime.Dyn _ | Runtime.String _) as v ->
+  | Runtime.(Judgement _ | Boundary _ | Closure _ | Handler _ |
+             Tag _ | Tuple _ | Ref _ | Dyn _ | String _) as v ->
      Runtime.(error ~loc (OptionExpected v))
 
 (** Conversion between OCaml coercible and ML coercible *)
@@ -62,9 +61,8 @@ let as_coercible ~loc = function
     let e = Runtime.as_is_term_abstraction ~loc v in
     Runtime.Coercible e
 
-  | (Runtime.IsType _ | Runtime.IsTerm _ | Runtime.EqType _ | Runtime.EqTerm _ |
-     Runtime.Closure _ | Runtime.Handler _ | Runtime.Tag _ | Runtime.Tuple _ |
-     Runtime.Ref _ | Runtime.Dyn _ | Runtime.String _) as v ->
+  | Runtime.(Judgement _ | Boundary _  | Closure _ | Handler _ | Tag _ | Tuple _ |
+             Ref _ | Dyn _ | String _) as v ->
      Runtime.(error ~loc (CoercibleExpected v))
 
 (** Conversion from OCaml [Runtime.order] to  [ML.order]. *)

--- a/src/runtime/reflect.mli
+++ b/src/runtime/reflect.mli
@@ -30,7 +30,7 @@ val operation_equal_type :
     the resulting ML value as a value of the correponding ML type [coercible].
  *)
 val operation_coerce :
-  loc:Location.t -> Nucleus.is_term_abstraction -> Nucleus.is_type_abstraction -> Runtime.coercible Runtime.comp
+  loc:Location.t -> Nucleus.judgement -> Nucleus.boundary -> Nucleus.judgement option Runtime.comp
 
 (** A hack which will probably disappear: add an atom to the dynamic variable [hypotheses] *)
 val add_abstracting : Nucleus.is_term Nucleus.abstraction -> 'a Runtime.comp -> 'a Runtime.comp

--- a/src/runtime/reflect.mli
+++ b/src/runtime/reflect.mli
@@ -30,7 +30,7 @@ val operation_equal_type :
     the resulting ML value as a value of the correponding ML type [coercible].
  *)
 val operation_coerce :
-  loc:Location.t -> Nucleus.judgement -> Nucleus.boundary -> Nucleus.judgement option Runtime.comp
+  loc:Location.t -> Nucleus.judgement_abstraction -> Nucleus.boundary_abstraction -> Nucleus.judgement_abstraction option Runtime.comp
 
 (** A hack which will probably disappear: add an atom to the dynamic variable [hypotheses] *)
-val add_abstracting : Nucleus.is_term Nucleus.abstraction -> 'a Runtime.comp -> 'a Runtime.comp
+val add_abstracting : Nucleus.is_term -> 'a Runtime.comp -> 'a Runtime.comp

--- a/src/runtime/runtime.ml
+++ b/src/runtime/runtime.ml
@@ -384,29 +384,45 @@ let as_eq_term ~loc abstr = function
   | (Boundary _ | Closure _ | Handler _ | Tag _ | Tuple _ | Ref _ | Dyn _ | String _) as v ->
     error ~loc (EqTermExpected v)
 
-let as_is_type_abstraction ~loc = function
-  | Judgement (Nucleus.JudgementIsType t) -> t
-  | (Judgement (Nucleus.(JudgementIsTerm _ | JudgementEqTerm _ | JudgementEqType _)) |
-     Boundary _ | Closure _ | Handler _ | Tag _ | Tuple _ | Ref _ | Dyn _ | String _) as v ->
+let as_is_type_abstraction ~loc v =
+  match v with
+  | Judgement abstr ->
+     begin match Nucleus.as_is_type_abstraction abstr with
+     | Some abstr -> abstr
+     | None -> error ~loc (IsTypeAbstractionExpected v)
+     end
+  | (Boundary _ | Closure _ | Handler _ | Tag _ | Tuple _ | Ref _ | Dyn _ | String _) as v ->
     error ~loc (IsTypeAbstractionExpected v)
 
-let as_is_term_abstraction ~loc = function
-  | Judgement (Nucleus.JudgementIsTerm e) -> e
-  | (Judgement (Nucleus.(JudgementIsType _ | JudgementEqTerm _ | JudgementEqType _)) |
-     Boundary _ | Closure _ | Handler _ | Tag _ | Tuple _ | Ref _ | Dyn _ | String _) as v ->
+let as_is_term_abstraction ~loc v =
+  match v with
+  | Judgement abstr ->
+     begin match Nucleus.as_is_term_abstraction abstr with
+     | Some abstr -> abstr
+     | None -> error ~loc (IsTermAbstractionExpected v)
+     end
+  | (Boundary _ | Closure _ | Handler _ | Tag _ | Tuple _ | Ref _ | Dyn _ | String _) as v ->
     error ~loc (IsTermAbstractionExpected v)
 
-let as_eq_type_abstraction ~loc = function
-  | Judgement (Nucleus.JudgementEqType eq) -> eq
-  | (Judgement (Nucleus.(JudgementIsType _ | JudgementIsTerm _ | JudgementEqTerm _)) |
-     Boundary _ | Closure _ | Handler _ | Tag _ | Tuple _ | Ref _ | Dyn _ | String _) as v ->
-    error ~loc (EqTypeAbstractionExpected v)
+let as_eq_type_abstraction ~loc v =
+  match v with
+  | Judgement abstr ->
+     begin match Nucleus.as_eq_type_abstraction abstr with
+     | Some abstr -> abstr
+     | None -> error ~loc (EqTypeAbstractionExpected v)
+     end
+  | (Boundary _ | Closure _ | Handler _ | Tag _ | Tuple _ | Ref _ | Dyn _ | String _) as v ->
+    error ~loc (IsTypeAbstractionExpected v)
 
-let as_eq_term_abstraction ~loc = function
-  | Judgement (Nucleus.JudgementEqTerm eq) -> eq
-  | (Judgement (Nucleus.(JudgementIsType _ | JudgementIsTerm _ | JudgementEqType _)) |
-     Boundary _ | Closure _ | Handler _ | Tag _ | Tuple _ | Ref _ | Dyn _ | String _) as v ->
-    error ~loc (EqTermAbstractionExpected v)
+let as_eq_term_abstraction ~loc v =
+  match v with
+  | Judgement abstr ->
+     begin match Nucleus.as_eq_term_abstraction abstr with
+     | Some abstr -> abstr
+     | None -> error ~loc (EqTermAbstractionExpected v)
+     end
+  | (Boundary _ | Closure _ | Handler _ | Tag _ | Tuple _ | Ref _ | Dyn _ | String _) as v ->
+    error ~loc (IsTermAbstractionExpected v)
 
 let as_closure ~loc = function
   | Closure f -> f
@@ -502,7 +518,7 @@ let add_bound0 v env =
 
 let add_free x jt m env =
   let jy = Nucleus.fresh_atom x jt in
-  let y_val = mk_is_term (Nucleus.abstract_not_abstract (Nucleus.form_is_term_atom jy)) in
+  let y_val = mk_judgement Nucleus.(abstract_not_abstract (JudgementIsTerm (form_is_term_atom jy))) in
   let env = add_bound0 y_val env in
   m jy env
 
@@ -624,9 +640,9 @@ let top_lookup_signature env =
 let rec print_value ?max_level ~penv v ppf =
   match v with
 
-  | Judgement jdg -> Nucleus.print_judgement ~penv:(mk_nucleus_penv penv) ?max_level jdg ppf
+  | Judgement jdg -> Nucleus.print_judgement_abstraction ~penv:(mk_nucleus_penv penv) ?max_level jdg ppf
 
-  | Boundary bdry -> Nucleus.print_boundary ~penv:(mk_nucleus_penv penv) ?max_level bdry ppf
+  | Boundary bdry -> Nucleus.print_boundary_abstraction ~penv:(mk_nucleus_penv penv) ?max_level bdry ppf
 
   | Closure f -> Format.fprintf ppf "<function>"
 

--- a/src/runtime/runtime.ml
+++ b/src/runtime/runtime.ml
@@ -347,11 +347,6 @@ let as_not_abstract ~loc abstr =
   | Some x -> x
   | None -> error ~loc UnexpectedAbstraction
 
-let as_abstract ~loc abstr =
-  match Nucleus.as_abstract abstr with
-  | Some x -> x
-  | None -> error ~loc AbstractionExpected
-
 let as_is_type ~loc = function
   | Judgement abstr as v ->
      begin match Nucleus.as_not_abstract abstr with

--- a/src/runtime/runtime.ml
+++ b/src/runtime/runtime.ml
@@ -170,10 +170,8 @@ and lexical = {
 and state = value Store.Ref.t
 
 and value =
-  | IsTerm of Nucleus.is_term_abstraction
-  | IsType of Nucleus.is_type_abstraction
-  | EqTerm of Nucleus.eq_term_abstraction
-  | EqType of Nucleus.eq_type_abstraction
+  | Judgement of Nucleus.judgement
+  | Boundary of Nucleus.boundary
   | Closure of (value, value) closure
   | Handler of handler
   | Tag of ml_constructor * value list

--- a/src/runtime/runtime.ml
+++ b/src/runtime/runtime.ml
@@ -187,11 +187,11 @@ and ('a, 'b) closure = Clos of ('a -> 'b comp)
 
 and 'a result =
   | Return of 'a
-  | Operation of Ident.t * value list * Nucleus.is_type_abstraction option * dynamic * 'a continuation
+  | Operation of Ident.t * value list * Nucleus.boundary option * dynamic * 'a continuation
 
 and 'a comp = env -> 'a result * state
 
-and operation_args = { args : value list; checking : Nucleus.is_type_abstraction option }
+and operation_args = { args : value list; checking : Nucleus.boundary option }
 
 and handler = {
   handler_val: (value,value) closure option;

--- a/src/runtime/runtime.ml
+++ b/src/runtime/runtime.ml
@@ -238,7 +238,7 @@ type error =
   | StringExpected of value
   | CoercibleExpected of value
   | InvalidConvertible of Nucleus.is_type_abstraction * Nucleus.is_type_abstraction * Nucleus.eq_type_abstraction
-  | InvalidCoerce of Nucleus.is_type_abstraction * Nucleus.is_term_abstraction
+  | InvalidCoerce of Nucleus.judgement * Nucleus.boundary
   | UnhandledOperation of Ident.t * value list
   | InvalidPatternMatch of value
   | InvalidHandlerMatch
@@ -861,11 +861,11 @@ let print_error ~penv err ppf =
                     (Nucleus.print_is_type_abstraction ~penv t2)
                     (Nucleus.print_eq_type_abstraction ~penv eq)
 
-  | InvalidCoerce (t, e) ->
+  | InvalidCoerce (jdg, bdry) ->
      let penv = mk_nucleus_penv penv in
-     Format.fprintf ppf "expected a term of type@ %t@ but got@ %t"
-                    (Nucleus.print_is_type_abstraction ~penv t)
-                    (Nucleus.print_is_term_abstraction ~penv e)
+     Format.fprintf ppf "expected a judgement with boundary@ %t@ but got@ %t"
+                    (Nucleus.print_boundary ~penv bdry)
+                    (Nucleus.print_judgement ~penv jdg)
 
   | UnhandledOperation (op, vs) ->
      Format.fprintf ppf "unhandled operation %t"

--- a/src/runtime/runtime.mli
+++ b/src/runtime/runtime.mli
@@ -45,17 +45,11 @@ val equal_tag : ml_constructor -> ml_constructor -> bool
 
 (** {b Value construction} *)
 
-(** Build an [IsTerm] value *)
-val mk_is_term : Nucleus.is_term_abstraction -> value
+(** Build an abstracted judgement as a value *)
+val mk_judgement : Nucleus.judgement_abstraction -> value
 
-(** Build an [IsType] value *)
-val mk_is_type : Nucleus.is_type_abstraction -> value
-
-(** Build an [EqTerm] value *)
-val mk_eq_term : Nucleus.eq_term_abstraction -> value
-
-(** Build an [EqType] value *)
-val mk_eq_type : Nucleus.eq_type_abstraction -> value
+(** Build an abstracted boundary as a value *)
+val mk_boundary : Nucleus.boundary_abstraction -> value
 
 (** Build a [Handler] value *)
 val mk_handler : handler -> value
@@ -203,7 +197,6 @@ val return : 'a -> 'a comp
 val return_unit : value comp
 
 val return_judgement : Nucleus.judgement -> value comp
-val return_is_term : Nucleus.is_term_abstraction -> value comp
 
 val return_closure : (value -> value comp) -> value comp
 val return_handler :

--- a/src/runtime/runtime.mli
+++ b/src/runtime/runtime.mli
@@ -30,7 +30,7 @@ type value =
   | Dyn of ml_dyn                              (** Dynamic variable *)
   | String of string                           (** String constant (opaque, not a list) *)
 
-and operation_args = { args : value list; checking : Nucleus.is_type_abstraction option }
+and operation_args = { args : value list; checking : Nucleus.boundary option }
 
 (** A handler contains ML code for handling zero or more operations,
     plus the default case *)
@@ -232,7 +232,7 @@ val lookup_ref : ml_ref -> value comp
 val update_ref : ml_ref -> value -> unit comp
 
 (** A computation that invokes the specified operation. *)
-val operation : Ident.t -> ?checking:Nucleus.is_type_abstraction -> value list -> value comp
+val operation : Ident.t -> ?checking:Nucleus.boundary -> value list -> value comp
 
 (** Wrap the given computation with a handler. *)
 val handle_comp : handler -> value comp -> value comp

--- a/src/runtime/runtime.mli
+++ b/src/runtime/runtime.mli
@@ -18,10 +18,8 @@ type ml_constructor = Ident.t
 
 (** values are "finished" or "computed". They are inert pieces of data. *)
 type value =
-  | IsTerm of Nucleus.is_term_abstraction      (** A term judgment *)
-  | IsType of Nucleus.is_type_abstraction      (** A type judgment *)
-  | EqTerm of Nucleus.eq_term_abstraction      (** A term equality *)
-  | EqType of Nucleus.eq_type_abstraction      (** A type equality *)
+  | Judgement of Nucleus.judgement             (** A judgement *)
+  | Boundary of Nucleus.boundary               (** A judgement boundary (also known as a goal) *)
   | Closure of (value,value) closure           (** An ML function *)
   | Handler of handler                         (** Handler value *)
   | Tag of ml_constructor * value list         (** Application of a data constructor *)

--- a/src/runtime/runtime.mli
+++ b/src/runtime/runtime.mli
@@ -28,7 +28,7 @@ type value =
   | Dyn of ml_dyn                              (** Dynamic variable *)
   | String of string                           (** String constant (opaque, not a list) *)
 
-and operation_args = { args : value list; checking : Nucleus.boundary option }
+and operation_args = { args : value list; checking : Nucleus.boundary_abstraction option }
 
 (** A handler contains ML code for handling zero or more operations,
     plus the default case *)
@@ -78,6 +78,9 @@ val as_eq_term : loc:Location.t -> value -> Nucleus.eq_term
 (** Convert, or fail with [EqTypeExpected] *)
 val as_eq_type : loc:Location.t -> value -> Nucleus.eq_type
 
+(** Convert, or fail with [JudgementExpected] *)
+val as_judgement : loc:Location.t -> value -> Nucleus.judgement
+
 (** Convert, or fail with [IsTermAbstractionExpected] *)
 val as_is_term_abstraction : loc:Location.t -> value -> Nucleus.is_term_abstraction
 
@@ -89,6 +92,12 @@ val as_eq_term_abstraction : loc:Location.t -> value -> Nucleus.eq_term_abstract
 
 (** Convert, or fail with [EqTypeAbstractionExpected] *)
 val as_eq_type_abstraction : loc:Location.t -> value -> Nucleus.eq_type_abstraction
+
+(** Convert, or fail with [JudgementAbstractionExpected] *)
+val as_judgement_abstraction : loc:Location.t -> value -> Nucleus.judgement_abstraction
+
+(** Convert, or fail with [BoundaryAbstractionExpected] *)
+val as_boundary_abstraction : loc:Location.t -> value -> Nucleus.boundary_abstraction
 
 (** Convert, or fail with [ClosureExpected] *)
 val as_closure : loc:Location.t -> value -> (value,value) closure
@@ -134,8 +143,8 @@ type error =
   | UnknownConfig of string
   | Inapplicable of value
   | AnnotationMismatch of Nucleus.is_type * Nucleus.is_type_abstraction
-  | TypeMismatchCheckingMode of Nucleus.is_term_abstraction * Nucleus.is_type_abstraction
-  | UnexpectedAbstraction of Nucleus.is_type
+  | TypeMismatchCheckingMode of Nucleus.judgement_abstraction * Nucleus.boundary_abstraction
+  | UnexpectedAbstraction of Nucleus.boundary_abstraction
   | TermEqualityFail of Nucleus.is_term * Nucleus.is_term
   | TypeEqualityFail of Nucleus.is_type * Nucleus.is_type
   | UnannotatedAbstract of Name.t
@@ -155,7 +164,8 @@ type error =
   | IsTermAbstractionExpected of value
   | EqTypeAbstractionExpected of value
   | EqTermAbstractionExpected of value
-  | AbstractionExpected of value
+  | JudgementAbstractionExpected of value
+  | BoundaryAbstractionExpected of value
   | JudgementExpected of value
   | ClosureExpected of value
   | HandlerExpected of value
@@ -221,7 +231,7 @@ val lookup_ref : ml_ref -> value comp
 val update_ref : ml_ref -> value -> unit comp
 
 (** A computation that invokes the specified operation. *)
-val operation : Ident.t -> ?checking:Nucleus.boundary -> value list -> value comp
+val operation : Ident.t -> ?checking:Nucleus.boundary_abstraction -> value list -> value comp
 
 (** Wrap the given computation with a handler. *)
 val handle_comp : handler -> value comp -> value comp

--- a/src/runtime/runtime.mli
+++ b/src/runtime/runtime.mli
@@ -66,6 +66,12 @@ val mk_string : string -> value
 
 (** {b Value extraction} *)
 
+(** Convert to a non-abstracted value, or fail with [UnexpectedAbstraction] *)
+val as_not_abstract : loc:Location.t -> 'a Nucleus.abstraction -> 'a
+
+(** Convert to an abstracted value, or fail with [AbstractionExpected] *)
+val as_abstract : loc:Location.t -> 'a Nucleus.abstraction -> Nucleus.is_atom * 'a Nucleus.abstraction
+
 (** Convert, or fail with [IsTermExpected] *)
 val as_is_term : loc:Location.t -> value -> Nucleus.is_term
 
@@ -144,7 +150,7 @@ type error =
   | Inapplicable of value
   | AnnotationMismatch of Nucleus.is_type * Nucleus.is_type_abstraction
   | TypeMismatchCheckingMode of Nucleus.judgement_abstraction * Nucleus.boundary_abstraction
-  | UnexpectedAbstraction of Nucleus.boundary_abstraction
+  | UnexpectedAbstraction
   | TermEqualityFail of Nucleus.is_term * Nucleus.is_term
   | TypeEqualityFail of Nucleus.is_type * Nucleus.is_type
   | UnannotatedAbstract of Name.t
@@ -160,12 +166,7 @@ type error =
   | IsTermExpected of value
   | EqTypeExpected of value
   | EqTermExpected of value
-  | IsTypeAbstractionExpected of value
-  | IsTermAbstractionExpected of value
-  | EqTypeAbstractionExpected of value
-  | EqTermAbstractionExpected of value
-  | JudgementAbstractionExpected of value
-  | BoundaryAbstractionExpected of value
+  | AbstractionExpected
   | JudgementExpected of value
   | ClosureExpected of value
   | HandlerExpected of value
@@ -173,7 +174,7 @@ type error =
   | DynExpected of value
   | StringExpected of value
   | CoercibleExpected of value
-  | InvalidConvertible of Nucleus.is_type_abstraction * Nucleus.is_type_abstraction * Nucleus.eq_type_abstraction
+  | InvalidConvert of Nucleus.judgement_abstraction * Nucleus.eq_type_abstraction
   | InvalidCoerce of Nucleus.judgement_abstraction * Nucleus.boundary_abstraction
   | UnhandledOperation of Ident.t * value list
   | InvalidPatternMatch of value
@@ -207,6 +208,8 @@ val return : 'a -> 'a comp
 val return_unit : value comp
 
 val return_judgement : Nucleus.judgement_abstraction -> value comp
+
+val return_boundary : Nucleus.boundary_abstraction -> value comp
 
 val return_closure : (value -> value comp) -> value comp
 val return_handler :

--- a/src/runtime/runtime.mli
+++ b/src/runtime/runtime.mli
@@ -202,10 +202,8 @@ val return : 'a -> 'a comp
 
 val return_unit : value comp
 
+val return_judgement : Nucleus.judgement -> value comp
 val return_is_term : Nucleus.is_term_abstraction -> value comp
-val return_is_type : Nucleus.is_type_abstraction -> value comp
-val return_eq_term : Nucleus.eq_term_abstraction -> value comp
-val return_eq_type : Nucleus.eq_type_abstraction -> value comp
 
 val return_closure : (value -> value comp) -> value comp
 val return_handler :

--- a/src/runtime/runtime.mli
+++ b/src/runtime/runtime.mli
@@ -170,7 +170,7 @@ type error =
   | StringExpected of value
   | CoercibleExpected of value
   | InvalidConvertible of Nucleus.is_type_abstraction * Nucleus.is_type_abstraction * Nucleus.eq_type_abstraction
-  | InvalidCoerce of Nucleus.is_type_abstraction * Nucleus.is_term_abstraction
+  | InvalidCoerce of Nucleus.judgement * Nucleus.boundary
   | UnhandledOperation of Ident.t * value list
   | InvalidPatternMatch of value
   | InvalidHandlerMatch

--- a/src/runtime/runtime.mli
+++ b/src/runtime/runtime.mli
@@ -18,8 +18,8 @@ type ml_constructor = Ident.t
 
 (** values are "finished" or "computed". They are inert pieces of data. *)
 type value =
-  | Judgement of Nucleus.judgement             (** A judgement *)
-  | Boundary of Nucleus.boundary               (** A judgement boundary (also known as a goal) *)
+  | Judgement of Nucleus.judgement_abstraction (** A judgement *)
+  | Boundary of Nucleus.boundary_abstraction   (** A judgement boundary (also known as a goal) *)
   | Closure of (value,value) closure           (** An ML function *)
   | Handler of handler                         (** Handler value *)
   | Tag of ml_constructor * value list         (** Application of a data constructor *)
@@ -164,7 +164,7 @@ type error =
   | StringExpected of value
   | CoercibleExpected of value
   | InvalidConvertible of Nucleus.is_type_abstraction * Nucleus.is_type_abstraction * Nucleus.eq_type_abstraction
-  | InvalidCoerce of Nucleus.judgement * Nucleus.boundary
+  | InvalidCoerce of Nucleus.judgement_abstraction * Nucleus.boundary_abstraction
   | UnhandledOperation of Ident.t * value list
   | InvalidPatternMatch of value
   | InvalidHandlerMatch
@@ -196,7 +196,7 @@ val return : 'a -> 'a comp
 
 val return_unit : value comp
 
-val return_judgement : Nucleus.judgement -> value comp
+val return_judgement : Nucleus.judgement_abstraction -> value comp
 
 val return_closure : (value -> value comp) -> value comp
 val return_handler :
@@ -292,17 +292,8 @@ val add_dynamic : Name.t -> value -> unit toplevel
 (** Modify the value bound by a dynamic variable *)
 val top_now : ml_dyn -> value -> unit toplevel
 
-(** Extend the signature with a new is_type rule *)
-val add_rule_is_type : Ident.t -> Rule.rule_is_type -> unit toplevel
-
-(** Extend the signature with a new is_term rule *)
-val add_rule_is_term : Ident.t -> Rule.rule_is_term -> unit toplevel
-
-(** Extend the signature with a new is_type rule *)
-val add_rule_eq_type : Ident.t -> Rule.rule_eq_type -> unit toplevel
-
-(** Extend the signature with a new is_term rule *)
-val add_rule_eq_term : Ident.t -> Rule.rule_eq_term -> unit toplevel
+(** Extend the signature with a new rule *)
+val add_rule : Ident.t -> Rule.rule -> unit toplevel
 
 (** Handle a computation at the toplevel. *)
 val top_handle : loc:Location.t -> 'a comp -> 'a toplevel

--- a/src/runtime/runtime.mli
+++ b/src/runtime/runtime.mli
@@ -69,9 +69,6 @@ val mk_string : string -> value
 (** Convert to a non-abstracted value, or fail with [UnexpectedAbstraction] *)
 val as_not_abstract : loc:Location.t -> 'a Nucleus.abstraction -> 'a
 
-(** Convert to an abstracted value, or fail with [AbstractionExpected] *)
-val as_abstract : loc:Location.t -> 'a Nucleus.abstraction -> Nucleus.is_atom * 'a Nucleus.abstraction
-
 (** Convert, or fail with [IsTermExpected] *)
 val as_is_term : loc:Location.t -> value -> Nucleus.is_term
 

--- a/src/runtime/toplevel.ml
+++ b/src/runtime/toplevel.ml
@@ -29,7 +29,7 @@ let print_error state err ppf =
 
   | RuntimeError {Location.thing=err; loc} ->
      let penv = Runtime.get_penv state.runtime in
-     Format.fprintf ppf "@[<hov 2>Runtime error:@ %t@]" (Runtime.print_error ~penv err)
+     Format.fprintf ppf "%t:@.@[<hov 2>Runtime error:@ %t@]" (Location.print loc) (Runtime.print_error ~penv err)
 
   | NucleusError err ->
      let penv = Runtime.get_nucleus_penv state.runtime in

--- a/src/typing/context.ml
+++ b/src/typing/context.ml
@@ -16,12 +16,12 @@ sig
 
   val add_ml_type : Ident.t * Mlty.ty_def -> t -> t
   val add_ml_operation : Ident.t * (Mlty.ty list * Mlty.ty) -> t -> t
-  val add_tt_constructor : Ident.t * Mlty.tt_constructor -> t -> t
+  val add_tt_constructor : Ident.t -> t -> t
   val add_ml_value : Mlty.ty_schema -> t -> t
 
   val get_ml_type : Path.t -> t -> Ident.t * Mlty.ty_def
   val get_ml_operation : Path.t -> t -> Ident.t * (Mlty.ty list * Mlty.ty)
-  val get_tt_constructor : Path.t -> t -> Ident.t * Mlty.tt_constructor
+  val get_tt_constructor : Path.t -> t -> Ident.t
   val get_ml_value : Path.t -> t -> Mlty.ty_schema
 
   val push_ml_module : t -> t
@@ -60,7 +60,7 @@ struct
       ml_modules : ml_module table;
       ml_types : (Ident.t * Mlty.ty_def) table;
       ml_operations : (Ident.t * (Mlty.ty list * Mlty.ty)) table;
-      tt_constructors : (Ident.t * Mlty.tt_constructor) table;
+      tt_constructors : Ident.t table;
       ml_values : Mlty.ty_schema table;
   }
 
@@ -203,8 +203,8 @@ let lookup_continuation {ml_yield;_} =
     | Some cont -> cont
     | None -> assert false
 
-let add_tt_constructor c t ctx =
-  { ctx with table = SymbolTable.add_tt_constructor (c, t) ctx.table }
+let add_tt_constructor c ctx =
+  { ctx with table = SymbolTable.add_tt_constructor c ctx.table }
 
 let add_ml_type t d ctx =
   let t = Ident.create t in

--- a/src/typing/context.mli
+++ b/src/typing/context.mli
@@ -26,13 +26,13 @@ val lookup_ml_operation : Path.t -> t -> Ident.t * (Mlty.ty list * Mlty.ty)
 val lookup_ml_constructor : Path.ml_constructor -> t -> Ident.t * Mlty.ty list * Mlty.ty
 
 (** Lookup the (M)L type of a TT constructor. *)
-val lookup_tt_constructor : Path.t -> t -> Ident.t * Mlty.tt_constructor
+val lookup_tt_constructor : Path.t -> t -> Ident.t
 
 (** Lookup the type of the current continuation. *)
 val lookup_continuation : t -> Mlty.ty * Mlty.ty
 
 (** Declare a new TT constructor. *)
-val add_tt_constructor : Ident.t -> Mlty.tt_constructor -> t -> t
+val add_tt_constructor : Ident.t -> t -> t
 
 (** Define a new type. The type definition may refer to not-yet-defined types, relying on the caller to add them afterwards. *)
 val add_ml_type : Path.t -> Mlty.ty_def -> t -> t

--- a/src/typing/mlty.mli
+++ b/src/typing/mlty.mli
@@ -16,21 +16,10 @@ end
 (** Sets of metavariables. *)
 module MetaSet : Set.S with type elt = meta
 
-(** ML typing keeps track of judgement forms *)
-type judgement =
-  | IsType
-  | IsTerm
-  | EqType
-  | EqTerm
-
-(** ML typing keeps track of TT abstractions (without dependencies) *)
-type abstracted_judgement =
-  | NotAbstract of judgement
-  | Abstract of abstracted_judgement
-
 (** The type of ML types. *)
 type ty =
-  | Judgement of abstracted_judgement
+  | Judgement
+  | Boundary
   | String
   | Meta of meta
   | Param of param
@@ -40,18 +29,6 @@ type ty =
   | Apply of Path.t * ty list
   | Ref of ty
   | Dynamic of ty
-
-(** The ML type of a TT constructor. *)
-type tt_constructor = abstracted_judgement list * judgement
-
-(** Non-abstracted type judgement *)
-val is_type : ty
-
-(** Non-abstracted term judgement *)
-val is_term : ty
-
-(** Non-abstracted equality type judgement *)
-val eq_type : ty
 
 (** The unit type encoded as an empty product. *)
 val unit_ty : ty
@@ -89,8 +66,6 @@ type error =
   | Ungeneralizable of param list * ty
   | UnknownJudgementForm
   | JudgementExpected of ty
-  | AbstractionExpected of judgement
-  | UnexpectedJudgementAbstraction of judgement
 
 exception Error of error Location.located
 

--- a/src/typing/substitution.ml
+++ b/src/typing/substitution.ml
@@ -17,7 +17,8 @@ let apply (s : t) t =
   then t
   else begin
       let rec app = function
-        | Mlty.Judgement _
+        | Mlty.Judgement
+        | Mlty.Boundary
         | Mlty.String
         | Mlty.Param _ as t -> t
 

--- a/src/typing/tyenv.mli
+++ b/src/typing/tyenv.mli
@@ -34,14 +34,14 @@ val lookup_ml_operation : Path.t -> (Ident.t * (Mlty.ty list * Mlty.ty)) tyenvM
 val lookup_ml_constructor : Path.ml_constructor -> (Ident.t * Mlty.ty list * Mlty.ty) tyenvM
 
 (** Lookup a TT constructor and return its expected form. *)
-val lookup_tt_constructor : Path.t -> (Ident.t * Mlty.tt_constructor) tyenvM
+val lookup_tt_constructor : Path.t -> Ident.t tyenvM
 
 (** Lookup the continuation and return the expected type of its argument and the type it
    returns. *)
 val lookup_continuation : (Mlty.ty * Mlty.ty) tyenvM
 
 (** Add a TT constructor to the typing context, globally forever. *)
-val add_tt_constructor : Ident.t -> Mlty.tt_constructor -> unit tyenvM
+val add_tt_constructor : Ident.t -> unit tyenvM
 
 (** [add_equation ~loc t1 t2] try to unify the actual type [t1] with the expected type
     [t2]. If successful, retry to solve the current unsolved constraints. *)

--- a/src/typing/typecheck.ml
+++ b/src/typing/typecheck.ml
@@ -925,10 +925,6 @@ struct
   let _, none = run (Tyenv.lookup_ml_constructor Desugar.Builtin.none)
   let _, some = run (Tyenv.lookup_ml_constructor Desugar.Builtin.some)
 
-  let _, notcoercible = run (Tyenv.lookup_ml_constructor Desugar.Builtin.notcoercible)
-  let _, convertible = run (Tyenv.lookup_ml_constructor Desugar.Builtin.convertible)
-  let _, coercible_constructor = run (Tyenv.lookup_ml_constructor Desugar.Builtin.coercible_constructor)
-
   let _, mlless = run (Tyenv.lookup_ml_constructor Desugar.Builtin.mlless)
   let _, mlequal = run (Tyenv.lookup_ml_constructor Desugar.Builtin.mlequal)
   let _, mlgreater = run (Tyenv.lookup_ml_constructor Desugar.Builtin.mlgreater)

--- a/src/typing/typecheck.ml
+++ b/src/typing/typecheck.ml
@@ -45,10 +45,7 @@ let rec generalizable c =
   | Rsyntax.Substitute _
   | Rsyntax.Yield _
   | Rsyntax.Apply _
-  | Rsyntax.OccursIsTypeAbstraction _
-  | Rsyntax.OccursIsTermAbstraction _
-  | Rsyntax.OccursEqTypeAbstraction _
-  | Rsyntax.OccursEqTermAbstraction _
+  | Rsyntax.Occurs _
   | Rsyntax.Context _
   | Rsyntax.Natural _ -> Ungeneralizable
 

--- a/src/typing/typecheck.ml
+++ b/src/typing/typecheck.ml
@@ -785,12 +785,8 @@ let premises prems m =
        m >>= fun x ->
        let ps = List.rev ps in return (ps, x)
     | prem :: prems ->
-       premise prem >>= fun (xopt, p) ->
-       begin match xopt with
-       | None -> fold (p :: ps) prems
-       | Some x ->
-          Tyenv.add_bound_mono x Mlty.Judgement (fold (p::ps) prems)
-       end
+       premise prem >>= fun (x, p) ->
+       Tyenv.add_bound_mono x Mlty.Judgement (fold (p::ps) prems)
   in
   fold [] prems
 

--- a/src/typing/typecheck.mli
+++ b/src/typing/typecheck.mli
@@ -19,10 +19,6 @@ sig
   val none : Ident.t * Mlty.ty list * Mlty.ty
   val some : Ident.t * Mlty.ty list * Mlty.ty
 
-  val notcoercible : Ident.t * Mlty.ty list * Mlty.ty
-  val convertible : Ident.t * Mlty.ty list * Mlty.ty
-  val coercible_constructor : Ident.t * Mlty.ty list * Mlty.ty
-
   val mlless : Ident.t * Mlty.ty list * Mlty.ty
   val mlequal : Ident.t * Mlty.ty list * Mlty.ty
   val mlgreater : Ident.t * Mlty.ty list * Mlty.ty

--- a/src/utils/level.ml
+++ b/src/utils/level.ml
@@ -40,6 +40,8 @@ let abstraction = 800
 let abstraction_body = abstraction
 let binder = abstraction
 
+let boundary = abstraction_body
+
 let jdg = highest
 
 let ml_app = constructor

--- a/src/utils/level.mli
+++ b/src/utils/level.mli
@@ -56,6 +56,9 @@ val abstraction : t
 val abstraction_body : t
 val binder : t (* The type inside a binder *)
 
+(** A judgement boundary *)
+val boundary : t
+
 (** A judgement [ctx |- e : t] *)
 val jdg : t
 

--- a/src/utils/name.ml
+++ b/src/utils/name.ml
@@ -251,8 +251,11 @@ let level x ys = index x (List.rev ys)
 
 (** Association lists indexed by de Bruijn indices *)
 let print_debruijn xs k ppf =
-  let x = List.nth xs k in
-  print x ppf
+  try
+    let x = List.nth xs k in
+    print x ppf
+  with
+  | Failure _ -> Format.fprintf ppf "[%d]" k
 
 module Json =
 struct

--- a/tests/modules/module_open_print.m31.ref
+++ b/tests/modules/module_open_print.m31.ref
@@ -1,7 +1,7 @@
 Processing module A
 Rule A.X is postulated.
 ML type A.cow declared.
-- : is_type = ⊢ A.X type
+- : judgement = A.X
 - : A.cow = A.Cow
-- : is_type = ⊢ X type
+- : judgement = X
 - : A.cow = Cow

--- a/tests/nucleus/alpha_equality.m31
+++ b/tests/nucleus/alpha_equality.m31
@@ -6,6 +6,6 @@ rule u : P a
 rule B type
 rule ξ : A ≡ B
 rule ζ : B ≡ A
-let a' = handle a : B with ML.coerce _ _ => yield (ML.Convertible ξ) end
-let Q = handle P (a' : A) with ML.coerce _ _ => yield (ML.Convertible ζ) end
-let u' = u : Q
+let a' = handle a : (? : B) with ML.coerce _ _ => yield (ML.Some (convert a ξ)) end
+let Q = handle P (a' : (? : A)) with ML.coerce _ _ => yield (ML.Some (convert a' ζ)) end
+let u' = u : (? : Q)

--- a/tests/nucleus/alpha_equality.m31.ref
+++ b/tests/nucleus/alpha_equality.m31.ref
@@ -5,6 +5,6 @@ Rule u is postulated.
 Rule B is postulated.
 Rule ξ is postulated.
 Rule ζ is postulated.
-val a' :> is_term = ⊢ a
-val Q :> is_type = ⊢ P a type
-val u' :> is_term = ⊢ u
+val a' :> judgement = a
+val Q :> judgement = P a
+val u' :> judgement = u

--- a/tests/nucleus/boundary.m31
+++ b/tests/nucleus/boundary.m31
@@ -1,0 +1,16 @@
+rule A type ;;
+rule B type ;;
+rule a : A ;;
+rule b : A ;;
+
+? type ;;
+{x : A} {y : A} (? type) ;;
+
+? : A ;;
+{x : A} {y : A} ? : A ;;
+
+A ≡ B as ? ;;
+{x : A} {y : A} A ≡ B as ? ;;
+
+a ≡ b : A as ? ;;
+{x : A} a ≡ x : A as ? ;;

--- a/tests/nucleus/boundary.m31.ref
+++ b/tests/nucleus/boundary.m31.ref
@@ -1,0 +1,12 @@
+Rule A is postulated.
+Rule B is postulated.
+Rule a is postulated.
+Rule b is postulated.
+- : boundary = ? type
+- : boundary = {_ : A} {_ : A} ? type
+- : boundary = ? : A
+- : boundary = {_ : A} {_ : A} ? : A
+- : boundary = A ≡ B as ?
+- : boundary = {_ : A} {_ : A} A ≡ B as ?
+- : boundary = a ≡ b : A as ?
+- : boundary = {x : A} a ≡ x : A as ?

--- a/tests/nucleus/convert.m31
+++ b/tests/nucleus/convert.m31
@@ -1,10 +1,22 @@
-rule A type
-rule B type
-rule ξ : A ≡ B
-rule a : A
-;;
+rule A type ;;
+rule B type ;;
+rule ξ : A ≡ B ;;
+rule a : A ;;
+rule b : A ;;
 
-(convert a ξ)
-;;
+convert a ξ ;;
 
-match (convert a ξ) with ⊢ _ : t => t end
+match (convert a ξ) with ⊢ _ : t => t end ;;
+
+rule P (⊢ _ : A) type ;;
+
+rule ζ (⊢ x : A) : P x ≡ P a ;;
+
+ζ b ;;
+
+rule z : A ;;
+
+let e = (convert ({u : P z} u) ({u : P z} ζ z)) ;;
+
+match e with ⊢ {r : R} (v : V) => (r, R, v, V) end ;;
+

--- a/tests/nucleus/convert.m31
+++ b/tests/nucleus/convert.m31
@@ -1,0 +1,10 @@
+rule A type
+rule B type
+rule ξ : A ≡ B
+rule a : A
+;;
+
+(convert a ξ)
+;;
+
+match (convert a ξ) with ⊢ _ : t => t end

--- a/tests/nucleus/convert.m31.ref
+++ b/tests/nucleus/convert.m31.ref
@@ -2,5 +2,12 @@ Rule A is postulated.
 Rule B is postulated.
 Rule ξ is postulated.
 Rule a is postulated.
+Rule b is postulated.
 - : judgement = a
 - : judgement = B
+Rule P is postulated.
+Rule ζ is postulated.
+- : judgement = P b ≡ P a as ?
+Rule z is postulated.
+val e :> judgement = {u : P z} u
+- : judgement * judgement * judgement * judgement = (?u₀, P z, ?u₀, P a)

--- a/tests/nucleus/convert.m31.ref
+++ b/tests/nucleus/convert.m31.ref
@@ -1,0 +1,6 @@
+Rule A is postulated.
+Rule B is postulated.
+Rule ξ is postulated.
+Rule a is postulated.
+- : judgement = a
+- : judgement = B

--- a/tests/nucleus/order_of_arguments.m31.ref
+++ b/tests/nucleus/order_of_arguments.m31.ref
@@ -5,6 +5,6 @@ Rule b is postulated.
 Rule P is postulated.
 Rule p is postulated.
 Rule Q is postulated.
-- : is_type = ⊢ P a b type
-- : is_term = ⊢ p
-- : is_type = ⊢ Q p a b type
+- : judgement = P a b
+- : judgement = p
+- : judgement = Q p a b

--- a/tests/syntax/subscripts.m31.ref
+++ b/tests/syntax/subscripts.m31.ref
@@ -1,28 +1,27 @@
 Rule A is postulated.
 Rule f is postulated.
-- : {}{}is_term = {a₀ : A} {a : A} (⊢ f a₀ a)
+- : judgement = {a₀ : A} {a : A} f a₀ a
 Rule a is postulated.
-- : {}{}is_term = {a₀ : A} {a₁ : A} (⊢ f a₀ a₁)
+- : judgement = {a₀ : A} {a₁ : A} f a₀ a₁
 Rule a₁ is postulated.
-- : {}{}is_term = {a₀ : A} {a₂ : A} (⊢ f a₀ a₂)
+- : judgement = {a₀ : A} {a₂ : A} f a₀ a₂
 Rule a₂ is postulated.
 Rule a₃ is postulated.
-- : {}{}is_term = {a₀ : A} {a₄ : A} (⊢ f a₀ a₄)
-- : {}{}{}is_term = {a₀ : A} {a₄ : A} {a₅ : A}
-  (⊢ f (f a₀ a₄) a₅)
-- : {}{}{}is_term = {a₀ : A} {a4 : A} {a₄ : A} (⊢ f (f a₀ a4) a₄)
+- : judgement = {a₀ : A} {a₄ : A} f a₀ a₄
+- : judgement = {a₀ : A} {a₄ : A} {a₅ : A} f (f a₀ a₄) a₅
+- : judgement = {a₀ : A} {a4 : A} {a₄ : A} f (f a₀ a4) a₄
 Rule a₄ is postulated.
 Rule a₅ is postulated.
 Rule a₆ is postulated.
 Rule a₇ is postulated.
 Rule a₈ is postulated.
 Rule a₉ is postulated.
-- : {}{}is_term = {a₀ : A} {a₁₀ : A} (⊢ f a₀ a₁₀)
+- : judgement = {a₀ : A} {a₁₀ : A} f a₀ a₁₀
 Rule a₁₀ is postulated.
-- : {}{}is_term = {a₀ : A} {a₁₁ : A} (⊢ f a₀ a₁₁)
+- : judgement = {a₀ : A} {a₁₁ : A} f a₀ a₁₁
 Rule a₁1 is postulated.
-- : {}{}is_term = {a₀ : A} {a₁₁ : A} (⊢ f (f a₁1 a₀) a₁₁)
-- : {}{}is_term = {a₀ : A} {a₁₁ : A} (⊢ f (f a₁1 a₀) a₁₁)
+- : judgement = {a₀ : A} {a₁₁ : A} f (f a₁1 a₀) a₁₁
+- : judgement = {a₀ : A} {a₁₁ : A} f (f a₁1 a₀) a₁₁
 Rule a₁₁ is postulated.
-- : {}{}is_term = {a₀ : A} {a₁₂ : A} (⊢ f (f a₁1 a₀) a₁₂)
-- : {}{}is_term = {a₀ : A} {a₁₂ : A} (⊢ f (f a₁₂ a₀) a₁₂)
+- : judgement = {a₀ : A} {a₁₂ : A} f (f a₁1 a₀) a₁₂
+- : judgement = {a₀ : A} {a₁₂ : A} f (f a₁₂ a₀) a₁₂

--- a/theories/dependent_sum.m31
+++ b/theories/dependent_sum.m31
@@ -28,11 +28,11 @@ let type_of e = match e with ⊢ _ : t => t end
 
 rule Σ_β₂ (⊢ A type) (x : A ⊢ B type) (⊢ a : A) (⊢ b : B{a})
   :
-  ( let H ξ = handler ML.coerce _ _ => yield (ML.Convertible ξ) end in
+  ( let H ξ = handler ML.coerce x _ => yield (ML.Some (convert x ξ)) end in
     let eq_π₁_a = Σ_β₁ A B a b in
     let ξ = eq_subst.eq_subst A B (π₁ A B (pair A B a b)) a eq_π₁_a in
     with H ξ handle
-    (π₂ A B (pair A B a b)) : B{a} )
+    (π₂ A B (pair A B a b)) : (? : B{a}) )
   ==
   b
   : B{a}

--- a/theories/identity_type.m31
+++ b/theories/identity_type.m31
@@ -19,7 +19,6 @@ rule Id_β
   : Id_ind A C c a a (Id_refl A a) ≡ c{a} : C{a, a, Id_refl A a}
 
 require judgemental_equality
-let convert = judgemental_equality.convert_term
 let sym = judgemental_equality.sym_eq_type
 
 rule Id_congr

--- a/theories/judgemental_equality.m31
+++ b/theories/judgemental_equality.m31
@@ -1,9 +1,5 @@
 require judgemental_equality_type
 
-let convert_term s ξ =
-  let b = match ξ with ⊢ _ ≡ B => B end in
-  handle s : b with ML.coerce x y => yield (ML.Convertible ξ) end
-
 let sym_eq_type h = match h with
   | ⊢ a ≡ b => judgemental_equality_type.eq_type_sym a b h
   end


### PR DESCRIPTION
AML is simplified as follows:

1. there is a single `judgement` AML type which merges together the  previous AML types for abstracted judgement forms. Thus the typing information provided by AML is less precise, but on the other hand we gain flexibility in writing tactics. For example, we can write a tactic which descends inside an abstraction to an arbitrary depth.

2. There is a new AML type `boundary` which describes the boundary of a possibly abstracted judgement. We're still missing constructos and patterns for boundaries in the AML syntax, but the rest is there.

3. The evaluation mode in which we evaluate a term to a prescribed type has been generalized to evaluation of a judgement to a prescribed boundary. Consequently, `coerce` takes as an argument a judgement and a boundary (instead of a term and a type).
