### PR TITLE
Unify ML and TT patterns.

### DIFF
--- a/src/dsyntax.mli
+++ b/src/dsyntax.mli
@@ -27,27 +27,20 @@ type let_annotation =
   | Let_annot_none
   | Let_annot_schema of ml_schema
 
-type tt_pattern = tt_pattern' located
-and tt_pattern' =
-  | Patt_TT_Anonymous
-  | Patt_TT_Var of Name.t
-  | Patt_TT_As of tt_pattern * tt_pattern
-  | Patt_TT_Constructor of Path.t * tt_pattern list
-  | Patt_TT_GenAtom of tt_pattern
-  | Patt_TT_IsType of tt_pattern
-  | Patt_TT_IsTerm of tt_pattern * tt_pattern
-  | Patt_TT_EqType of tt_pattern * tt_pattern
-  | Patt_TT_EqTerm of tt_pattern * tt_pattern * tt_pattern
-  | Patt_TT_Abstraction of Name.t option * tt_pattern * tt_pattern
-
-type ml_pattern = ml_pattern' located
-and ml_pattern' =
+type pattern = pattern' located
+and pattern' =
   | Patt_Anonymous
   | Patt_Var of Name.t
-  | Patt_As of ml_pattern * ml_pattern
-  | Patt_Judgement of tt_pattern
-  | Patt_Constructor of Path.ml_constructor * ml_pattern list
-  | Patt_Tuple of ml_pattern list
+  | Patt_As of pattern * pattern
+  | Patt_TTConstructor of Path.t * pattern list
+  | Patt_GenAtom of pattern
+  | Patt_IsType of pattern
+  | Patt_IsTerm of pattern * pattern
+  | Patt_EqType of pattern * pattern
+  | Patt_EqTerm of pattern * pattern * pattern
+  | Patt_Abstraction of Name.t option * pattern * pattern
+  | Patt_MLConstructor of Path.ml_constructor * pattern list
+  | Patt_Tuple of pattern list
 
 (** Desugared computations *)
 type comp = comp' located
@@ -92,7 +85,7 @@ and boundary =
    | BoundaryEqTerm of comp * comp * comp
 
 and let_clause =
-  | Let_clause of ml_pattern * let_annotation * comp (* [let (?p :> t) = c] *)
+  | Let_clause of pattern * let_annotation * comp (* [let (?p :> t) = c] *)
 
 and letrec_clause =
   | Letrec_clause of Name.t * (Name.t * arg_annotation) * let_annotation * comp
@@ -103,10 +96,10 @@ and handler = {
   handler_finally : match_case list;
 }
 
-and match_case = ml_pattern * comp option * comp
+and match_case = pattern * comp option * comp
 
 (** Match multiple patterns at once, with shared pattern variables *)
-and match_op_case = ml_pattern list * tt_pattern option * comp
+and match_op_case = pattern list * pattern option * comp
 
 type ml_tydef =
   | ML_Sum of (Name.t * ml_ty list) list

--- a/src/parser/input.mli
+++ b/src/parser/input.mli
@@ -41,26 +41,18 @@ type let_annotation =
 (* An argument of a function or a let-clause *)
 type ml_arg = Name.t * arg_annotation
 
-(** Sugared term patterns *)
-type tt_pattern = tt_pattern' located
-and tt_pattern' =
-  | Patt_TT_Anonymous
-  | Patt_TT_Name of Name.t (* pattern variable *)
-  | Patt_TT_As of tt_pattern * tt_pattern
-  | Patt_TT_Constructor of path * tt_pattern list
-  | Patt_TT_GenAtom of tt_pattern
-  | Patt_TT_IsType of tt_pattern
-  | Patt_TT_IsTerm of tt_pattern * tt_pattern
-  | Patt_TT_EqType of tt_pattern * tt_pattern
-  | Patt_TT_EqTerm of tt_pattern * tt_pattern * tt_pattern
-  | Patt_TT_Abstraction of (Name.t option * tt_pattern option) list * tt_pattern
-
+(** Sugared patterns *)
 type pattern = pattern' located
 and pattern' =
   | Patt_Anonymous
-  | Patt_Name of Name.path
+  | Patt_Path of Name.path
   | Patt_As of pattern * pattern
-  | Patt_Judgement of tt_pattern
+  | Patt_GenAtom of pattern
+  | Patt_IsType of pattern
+  | Patt_IsTerm of pattern * pattern
+  | Patt_EqType of pattern * pattern
+  | Patt_EqTerm of pattern * pattern * pattern
+  | Patt_Abstraction of (Name.t option * pattern option) list * pattern
   | Patt_Constructor of path * pattern list
   | Patt_List of pattern list
   | Patt_Tuple of pattern list
@@ -121,7 +113,7 @@ and handle_case =
 
 and match_case = pattern * comp option * comp
 
-and match_op_case = pattern list * tt_pattern option * comp
+and match_op_case = pattern list * pattern option * comp
 
 type ml_tydef =
   | ML_Sum of (Name.t * ml_ty list) list

--- a/src/rsyntax.mli
+++ b/src/rsyntax.mli
@@ -12,39 +12,20 @@ type tt_constructor = Ident.t
     from, so that we can print informative runtime error messages. *)
 type 'a located = 'a Location.located
 
-module Pattern :
-sig
-(** Judgement pattern. *)
-  type judgement = judgement' located
-  and judgement' =
-    | TTAnonymous
-    | TTVar
-    | TTAs of judgement * judgement
-    | TTConstructor of tt_constructor * argument list
-    | TTGenAtom of is_term
-    | TTIsType of is_type
-    | TTIsTerm of is_term * is_type
-    | TTEqType of is_type * is_type
-    | TTEqTerm of is_term * is_term * is_type
-    | TTAbstract of Name.t option * is_type * judgement
-
-  and is_type = judgement
-  and is_term = judgement
-  and argument = judgement
-
-  (** Boundary pattern *)
-  type boundary = Boundary_Pattern_Not_Implemented
-
-  (** ML pattern *)
-  type aml = aml' located
-  and aml' =
-    | Anonymous
-    | Var
-    | As of aml * aml
-    | Judgement of judgement
-    | MLConstructor of ml_constructor * aml list
-    | Tuple of aml list
-end
+type pattern = pattern' located
+and pattern' =
+  | Patt_Anonymous
+  | Patt_Var
+  | Patt_As of pattern * pattern
+  | Patt_TTConstructor of tt_constructor * pattern list
+  | Patt_GenAtom of pattern
+  | Patt_IsType of pattern
+  | Patt_IsTerm of pattern * pattern
+  | Patt_EqType of pattern * pattern
+  | Patt_EqTerm of pattern * pattern * pattern
+  | Patt_Abstract of Name.t option * pattern * pattern
+  | Patt_MLConstructor of ml_constructor * pattern list
+  | Patt_Tuple of pattern list
 
 (** Computations *)
 type comp = comp' located
@@ -94,7 +75,7 @@ and boundary =
 
    The names and types are used only for printing during runtime. *)
 and let_clause =
-  | Let_clause of Pattern.aml * comp
+  | Let_clause of pattern * comp
 
 and letrec_clause =
   | Letrec_clause of comp
@@ -105,10 +86,10 @@ and handler = {
   handler_finally : match_case list;
 }
 
-and match_case = Pattern.aml * comp option * comp
+and match_case = pattern * comp option * comp
 
 (** Match multiple patterns at once, with shared pattern variables *)
-and match_op_case = Pattern.aml list * Pattern.boundary option * comp
+and match_op_case = pattern list * pattern option * comp
 
 (** Type definitions are needed during runtime so that we can print them
     at the toplevel. *)

--- a/src/runtime/matching.ml
+++ b/src/runtime/matching.ml
@@ -13,107 +13,131 @@ let as_is_term jdg =
   | Some (Nucleus.JudgementIsTerm e) -> e
   | Some Nucleus.(JudgementIsType _ | JudgementEqType _ | JudgementEqTerm _) -> raise Match_fail
 
-let rec collect_judgement sgn xvs {Location.thing=p';loc} jdg =
-  match p' with
+let rec collect_pattern sgn xvs {Location.thing=p';loc} v =
+  match p', v with
+  | Rsyntax.Patt_Anonymous, _ -> xvs
 
-  | Rsyntax.Pattern.TTAnonymous -> xvs
+  | Rsyntax.Patt_Var, v ->
+     add_var v xvs
 
-  | Rsyntax.Pattern.TTVar ->
-     add_var (Runtime.Judgement jdg) xvs
+  | Rsyntax.Patt_As (p1, p2), v ->
+     let xvs = collect_pattern sgn xvs p1 v in
+     collect_pattern sgn xvs p2 v
 
-  | Rsyntax.Pattern.TTAs (p1, p2) ->
-     let xvs = collect_judgement sgn xvs p1 jdg in
-     collect_judgement sgn xvs p2 jdg
+  | Rsyntax.Patt_MLConstructor (tag, ps), Runtime.Tag (tag', vs) ->
+     if not (Runtime.equal_tag tag tag')
+     then
+       raise Match_fail
+     else
+       collect_patterns sgn xvs ps vs
 
-  | Rsyntax.Pattern.TTAbstract (xopt, p1, p2) ->
-     begin match Nucleus.invert_judgement_abstraction jdg with
-     | Nucleus.Stump_NotAbstract _ -> raise Match_fail
-     | Nucleus.Stump_Abstract (a, v2) ->
-        let v1 = Nucleus.(abstract_not_abstract (JudgementIsType (type_of_atom a))) in
-        let xvs = collect_judgement sgn xvs p1 v1 in
-        let xvs =
-          match xopt with
-          | None -> xvs
-          | Some _ ->
-             let e = Nucleus.(abstract_not_abstract (JudgementIsTerm (form_is_term_atom a))) in
-             add_var (Runtime.mk_judgement e) xvs
-        in
-        collect_judgement sgn xvs p2 v2
-     end
-
-  | Rsyntax.Pattern.TTConstructor (c, ps) ->
-     begin match Nucleus.as_not_abstract jdg with
+  | Rsyntax.Patt_TTConstructor (c, ps), Runtime.Judgement abstr ->
+     begin match Nucleus.as_not_abstract abstr with
      | None -> raise Match_fail
      | Some jdg -> collect_constructor sgn xvs c ps jdg
      end
 
-  | Rsyntax.Pattern.TTGenAtom p ->
-     let e = as_is_term jdg in
+  | Rsyntax.Patt_GenAtom p, (Runtime.Judgement abstr as v) ->
+     let e = as_is_term abstr in
      begin match Nucleus.invert_is_term sgn e with
      | Nucleus.Stump_TermAtom a ->
-        collect_judgement sgn xvs p jdg
+        collect_pattern sgn xvs p v
      | Nucleus.(Stump_TermConstructor _ | Stump_TermMeta _ | Stump_TermConvert _) ->
         raise Match_fail
      end
 
-
-  | Rsyntax.Pattern.TTIsType p ->
-     begin match Nucleus.as_not_abstract jdg with
+  | Rsyntax.Patt_IsType p, (Runtime.Judgement abstr as v) ->
+     begin match Nucleus.as_not_abstract abstr with
      | None -> raise Match_fail
-     | Some (Nucleus.JudgementIsType _) -> collect_judgement sgn xvs p jdg
+     | Some (Nucleus.JudgementIsType _) -> collect_pattern sgn xvs p v
      | Some Nucleus.(JudgementIsTerm _ | JudgementEqType _ | JudgementEqTerm _) -> raise Match_fail
      end
 
-  | Rsyntax.Pattern.TTIsTerm (p1, p2) ->
+  | Rsyntax.Patt_IsTerm (p1, p2), (Runtime.Judgement abstr as v) ->
      (* By computing [e] first, we make sure that we're actually matching against
         a term judgement. If you change the order of evaluation, then it could
         happen that [p1] will match against [jdg] even though [jdg] is not a term
         judgement. *)
-     let e = as_is_term jdg in
-     let xvs = collect_judgement sgn xvs p1 jdg in
+     let e = as_is_term abstr in
+     let xvs = collect_pattern sgn xvs p1 v  in
      begin match p2 with
-     | {Location.thing=Rsyntax.Pattern.TTAnonymous;_} -> xvs
+     | {Location.thing=Rsyntax.Patt_Anonymous;_} -> xvs
      | _ ->
         let t = Nucleus.type_of_term sgn e in
-        collect_judgement sgn xvs p2 (Nucleus.(abstract_not_abstract (JudgementIsType t)))
+        let t_abstr = Nucleus.(abstract_not_abstract (JudgementIsType t)) in
+        collect_judgement sgn xvs p2 t_abstr
      end
 
-  | Rsyntax.Pattern.TTEqType (pt1, pt2) ->
-     begin match Nucleus.as_not_abstract jdg with
-     | None -> raise Match_fail
-     | Some Nucleus.(JudgementIsTerm _ | JudgementIsType _ | JudgementEqTerm _) -> raise Match_fail
+  | Rsyntax.Patt_EqType (pt1, pt2), Runtime.Judgement abstr ->
+     begin match Nucleus.as_not_abstract abstr with
+     | None | Some Nucleus.(JudgementIsTerm _ | JudgementIsType _ | JudgementEqTerm _) ->
+        raise Match_fail
      | Some (Nucleus.JudgementEqType eq) ->
         begin match Nucleus.invert_eq_type eq with
         | Nucleus.Stump_EqType (_asmp, t1, t2) ->
-           let jdg1 = Nucleus.(abstract_not_abstract (JudgementIsType t1))
-           and jdg2 = Nucleus.(abstract_not_abstract (JudgementIsType t2)) in
-           let xvs = collect_judgement sgn xvs pt1 jdg1 in
-           collect_judgement sgn xvs pt2 jdg2
+           let t1_abstr = Nucleus.(abstract_not_abstract (JudgementIsType t1))
+           and t2_abstr = Nucleus.(abstract_not_abstract (JudgementIsType t2)) in
+           let xvs = collect_judgement sgn xvs pt1 t1_abstr in
+           collect_judgement sgn xvs pt2 t2_abstr
         end
      end
 
-  | Rsyntax.Pattern.TTEqTerm (pe1, pe2, pt) ->
-     begin match Nucleus.as_not_abstract jdg with
-     | None -> raise Match_fail
-     | Some Nucleus.(JudgementIsTerm _ | JudgementIsType _ | JudgementEqType _) -> raise Match_fail
+  | Rsyntax.Patt_EqTerm (pe1, pe2, pt), Runtime.Judgement abstr ->
+     begin match Nucleus.as_not_abstract abstr with
+     | None | Some Nucleus.(JudgementIsTerm _ | JudgementIsType _ | JudgementEqType _) ->
+        raise Match_fail
      | Some (Nucleus.JudgementEqTerm eq) ->
         begin match Nucleus.invert_eq_term eq with
         | Nucleus.Stump_EqTerm (_asmp, e1, e2, t) ->
-           let jdg_e1 = Nucleus.(abstract_not_abstract (JudgementIsTerm e1))
-           and jdg_e2 = Nucleus.(abstract_not_abstract (JudgementIsTerm e2))
-           and jdg_t = Nucleus.(abstract_not_abstract (JudgementIsType t)) in
-           let xvs = collect_judgement sgn xvs pe1 jdg_e1 in
-           let xvs = collect_judgement sgn xvs pe2 jdg_e2 in
-           collect_judgement sgn xvs pt jdg_t
+           let e1_abstr = Nucleus.(abstract_not_abstract (JudgementIsTerm e1))
+           and e2_abstr = Nucleus.(abstract_not_abstract (JudgementIsTerm e2))
+           and t_abstr = Nucleus.(abstract_not_abstract (JudgementIsType t)) in
+           let xvs = collect_judgement sgn xvs pe1 e1_abstr in
+           let xvs = collect_judgement sgn xvs pe2 e2_abstr in
+           collect_judgement sgn xvs pt t_abstr
         end
      end
+
+  | Rsyntax.Patt_Abstract (xopt, p1, p2), Runtime.Judgement abstr ->
+     begin match Nucleus.invert_judgement_abstraction abstr with
+     | Nucleus.Stump_NotAbstract _ -> raise Match_fail
+     | Nucleus.Stump_Abstract (a, abstr') ->
+        let t_abstr = Nucleus.(abstract_not_abstract (JudgementIsType (type_of_atom a))) in
+        let xvs = collect_judgement sgn xvs p1 t_abstr in
+        let xvs =
+          match xopt with
+          | None -> xvs
+          | Some _ ->
+             let a_abstr = Nucleus.(abstract_not_abstract (JudgementIsTerm (form_is_term_atom a))) in
+             add_var (Runtime.mk_judgement a_abstr) xvs
+        in
+        collect_judgement sgn xvs p2 abstr'
+     end
+
+  | Rsyntax.Patt_Tuple ps, Runtime.Tuple vs ->
+     collect_patterns sgn xvs ps vs
+
+  (* mismatches *)
+  | Rsyntax.Patt_MLConstructor _,
+    Runtime.(Judgement _ | Boundary _ | Closure _ | Handler _ | Ref _ | Dyn _ | Tuple _ | String _)
+
+  | Rsyntax.(Patt_Abstract _ | Patt_TTConstructor _ | Patt_GenAtom _ | Patt_IsType _ | Patt_IsTerm _ | Patt_EqType _ | Patt_EqTerm _),
+    Runtime.(Boundary _ | Closure _ | Handler _ | Tag _ | Ref _ | Dyn _ | Tuple _ | String _)
+
+  | Rsyntax.Patt_Tuple _,
+    Runtime.(Judgement _ | Boundary _ | Closure _ | Handler _ | Tag _ | Ref _ | Dyn _ | String _) ->
+     Runtime.(error ~loc (InvalidPatternMatch v))
+
+and collect_judgement sgn xvs p abstr =
+  collect_pattern sgn xvs p (Runtime.mk_judgement abstr)
 
 and collect_constructor sgn xvs c ps = function
   | Nucleus.JudgementIsType t ->
      begin match Nucleus.invert_is_type t with
      | Nucleus.Stump_TypeConstructor (c', args) ->
         if Ident.equal c c' then
-          collect_arguments sgn xvs ps args
+          let args = List.map Runtime.mk_judgement args in
+          collect_patterns sgn xvs ps args
         else
           raise Match_fail
      | Nucleus.Stump_TypeMeta _ -> raise Match_fail
@@ -127,7 +151,8 @@ and collect_constructor sgn xvs c ps = function
 
        | Nucleus.Stump_TermConstructor (c', args) ->
           if Ident.equal c c' then
-            collect_arguments sgn xvs ps args
+            let args = List.map Runtime.mk_judgement args in
+            collect_patterns sgn xvs ps args
           else
             raise Match_fail
 
@@ -141,72 +166,19 @@ and collect_constructor sgn xvs c ps = function
 
   | Nucleus.JudgementEqTerm _ -> raise Match_fail
 
-and collect_arguments sgn xvs ps vs =
+and collect_patterns sgn xvs ps vs =
   match ps, vs with
 
   | [], [] -> xvs
 
   | p::ps, v::vs ->
-     let xvs = collect_judgement sgn xvs p v in
-     collect_arguments sgn xvs ps vs
+     let xvs = collect_pattern sgn xvs p v in
+     collect_patterns sgn xvs ps vs
 
   | [], _::_ | _::_, [] ->
      (* This should never happen because desugaring checks arities of constructors and patterns. *)
      assert false
 
-let rec collect_pattern sgn xvs {Location.thing=p';loc} v =
-  match p', v with
-  | Rsyntax.Pattern.Anonymous, _ -> xvs
-
-  | Rsyntax.Pattern.Var, v ->
-     add_var v xvs
-
-  | Rsyntax.Pattern.As (p1, p2), v ->
-     let xvs = collect_pattern sgn xvs p1 v in
-     collect_pattern sgn xvs p2 v
-
-  | Rsyntax.Pattern.Judgement p, Runtime.Judgement jdg ->
-     collect_judgement sgn xvs p jdg
-
-  | Rsyntax.Pattern.MLConstructor (tag, ps), Runtime.Tag (tag', vs) ->
-     if not (Runtime.equal_tag tag tag')
-     then
-       raise Match_fail
-     else
-       begin
-         match collect_pattern_list sgn xvs ps vs with
-         | None -> Runtime.(error ~loc (InvalidPatternMatch v))
-         | Some vs -> vs
-       end
-
-  | Rsyntax.Pattern.Tuple ps, Runtime.Tuple vs ->
-    begin
-      match collect_pattern_list sgn xvs ps vs with
-      | None -> Runtime.(error ~loc (InvalidPatternMatch v))
-      | Some vs -> vs
-    end
-
-  (* mismatches *)
-  | Rsyntax.Pattern.Judgement _,
-    Runtime.(Boundary _ | Closure _ | Handler _ | Tag _ | Ref _ | Dyn _ | Tuple _ | String _)
-
-  | Rsyntax.Pattern.MLConstructor _,
-    Runtime.(Judgement _ | Boundary _ | Closure _ | Handler _ | Ref _ | Dyn _ | Tuple _ | String _)
-
-  | Rsyntax.Pattern.Tuple _,
-    Runtime.(Judgement _ | Boundary _ | Closure _ | Handler _ | Tag _ | Ref _ | Dyn _ | String _) ->
-     Runtime.(error ~loc (InvalidPatternMatch v))
-
-and collect_pattern_list sgn xvs ps vs =
-  let rec fold xvs = function
-    | [], [] -> Some xvs
-    | p::ps, v::vs ->
-      let xvs = collect_pattern sgn xvs p v in
-      fold xvs (ps, vs)
-    | ([], _::_ | _::_, []) ->
-       None
-  in
-  fold xvs (ps, vs)
 
 let match_pattern' sgn p v =
   try
@@ -238,13 +210,7 @@ let match_op_pattern ~loc ps p_bdry vs bdry =
   let r =
     begin
       try
-        let xvs =
-          begin
-            match collect_pattern_list sgn [] ps vs with
-            | None -> Runtime.(error ~loc InvalidHandlerMatch)
-            | Some xvs -> xvs
-          end
-        in
+        let xvs = collect_patterns sgn [] ps vs in
         let xvs =
           match p_bdry with
           | None -> xvs

--- a/src/runtime/matching.mli
+++ b/src/runtime/matching.mli
@@ -2,15 +2,15 @@
 (** Match a value against a pattern. Matches are returned in order of increasing de Bruijn index:
     if we match the pattern [(x,y,z)] against the value [("foo", "bar", "baz")], the list returned
     will be [["baz", "bar", "foo"]]. *)
-val match_pattern : Rsyntax.Pattern.aml -> Runtime.value -> Runtime.value list option Runtime.comp
+val match_pattern : Rsyntax.pattern -> Runtime.value -> Runtime.value list option Runtime.comp
 
 (** Match a value against a pattern. Matches are returned in the order of increasing de Bruijn index. *)
-val top_match_pattern : Rsyntax.Pattern.aml -> Runtime.value -> Runtime.value list option Runtime.toplevel
+val top_match_pattern : Rsyntax.pattern -> Runtime.value -> Runtime.value list option Runtime.toplevel
 
 (** [match_op_pattern ps p_out vs t_out] matches patterns [ps] against values [vs] and
     the optional pattern [p_out] against the optional type [t_out]. *)
 val match_op_pattern :
   loc:Location.t ->
-  Rsyntax.Pattern.aml list -> Rsyntax.Pattern.boundary option ->
+  Rsyntax.pattern list -> Rsyntax.pattern option ->
   Runtime.value list -> Nucleus.boundary_abstraction option ->
   Runtime.value list option Runtime.comp

--- a/tests/nucleus/convert.m31
+++ b/tests/nucleus/convert.m31
@@ -6,7 +6,7 @@ rule b : A ;;
 
 convert a ξ ;;
 
-match (convert a ξ) with ⊢ _ : t => t end ;;
+match (convert a ξ) with _ : t => t end ;;
 
 rule P (⊢ _ : A) type ;;
 
@@ -18,5 +18,5 @@ rule z : A ;;
 
 let e = (convert ({u : P z} u) ({u : P z} ζ z)) ;;
 
-match e with ⊢ {r : R} (v : V) => (r, R, v, V) end ;;
+match e with {r : R} (v : V) => (r, R, v, V) end ;;
 

--- a/tests/runtime/patterns.m31
+++ b/tests/runtime/patterns.m31
@@ -1,0 +1,78 @@
+match "foo" with _ => "bar" end ;;
+
+match "foo" with x => x end ;;
+
+match ("foo", "bar", "baz") with (x, y, z) => (z, x, y) end ;;
+
+let (x, y, z) = ("foo", "bar", "baz") in (z, x, y) ;;
+
+match ML.Some "foo" with
+  | ML.Some s => s
+  | ML.None => "WRONG ANSWER"
+end ;;
+
+rule A type ;;
+rule a : A ;;
+rule P (⊢ _ : A) type ;;
+
+match a with
+  | x : X => ([x; X], "isterm")
+  | X ≡ Y => ([X; Y], "eqtype")
+  | X type => ([X], "istype")
+  | x ≡ y : X => ([x; y; X], "eqterm")
+  | {x : X} jdg => ([x; X; jdg], "abstraction")
+end ;;
+
+match A with
+  | x : X => ([x; X], "isterm")
+  | X ≡ Y => ([X; Y], "eqtype")
+  | X type => ([X], "istype")
+  | x ≡ y : X => ([x; y; X], "eqterm")
+  | {x : X} jdg => ([x; X; jdg], "abstraction")
+end ;;
+
+match P a with
+  | x : X => ([x; X], "isterm")
+  | X ≡ Y => ([X; Y], "eqtype")
+  | X type => ([X], "istype")
+  | x ≡ y : X => ([x; y; X], "eqterm")
+  | {x : X} jdg => ([x; X; jdg], "abstraction")
+end ;;
+
+rule B type ;;
+rule ξ : A ≡ B ;;
+
+match ξ with
+  | x : X => ([x; X], "isterm")
+  | X ≡ Y => ([X; Y], "eqtype")
+  | X type => ([X], "istype")
+  | x ≡ y : X => ([x; y; X], "eqterm")
+  | {x : X} jdg => ([x; X; jdg], "abstraction")
+end ;;
+
+rule b : A ;;
+rule ζ : a ≡ b : A ;;
+
+match ζ with
+  | x : X => ([x; X], "isterm")
+  | X ≡ Y => ([X; Y], "eqtype")
+  | X type => ([X], "istype")
+  | x ≡ y : X => ([x; y; X], "eqterm")
+  | {x : X} jdg => ([x; X; jdg], "abstraction")
+end ;;
+
+match (convert a ξ) with
+  | x : X => ([x; X], "isterm")
+  | X ≡ Y => ([X; Y], "eqtype")
+  | X type => ([X], "istype")
+  | x ≡ y : X => ([x; y; X], "eqterm")
+  | {x : X} jdg => ([x; X; jdg], "abstraction")
+end ;;
+
+match {z : A} P z with
+  | x : X => ([x; X], "isterm")
+  | X ≡ Y => ([X; Y], "eqtype")
+  | X type => ([X], "istype")
+  | x ≡ y : X => ([x; y; X], "eqterm")
+  | {x : X} jdg => ([x; X; jdg], "abstraction")
+end ;;

--- a/tests/runtime/patterns.m31.ref
+++ b/tests/runtime/patterns.m31.ref
@@ -1,0 +1,19 @@
+- : mlstring = "bar"
+- : mlstring = "foo"
+- : mlstring * mlstring * mlstring = ("baz", "foo", "bar")
+- : mlstring * mlstring * mlstring = ("baz", "foo", "bar")
+- : mlstring = "foo"
+Rule A is postulated.
+Rule a is postulated.
+Rule P is postulated.
+- : list judgement * mlstring = (a :: A :: [], "isterm")
+- : list judgement * mlstring = (A :: [], "istype")
+- : list judgement * mlstring = (P a :: [], "istype")
+Rule B is postulated.
+Rule ξ is postulated.
+- : list judgement * mlstring = (A :: B :: [], "eqtype")
+Rule b is postulated.
+Rule ζ is postulated.
+- : list judgement * mlstring = (a :: b :: A :: [], "eqterm")
+- : list judgement * mlstring = (a :: B :: [], "isterm")
+- : list judgement * mlstring = (?z₀ :: A :: P ?z₀ :: [], "abstraction")

--- a/theories/dependent_sum.m31
+++ b/theories/dependent_sum.m31
@@ -15,7 +15,7 @@ rule π₂ (⊢ A type) (x : A ⊢ B type) (⊢ s : Σ A B)
 rule Σ_β₁ (⊢ A type) (x : A ⊢ B type) (⊢ a : A) (⊢ b : B{a})
   : π₁ A B (pair A B a b) == a : A
 
-let type_of e = match e with ⊢ _ : t => t end
+let type_of e = match e with _ : t => t end
 
 
 (* To show that the computation rule for the second projection is well-typed,

--- a/theories/judgemental_equality.m31
+++ b/theories/judgemental_equality.m31
@@ -1,5 +1,5 @@
 require judgemental_equality_type
 
 let sym_eq_type h = match h with
-  | ⊢ a ≡ b => judgemental_equality_type.eq_type_sym a b h
+  | a ≡ b => judgemental_equality_type.eq_type_sym a b h
   end


### PR DESCRIPTION
As it turns out, there's no reason to delimit TT patterns with a `⊢`. The code get suitably simplified.