### PR TITLE
Abstracted arguments without types

### DIFF
--- a/src/nucleus/abstract.ml
+++ b/src/nucleus/abstract.ml
@@ -86,7 +86,11 @@ and abstraction
 
 and term_arguments x ?(lvl=0) args = List.map (is_term x ~lvl) args
 
-and arguments x ?(lvl=0) args = List.map (abstraction judgement x ~lvl) args
+and argument x ?(lvl=0) = function
+  | Arg_NotAbstract jdg -> Arg_NotAbstract (judgement x ~lvl jdg)
+  | Arg_Abstract (y, arg) -> Arg_Abstract (y, argument x ~lvl:(lvl+1) arg)
+
+and arguments x ?(lvl=0) args = List.map (argument x ~lvl) args
 
 and judgement x ?(lvl=0) = function
   | JudgementIsType t -> JudgementIsType (is_type x ~lvl t)

--- a/src/nucleus/abstract.ml
+++ b/src/nucleus/abstract.ml
@@ -79,10 +79,10 @@ and abstraction
        let v = abstr_v x ~lvl v in
        NotAbstract v
 
-    | Abstract ({atom_nonce=y; atom_type=u}, abstr) ->
+    | Abstract (y, u, abstr) ->
        let u = is_type x ~lvl u in
        let abstr = abstraction abstr_v x ~lvl:(lvl+1) abstr in
-       Abstract ({atom_nonce=y; atom_type=u}, abstr)
+       Abstract (y, u, abstr)
 
 and term_arguments x ?(lvl=0) args = List.map (is_term x ~lvl) args
 
@@ -103,26 +103,26 @@ and judgement x ?(lvl=0) = function
 
 let not_abstract u = Mk.not_abstract u
 
-let is_type_abstraction atm abstr =
+let is_type_abstraction {atom_nonce=n; atom_type=t} abstr =
   (* XXX occurs check?! *)
-  let abstr = abstraction is_type atm.atom_nonce abstr in
-  Mk.abstract atm abstr
+  let abstr = abstraction is_type n abstr in
+  Mk.abstract (Nonce.name n) t abstr
 
-let is_term_abstraction atm abstr =
-  let abstr = abstraction is_term atm.atom_nonce abstr in
-  Mk.abstract atm abstr
+let is_term_abstraction {atom_nonce=n; atom_type=t} abstr =
+  let abstr = abstraction is_term n abstr in
+  Mk.abstract (Nonce.name n) t abstr
 
-let eq_type_abstraction atm abstr =
-  let abstr = abstraction eq_type atm.atom_nonce abstr in
-  Mk.abstract atm abstr
+let eq_type_abstraction {atom_nonce=n; atom_type=t} abstr =
+  let abstr = abstraction eq_type n abstr in
+  Mk.abstract (Nonce.name n) t abstr
 
-let eq_term_abstraction atm abstr =
-  let abstr = abstraction eq_term atm.atom_nonce abstr in
-  Mk.abstract atm abstr
+let eq_term_abstraction {atom_nonce=n; atom_type=t} abstr =
+  let abstr = abstraction eq_term n abstr in
+  Mk.abstract (Nonce.name n) t abstr
 
-let judgement_abstraction atm abstr =
-  let abstr = abstraction judgement atm.atom_nonce abstr in
-  Mk.abstract atm abstr
+let judgement_abstraction {atom_nonce=n; atom_type=t} abstr =
+  let abstr = abstraction judgement n abstr in
+  Mk.abstract (Nonce.name n) t abstr
 
 let boundary_is_type _atm ?lvl () = ()
 
@@ -145,22 +145,22 @@ let boundary atm ?lvl = function
   | BoundaryEqType bdry -> BoundaryEqType (boundary_eq_type atm ?lvl bdry)
   | BoundaryEqTerm bdry -> BoundaryEqTerm (boundary_eq_term atm ?lvl bdry)
 
-let boundary_is_type_abstraction atm abstr =
-  let abstr = abstraction boundary_is_type atm.atom_nonce abstr in
-  Mk.abstract atm abstr
+let boundary_is_type_abstraction {atom_nonce=n; atom_type=t} abstr =
+  let abstr = abstraction boundary_is_type n abstr in
+  Mk.abstract (Nonce.name n) t abstr
 
-let boundary_is_term_abstraction atm abstr =
-  let abstr = abstraction boundary_is_term atm.atom_nonce abstr in
-  Mk.abstract atm abstr
+let boundary_is_term_abstraction {atom_nonce=n; atom_type=t} abstr =
+  let abstr = abstraction boundary_is_term n abstr in
+  Mk.abstract (Nonce.name n) t abstr
 
-let boundary_eq_type_abstraction atm abstr =
-  let abstr = abstraction boundary_eq_type atm.atom_nonce abstr in
-  Mk.abstract atm abstr
+let boundary_eq_type_abstraction {atom_nonce=n; atom_type=t} abstr =
+  let abstr = abstraction boundary_eq_type n abstr in
+  Mk.abstract (Nonce.name n) t abstr
 
-let boundary_eq_term_abstraction atm abstr =
-  let abstr = abstraction boundary_eq_term atm.atom_nonce abstr in
-  Mk.abstract atm abstr
+let boundary_eq_term_abstraction {atom_nonce=n; atom_type=t} abstr =
+  let abstr = abstraction boundary_eq_term n abstr in
+  Mk.abstract (Nonce.name n) t abstr
 
-let boundary_abstraction atm abstr =
-  let abstr = abstraction boundary atm.atom_nonce abstr in
-  Mk.abstract atm abstr
+let boundary_abstraction {atom_nonce=n; atom_type=t} abstr =
+  let abstr = abstraction boundary n abstr in
+  Mk.abstract (Nonce.name n) t abstr

--- a/src/nucleus/abstract.ml
+++ b/src/nucleus/abstract.ml
@@ -103,26 +103,31 @@ and judgement x ?(lvl=0) = function
 
 let not_abstract u = Mk.not_abstract u
 
-let is_type_abstraction {atom_nonce=n; atom_type=t} abstr =
+let is_type_abstraction ?name {atom_nonce=n; atom_type=t} abstr =
   (* XXX occurs check?! *)
   let abstr = abstraction is_type n abstr in
-  Mk.abstract (Nonce.name n) t abstr
+  let x = match name with Some x -> x | None -> Nonce.name n in
+  Mk.abstract x t abstr
 
-let is_term_abstraction {atom_nonce=n; atom_type=t} abstr =
+let is_term_abstraction ?name {atom_nonce=n; atom_type=t} abstr =
   let abstr = abstraction is_term n abstr in
-  Mk.abstract (Nonce.name n) t abstr
+  let x = match name with Some x -> x | None -> Nonce.name n in
+  Mk.abstract x t abstr
 
-let eq_type_abstraction {atom_nonce=n; atom_type=t} abstr =
+let eq_type_abstraction ?name {atom_nonce=n; atom_type=t} abstr =
   let abstr = abstraction eq_type n abstr in
-  Mk.abstract (Nonce.name n) t abstr
+  let x = match name with Some x -> x | None -> Nonce.name n in
+  Mk.abstract x t abstr
 
-let eq_term_abstraction {atom_nonce=n; atom_type=t} abstr =
+let eq_term_abstraction ?name {atom_nonce=n; atom_type=t} abstr =
   let abstr = abstraction eq_term n abstr in
-  Mk.abstract (Nonce.name n) t abstr
+  let x = match name with Some x -> x | None -> Nonce.name n in
+  Mk.abstract x t abstr
 
-let judgement_abstraction {atom_nonce=n; atom_type=t} abstr =
+let judgement_abstraction ?name {atom_nonce=n; atom_type=t} abstr =
   let abstr = abstraction judgement n abstr in
-  Mk.abstract (Nonce.name n) t abstr
+  let x = match name with Some x -> x | None -> Nonce.name n in
+  Mk.abstract x t abstr
 
 let boundary_is_type _atm ?lvl () = ()
 

--- a/src/nucleus/alpha_equal.ml
+++ b/src/nucleus/alpha_equal.ml
@@ -65,14 +65,25 @@ and term_arguments args args' =
   | (_::_), []
   | [], (_::_) -> assert false
 
+and argument arg arg' =
+  match arg, arg' with
+  | Arg_NotAbstract jdg, Arg_NotAbstract jdg' ->
+     judgement jdg jdg'
+
+  | Arg_Abstract (_, arg), Arg_Abstract (_, arg') ->
+     argument arg arg'
+
+  | Arg_NotAbstract _, Arg_Abstract _
+  | Arg_Abstract _, Arg_NotAbstract _ -> false
+
 and arguments args args' =
   args == args' ||
   match args, args' with
 
   | [], [] -> true
 
-  | abstr :: args, abstr' :: args' ->
-     abstraction judgement abstr abstr' && arguments args args'
+  | arg :: args, arg' :: args' ->
+     argument arg arg' && arguments args args'
 
   | (_::_), []
 

--- a/src/nucleus/alpha_equal.ml
+++ b/src/nucleus/alpha_equal.ml
@@ -48,7 +48,7 @@ and abstraction
   = fun equal_v e e' ->
     match e, e' with
 
-    | Abstract ({atom_type=u;_}, abstr), Abstract({atom_type=u';_}, abstr') ->
+    | Abstract (_, u, abstr), Abstract(_, u', abstr') ->
        is_type u u' &&
        abstraction equal_v abstr abstr'
 

--- a/src/nucleus/alpha_equal.ml
+++ b/src/nucleus/alpha_equal.ml
@@ -48,7 +48,7 @@ and abstraction
   = fun equal_v e e' ->
     match e, e' with
 
-    | Abstract (_, u, abstr), Abstract(_, u', abstr') ->
+    | Abstract (_, u, abstr), Abstract (_, u', abstr') ->
        is_type u u' &&
        abstraction equal_v abstr abstr'
 

--- a/src/nucleus/apply_abstraction.ml
+++ b/src/nucleus/apply_abstraction.ml
@@ -3,7 +3,7 @@ open Nucleus_types
 let apply_abstraction inst_u sgn abstr e0 =
   match abstr with
   | NotAbstract _ -> Error.raise AbstractionExpected
-  | Abstract ({atom_type=t;_}, abstr) ->
+  | Abstract (_, t, abstr) ->
      begin match Alpha_equal.is_type t (Sanity.type_of_term sgn e0) with
      | false -> Error.raise InvalidSubstitution
      | true ->  Instantiate_bound.abstraction inst_u e0 abstr

--- a/src/nucleus/boundary.ml
+++ b/src/nucleus/boundary.ml
@@ -6,7 +6,7 @@ exception ConversionError
 
 let rec convert f = function
   | NotAbstract a -> NotAbstract (f a)
-  | Abstract (atm, abstr) -> Abstract (atm, convert f abstr)
+  | Abstract (x, t, abstr) -> Abstract (x, t, convert f abstr)
 
 let as_is_type_abstraction abstr =
   try

--- a/src/nucleus/collect_assumptions.ml
+++ b/src/nucleus/collect_assumptions.ml
@@ -60,9 +60,9 @@ and abstraction
     ?lvl:bound -> 'a abstraction -> assumption
   = fun asmp_v ?(lvl=0) -> function
     | NotAbstract v -> asmp_v ~lvl v
-    | Abstract (atm, abstr) ->
+    | Abstract (_, t, abstr) ->
        Assumption.union
-         (is_type ~lvl atm.atom_type)
+         (is_type ~lvl t)
          (abstraction asmp_v ~lvl:(lvl+1) abstr)
 
 and argument ?(lvl=0) = function

--- a/src/nucleus/collect_assumptions.ml
+++ b/src/nucleus/collect_assumptions.ml
@@ -65,6 +65,10 @@ and abstraction
          (is_type ~lvl atm.atom_type)
          (abstraction asmp_v ~lvl:(lvl+1) abstr)
 
+and argument ?(lvl=0) = function
+  | Arg_NotAbstract jdg -> judgement ~lvl jdg
+  | Arg_Abstract (_, arg) -> argument ~lvl:(lvl+1) arg
+
 and term_arguments ~lvl ts =
   List.fold_left
     (fun acc arg -> Assumption.union acc (is_term ~lvl arg))
@@ -74,7 +78,7 @@ and term_arguments ~lvl ts =
 and arguments' ~lvl args =
   let rec fold asmp = function
     | [] -> asmp
-    | arg :: args -> Assumption.union (abstraction judgement ~lvl arg) (fold asmp args)
+    | arg :: args -> Assumption.union (argument ~lvl arg) (fold asmp args)
   in
   fold Assumption.empty args
 

--- a/src/nucleus/congruence.ml
+++ b/src/nucleus/congruence.ml
@@ -8,7 +8,7 @@ let process_congruence_args args =
     match t1, t2, eq with
     | NotAbstract t1, NotAbstract t2, NotAbstract eq ->
        if not (check t1 t2 eq) then Error.raise InvalidCongruence
-    | Abstract ({atom_type=u1;_}, t1), Abstract ({atom_type=u2;_}, t2), Abstract ({atom_type=u';_}, eq) ->
+    | Abstract (_, u1, t1), Abstract (_, u2, t2), Abstract (_, u', eq) ->
        if Alpha_equal.is_type u1 u' || Alpha_equal.is_type u2 u' then
          check_endpoints check t1 t2 eq
        else
@@ -50,14 +50,16 @@ let process_congruence_args args =
 
 
 let congruence_type_constructor sgn c eqs =
-  let (asmp, lhs, rhs) = process_congruence_args eqs in
-  let t1 = Mk.type_constructor c lhs
-  and t2 = Mk.type_constructor c rhs
-  in Mk.eq_type asmp t1 t2
+  failwith "congruence_type_constructor (it's obsolete anyway)"
+  (* let (asmp, lhs, rhs) = process_congruence_args eqs in *)
+  (* let t1 = Mk.type_constructor c lhs *)
+  (* and t2 = Mk.type_constructor c rhs *)
+  (* in Mk.eq_type asmp t1 t2 *)
 
 let congruence_term_constructor sgn c eqs =
-  let (asmp, lhs, rhs) = process_congruence_args eqs in
-  let e1 = Mk.term_constructor c lhs
-  and e2 = Mk.term_constructor c rhs in
-  let t = Sanity.type_of_term sgn e1
-  in Mk.eq_term asmp e1 e2 t
+  failwith "congruence_term_constructor (it's obsolete anyway)"
+  (* let (asmp, lhs, rhs) = process_congruence_args eqs in *)
+  (* let e1 = Mk.term_constructor c lhs *)
+  (* and e2 = Mk.term_constructor c rhs in *)
+  (* let t = Sanity.type_of_term sgn e1 *)
+  (* in Mk.eq_term asmp e1 e2 t *)

--- a/src/nucleus/convert.ml
+++ b/src/nucleus/convert.ml
@@ -13,10 +13,10 @@ let rec abstraction inst_u abstr_v converter u eq =
   | Some (Stumps_NotAbstract (u, eq)) ->
      Mk.not_abstract (converter u eq)
 
-  | Some (Stumps_Abstract (a, u, eq)) ->
+  | Some (Stumps_Abstract ({atom_nonce=n; atom_type=t}, u, eq)) ->
      let v = abstraction inst_u abstr_v converter u eq in
-     let v = Abstract.abstraction abstr_v a.atom_nonce v in
-     Mk.abstract a v
+     let v = Abstract.abstraction abstr_v n v in
+     Mk.abstract (Nonce.name n) t v
 
 let term sgn e eq = opt_fail (Form.form_is_term_convert_opt sgn e eq)
 

--- a/src/nucleus/form.ml
+++ b/src/nucleus/form.ml
@@ -37,13 +37,14 @@ let rec form_alpha_equal_abstraction equal_u abstr1 abstr2 =
      | None -> None
      | Some eq -> Some (Mk.not_abstract eq)
      end
-  | Abstract (x1, t1, abstr1), Abstract (_, t2, abstr2) ->
+  | Abstract (x1, t1, abstr1), Abstract (x2, t2, abstr2) ->
+     let x = Name.prefer x1 x2 in
      begin match Alpha_equal.is_type t1 t2 with
      | false -> None
      | true ->
         begin match form_alpha_equal_abstraction equal_u abstr1 abstr2 with
         | None -> None
-        | Some eq -> Some (Mk.abstract x1 t1 eq)
+        | Some eq -> Some (Mk.abstract x t1 eq)
         end
      end
   | (NotAbstract _, Abstract _)

--- a/src/nucleus/form.ml
+++ b/src/nucleus/form.ml
@@ -37,13 +37,13 @@ let rec form_alpha_equal_abstraction equal_u abstr1 abstr2 =
      | None -> None
      | Some eq -> Some (Mk.not_abstract eq)
      end
-  | Abstract (atm1, abstr1), Abstract (atm2, abstr2) ->
-     begin match Alpha_equal.is_type atm1.atom_type atm2.atom_type with
+  | Abstract (x1, t1, abstr1), Abstract (_, t2, abstr2) ->
+     begin match Alpha_equal.is_type t1 t2 with
      | false -> None
      | true ->
         begin match form_alpha_equal_abstraction equal_u abstr1 abstr2 with
         | None -> None
-        | Some eq -> Some (Mk.abstract atm1 eq)
+        | Some eq -> Some (Mk.abstract x1 t1 eq)
         end
      end
   | (NotAbstract _, Abstract _)
@@ -97,9 +97,10 @@ let rap_boundary {rap_boundary;_} = rap_boundary
 
 (* Apply the given partially applied rule instance to the given argument. The result
    is again a partially applied rule (a special case of which is a fully applied rule). *)
-let rap_apply sgn {rap_arguments; rap_boundary; rap_premises; rap_constructor} arg =
-  if not (Check.judgement_boundary_abstraction sgn arg rap_boundary)
+let rap_apply sgn {rap_arguments; rap_boundary; rap_premises; rap_constructor} abstr =
+  if not (Check.judgement_boundary_abstraction sgn abstr rap_boundary)
   then Error.raise InvalidArgument ;
+  let arg = Judgement.to_argument abstr in
   let rap_arguments = arg :: rap_arguments in
   match rap_premises with
   | [] ->
@@ -210,5 +211,5 @@ let rec form_is_term_boundary_abstraction = function
   | NotAbstract t ->
      NotAbstract (form_is_term_boundary t)
 
-  | Abstract (atm, abstr) ->
-     Abstract (atm, form_is_term_boundary_abstraction abstr)
+  | Abstract (x, t, abstr) ->
+     Abstract (x, t, form_is_term_boundary_abstraction abstr)

--- a/src/nucleus/instantiate_bound.ml
+++ b/src/nucleus/instantiate_bound.ml
@@ -75,8 +75,12 @@ and abstraction
      in
      Abstract ({atom_nonce=x; atom_type=u}, abstr)
 
+and argument e0 ~lvl = function
+  | Arg_NotAbstract jdg -> Arg_NotAbstract (judgement e0 ~lvl jdg)
+  | Arg_Abstract (x, arg) -> Arg_Abstract (x, argument e0 ~lvl:(lvl+1) arg)
+
 and arguments e0 ~lvl args =
-  List.map (abstraction judgement e0 ~lvl) args
+  List.map (argument e0 ~lvl) args
 
 and term_arguments e0 ~lvl args =
   List.map (is_term e0 ~lvl) args
@@ -171,8 +175,12 @@ and abstraction_fully
      and abstr = abstraction_fully inst_u ~lvl:(lvl+1) es abstr
      in Abstract ({atom_nonce=x; atom_type=t}, abstr)
 
+and argument_fully ?(lvl=0) es = function
+  | Arg_NotAbstract jdg -> Arg_NotAbstract (judgement_fully ~lvl es jdg)
+  | Arg_Abstract (x, arg) -> Arg_Abstract (x, argument_fully ~lvl:(lvl+1) es arg)
+
 and arguments_fully ?(lvl=0) es args =
-  List.map (abstraction_fully judgement_fully ~lvl es) args
+  List.map (argument_fully ~lvl es) args
 
 and term_arguments_fully ?(lvl=0) es args =
   List.map (is_term_fully ~lvl es) args

--- a/src/nucleus/instantiate_bound.ml
+++ b/src/nucleus/instantiate_bound.ml
@@ -69,11 +69,11 @@ and abstraction
      let v = inst_v e0 ~lvl v in
      NotAbstract v
 
-  | Abstract ({atom_nonce=x; atom_type=u}, abstr) ->
+  | Abstract (x, u, abstr) ->
      let u = is_type e0 ~lvl u
      and abstr = abstraction inst_v e0 ~lvl:(lvl+1) abstr
      in
-     Abstract ({atom_nonce=x; atom_type=u}, abstr)
+     Abstract (x, u, abstr)
 
 and argument e0 ~lvl = function
   | Arg_NotAbstract jdg -> Arg_NotAbstract (judgement e0 ~lvl jdg)
@@ -170,10 +170,10 @@ and abstraction_fully
      let u = inst_u ~lvl es u in
      NotAbstract u
 
-  | Abstract ({atom_nonce=x; atom_type=t}, abstr) ->
+  | Abstract (x, t, abstr) ->
      let t = is_type_fully ~lvl es t
      and abstr = abstraction_fully inst_u ~lvl:(lvl+1) es abstr
-     in Abstract ({atom_nonce=x; atom_type=t}, abstr)
+     in Abstract (x, t, abstr)
 
 and argument_fully ?(lvl=0) es = function
   | Arg_NotAbstract jdg -> Arg_NotAbstract (judgement_fully ~lvl es jdg)

--- a/src/nucleus/instantiate_meta.ml
+++ b/src/nucleus/instantiate_meta.ml
@@ -58,10 +58,10 @@ and arguments ~lvl metas args =
   List.map (argument ~lvl metas) args
 
 and argument ~lvl metas = function
-  | Rule.NotAbstract jdg ->
+  | Rule.Arg_NotAbstract jdg ->
      Arg_NotAbstract (judgement ~lvl metas jdg)
 
-  | Rule.Abstract (x, _, abstr) ->
+  | Rule.Arg_Abstract (x, abstr) ->
      Arg_Abstract (x, argument ~lvl:(lvl+1) metas abstr)
 
 and judgement ~lvl metas = function
@@ -90,12 +90,3 @@ let rec abstraction inst_u ~lvl metas = function
        let t = is_type ~lvl metas t
        and abstr = abstraction inst_u ~lvl:(lvl+1) metas abstr
        in Mk.abstract x t abstr
-
-(* let annotate_arguments argument prems args =
- *   let rec fold argument prems args =
- *     match argument, prems, args with
- *     | Arg_NotAbstract jdg, [], [] -> jdg
- *     | Arg_Abstract (x, argument), prem::prems, arg::args ->
- *
- *   in
- *   fold *)

--- a/src/nucleus/judgement.ml
+++ b/src/nucleus/judgement.ml
@@ -6,7 +6,7 @@ exception ConversionError
 
 let rec convert f = function
   | NotAbstract a -> NotAbstract (f a)
-  | Abstract (atm, abstr) -> Abstract (atm, convert f abstr)
+  | Abstract (x, t, abstr) -> Abstract (x, t, convert f abstr)
 
 let as_is_type = function
   | JudgementIsType t -> Some t
@@ -79,3 +79,8 @@ let from_eq_type_abstraction abstr =
 
 let from_eq_term_abstraction abstr =
   convert (fun t -> JudgementEqTerm t) abstr
+
+(** Conversion to an argument *)
+let rec to_argument = function
+  | NotAbstract jdg -> Arg_NotAbstract jdg
+  | Abstract (x, _, abstr) -> Arg_Abstract (x, to_argument abstr)

--- a/src/nucleus/meta.ml
+++ b/src/nucleus/meta.ml
@@ -12,7 +12,7 @@ let rec check_term_arguments sgn abstr args =
   | NotAbstract u, [] -> ()
   | Abstract _, [] -> Error.raise TooFewArguments
   | NotAbstract _, _::_ -> Error.raise TooManyArguments
-  | Abstract ({atom_nonce=x; atom_type=t}, abstr), arg :: args ->
+  | Abstract (x, t, abstr), arg :: args ->
      let t_arg = Sanity.type_of_term sgn arg in
      if Alpha_equal.is_type t t_arg
      then
@@ -104,12 +104,11 @@ let meta_eta_expanded' instantiate_meta form_meta abstract_meta mv =
     | NotAbstract u ->
        Mk.not_abstract (form_meta mv (List.rev args))
 
-    | Abstract (atm, abstr) ->
-       let a, abstr =
-         Unabstract.abstraction instantiate_meta (Nonce.name atm.atom_nonce) atm.atom_type abstr in
+    | Abstract (x, t, abstr) ->
+       let a, abstr = Unabstract.abstraction instantiate_meta x t abstr in
        let abstr = fold ((Form.form_is_term_atom a) :: args) abstr in
        let abstr = Abstract.abstraction abstract_meta a.atom_nonce abstr in
-       Mk.abstract atm abstr
+       Mk.abstract x t abstr
 
   in fold [] mv.meta_type
 

--- a/src/nucleus/mk.ml
+++ b/src/nucleus/mk.ml
@@ -41,4 +41,4 @@ let eq_term asmp e1 e2 t = EqTerm (asmp, e1, e2, t)
 
 let not_abstract e = NotAbstract e
 
-let abstract a abstr = Abstract (a, abstr)
+let abstract x t abstr = Abstract (x, t, abstr)

--- a/src/nucleus/nucleus.mli
+++ b/src/nucleus/nucleus.mli
@@ -169,10 +169,10 @@ val abstract_not_abstract : 'a -> 'a abstraction
 
 (** Abstract a judgement abstraction *)
 (* val abstract_is_type : is_atom -> is_type_abstraction -> is_type_abstraction *)
-val abstract_is_term : is_atom -> is_term_abstraction -> is_term_abstraction
+val abstract_is_term : ?name:Name.t -> is_atom -> is_term_abstraction -> is_term_abstraction
 (* val abstract_eq_type : is_atom -> eq_type_abstraction -> eq_type_abstraction *)
 (* val abstract_eq_term : is_atom -> eq_term_abstraction -> eq_term_abstraction *)
-val abstract_judgement : is_atom -> judgement_abstraction -> judgement_abstraction
+val abstract_judgement : ?name:Name.t -> is_atom -> judgement_abstraction -> judgement_abstraction
 
 (** Abstract a boundary abstraction *)
 val abstract_boundary : is_atom -> boundary_abstraction -> boundary_abstraction
@@ -212,7 +212,7 @@ val convert_judgement_abstraction : signature -> judgement_abstraction -> eq_typ
 
 (** Inversion principles *)
 
-val invert_is_type : is_type -> stump_is_type
+val invert_is_type : signature -> is_type -> stump_is_type
 
 val invert_is_term : signature -> is_term -> stump_is_term
 

--- a/src/nucleus/nucleus_types.ml
+++ b/src/nucleus/nucleus_types.ml
@@ -38,7 +38,7 @@ and assumption =
 
 and 'a abstraction =
   | NotAbstract of 'a
-  | Abstract of is_atom * 'a abstraction (* XXX change is_atom to Name.t * is_type *)
+  | Abstract of Name.t * is_type * 'a abstraction
 
 and judgement =
   | JudgementIsType of is_type
@@ -62,10 +62,10 @@ and boundary =
 and boundary_abstraction = boundary abstraction
 
 type rule_application_status =
-  { rap_arguments : judgement_abstraction list (* the arguments collected so far *)
+  { rap_arguments : argument list (* the arguments collected so far *)
   ; rap_boundary : boundary_abstraction (* the boundary of the next argument *)
   ; rap_premises : Rule.boundary_abstraction list (* the remaining premises to be applied *)
-  ; rap_constructor : judgement_abstraction list -> judgement (* the function which makes the final result *)
+  ; rap_constructor : argument list -> judgement (* the function which makes the final result *)
   }
 
 (* A partial rule application *)

--- a/src/nucleus/nucleus_types.ml
+++ b/src/nucleus/nucleus_types.ml
@@ -4,13 +4,13 @@ type bound = int
 
 type is_type =
   | TypeMeta of is_type_meta * is_term list
-  | TypeConstructor of Ident.t * judgement_abstraction list
+  | TypeConstructor of Ident.t * argument list
 
 and is_term =
   | TermBound of bound
   | TermAtom of is_atom
   | TermMeta of is_term_meta * is_term list
-  | TermConstructor of Ident.t * judgement_abstraction list
+  | TermConstructor of Ident.t * argument list
   | TermConvert of is_term * assumption * is_type
 
 and eq_type = EqType of assumption * is_type * is_type
@@ -18,6 +18,10 @@ and eq_type = EqType of assumption * is_type * is_type
 and eq_term = EqTerm of assumption * is_term * is_term * is_type
 
 and is_atom = { atom_nonce : Nonce.t ; atom_type : is_type }
+
+and argument =
+  | Arg_NotAbstract of judgement
+  | Arg_Abstract of Name.t * argument
 
 and 't meta = { meta_nonce : Nonce.t ; meta_type : 't }
 
@@ -34,7 +38,7 @@ and assumption =
 
 and 'a abstraction =
   | NotAbstract of 'a
-  | Abstract of is_atom * 'a abstraction
+  | Abstract of is_atom * 'a abstraction (* XXX change is_atom to Name.t * is_type *)
 
 and judgement =
   | JudgementIsType of is_type

--- a/src/nucleus/occurs.ml
+++ b/src/nucleus/occurs.ml
@@ -26,12 +26,16 @@ and abstraction
   = fun occurs_v k ->
   function
   | NotAbstract v -> occurs_v k v
-  | Abstract ({atom_type=u;_}, abstr) ->
+  | Abstract (_, u, abstr) ->
      is_type k u || abstraction occurs_v (k+1) abstr
+
+and argument k = function
+  | Arg_NotAbstract v -> judgement k v
+  | Arg_Abstract (_, arg) -> argument (k+1) arg
 
 and arguments k = function
   | [] -> false
-  | arg :: args -> abstraction judgement k arg || arguments k args
+  | arg :: args -> argument k arg || arguments k args
 
 and term_arguments k = function
   | [] -> false

--- a/src/nucleus/rule.mli
+++ b/src/nucleus/rule.mli
@@ -6,17 +6,19 @@ type meta = int
 type bound = int
 
 type ty =
-  | TypeConstructor of Ident.t * judgement_abstraction list
+  | TypeConstructor of Ident.t * argument list
   | TypeMeta of meta * term list
 
 and term =
   | TermBound of bound
-  | TermConstructor of Ident.t * judgement_abstraction list
+  | TermConstructor of Ident.t * argument list
   | TermMeta of meta * term list
 
 and eq_type = EqType of ty * ty
 
 and eq_term = EqTerm of term * term * ty
+
+and argument = judgement abstraction
 
 and judgement =
   | JudgementIsType of ty

--- a/src/nucleus/rule.mli
+++ b/src/nucleus/rule.mli
@@ -18,7 +18,9 @@ and eq_type = EqType of ty * ty
 
 and eq_term = EqTerm of term * term * ty
 
-and argument = judgement abstraction
+and argument =
+  | Arg_NotAbstract of judgement
+  | Arg_Abstract of Name.t * argument
 
 and judgement =
   | JudgementIsType of ty
@@ -40,4 +42,6 @@ type boundary =
 
 and boundary_abstraction = boundary abstraction
 
-type rule = boundary_abstraction list * boundary
+and premise = boundary_abstraction
+
+type rule = premise list * boundary

--- a/src/nucleus/sanity.ml
+++ b/src/nucleus/sanity.ml
@@ -30,11 +30,12 @@ let type_of_term sgn = function
      Instantiate_meta.is_type ~lvl:0 inds t_schema
 
   | TermMeta ({meta_type;_}, args) ->
-     Instantiate_meta.fully_apply_abstraction_no_typechecks
-       (Instantiate_bound.is_type_fully ?lvl:None) meta_type args
+     begin match Judgement.as_is_type (Instantiate_meta.fully_apply_argument meta_type args) with
+     | Some t -> t
+     | None ->
+     end
 
   | TermConvert (e, _, t) -> t
-
 
 let type_at_abstraction = function
   | NotAbstract _ -> None

--- a/src/nucleus/sanity.ml
+++ b/src/nucleus/sanity.ml
@@ -2,6 +2,20 @@ open Nucleus_types
 
 let type_of_atom {atom_type=t;_} = t
 
+
+(** Apply [abstr] to a list of terms of length equal to the abstraction
+    level of [abstr]. Do not verify the terms to be substituted match the
+    types on the abstraction. Use with care! *)
+let fully_apply_abstraction_no_checks inst_u abstr args =
+  let rec fold es abstr args =
+    match abstr, args with
+    | NotAbstract u, [] -> inst_u es u
+    | Abstract (_, _, abstr), e :: args -> fold (e :: es) abstr args
+    | Abstract _, [] -> Error.raise TooFewArguments
+    | NotAbstract _, _::_ -> Error.raise TooManyArguments
+  in
+  fold [] abstr args
+
 (** [type_of_term sgn e] gives a type judgment [t], where [t] is the type of [e].
     Note that [t] itself gives no evidence that [e] actually has type [t].
     However, the assumptions of [e] are sufficient to show that [e] has
@@ -30,27 +44,24 @@ let type_of_term sgn = function
      Instantiate_meta.is_type ~lvl:0 inds t_schema
 
   | TermMeta ({meta_type;_}, args) ->
-     begin match Judgement.as_is_type (Instantiate_meta.fully_apply_argument meta_type args) with
-     | Some t -> t
-     | None ->
-     end
+     fully_apply_abstraction_no_checks (Instantiate_bound.is_type_fully ?lvl:None) meta_type args
 
   | TermConvert (e, _, t) -> t
 
 let type_at_abstraction = function
   | NotAbstract _ -> None
-  | Abstract ({atom_type=t;_}, _) -> Some t
+  | Abstract (_, t, _) -> Some t
 
 let rec type_of_term_abstraction sgn = function
   | NotAbstract e ->
      let t = type_of_term sgn e in
      Mk.not_abstract t
 
-  | Abstract ({atom_nonce=x; atom_type=t}, abstr) ->
-     let a, abstr = Unabstract.abstraction Instantiate_bound.is_term (Nonce.name x) t abstr in
+  | Abstract (x, t, abstr) ->
+     let a, abstr = Unabstract.abstraction Instantiate_bound.is_term x t abstr in
      let t_abstr = type_of_term_abstraction sgn abstr in
      let t_abstr = Abstract.abstraction Abstract.is_type a.atom_nonce t_abstr in
-     Mk.abstract {atom_nonce=x; atom_type=t} t_abstr
+     Mk.abstract x t t_abstr
 
 (** [natural_type sgn e] gives the judgment that the natural type [t] of [e] is derivable.
     We maintain the invariant that no further assumptions are needed (apart from those
@@ -81,9 +92,9 @@ let natural_type_eq sgn e =
 
 let rec boundary_abstraction boundary_u = function
   | NotAbstract u -> Mk.not_abstract (boundary_u u)
-  | Abstract (atm, abstr) ->
+  | Abstract (x, t, abstr) ->
      let b = boundary_abstraction boundary_u abstr in
-     Mk.abstract atm b
+     Mk.abstract x t b
 
 let boundary_is_type_abstraction abstr =
   boundary_abstraction (fun _ -> ()) abstr

--- a/src/nucleus/shift.ml
+++ b/src/nucleus/shift.ml
@@ -65,10 +65,10 @@ and abstraction
      let u = shift_u ~lvl k u
      in NotAbstract u
 
-  | Abstract ({atom_nonce=x; atom_type=t}, abstr) ->
+  | Abstract (x, t, abstr) ->
      let t = is_type ~lvl k t
      and abstr = abstraction shift_u ~lvl:(lvl+1) k abstr
-     in Abstract ({atom_nonce=x; atom_type=t}, abstr)
+     in Abstract (x, t, abstr)
 
 and term_arguments ~lvl k args =
   List.map (is_term ~lvl k) args

--- a/src/nucleus/shift.ml
+++ b/src/nucleus/shift.ml
@@ -73,10 +73,14 @@ and abstraction
 and term_arguments ~lvl k args =
   List.map (is_term ~lvl k) args
 
-and arguments ~lvl k args =
-  List.map (abstraction argument ~lvl k) args
-
 and argument ~lvl k = function
+  | Arg_NotAbstract jdg -> Arg_NotAbstract (judgement ~lvl k jdg)
+  | Arg_Abstract (x, arg) -> Arg_Abstract (x, argument ~lvl:(lvl+1) k arg)
+
+and arguments ~lvl k args =
+  List.map (argument ~lvl k) args
+
+and judgement ~lvl k = function
    | JudgementIsType t -> JudgementIsType (is_type ~lvl k t)
 
    | JudgementIsTerm e -> JudgementIsTerm (is_term ~lvl k e)

--- a/src/runtime/eval.ml
+++ b/src/runtime/eval.ml
@@ -421,7 +421,7 @@ and check_abstract ~loc bdry x uopt c =
           (Runtime.Judgement Nucleus.(abstract_not_abstract (JudgementIsTerm (form_is_term_atom a))))
           begin
             check_judgement c bdry >>= fun jdg ->
-            let jdg = Nucleus.abstract_judgement a jdg in
+            let jdg = Nucleus.abstract_judgement ~name:x a jdg in
             return jdg
           end
 

--- a/src/runtime/matching.ml
+++ b/src/runtime/matching.ml
@@ -189,7 +189,7 @@ and collect_abstraction :
 
 and collect_constructor sgn xvs c ps = function
   | Nucleus.JudgementIsType t ->
-     begin match Nucleus.invert_is_type t with
+     begin match Nucleus.invert_is_type sgn t with
      | Nucleus.Stump_TypeConstructor (c', args) ->
         if Ident.equal c c' then
           let args = List.map Runtime.mk_judgement args in

--- a/src/utils/name.mli
+++ b/src/utils/name.mli
@@ -52,6 +52,9 @@ val set_add : t -> set -> set
 (** Is the given name an element of the set? *)
 val set_mem : t -> set -> bool
 
+(** [prefer x y] returns [x] if [x] is not anonymous, otherwise [y]. *)
+val prefer : t -> t -> t
+
 (** [refresh xs x] finds a nice variant of [x] that does not occur in [xs]. *)
 val refresh : set -> t -> t
 


### PR DESCRIPTION
We should not keep the type information in abstracted arguments, .e.g., correct is

    λ A ({x} B) ({x} e)

and not

    λ A ({x:A} B) ({x:A} e)

This PR fixed the issue.