### PR TITLE
Fix typechecking of 'let rec`

### DIFF
--- a/src/typing/typecheck.ml
+++ b/src/typing/typecheck.ml
@@ -710,29 +710,35 @@ and letrec_clauses
           'a Tyenv.tyenvM -> ((Name.t * Mlty.ty_schema) list * Syntax.letrec_clause list * 'a) Tyenv.tyenvM
   = fun ~toplevel fycs m ->
 
-  let rec bind_functions acc = function
-    | [] -> return (List.rev acc)
+  let bind_functions acc clauses comp_in_extended_context =
 
-    | Desugared.Letrec_clause (f, (y, a), annot, c) :: rem ->
-       let a =
-         begin
-           match a with
-           | Desugared.Arg_annot_none -> Mlty.fresh_type ()
-           | Desugared.Arg_annot_ty t -> ml_ty [] t
-         end
-       and b = Mlty.fresh_type () in
-       begin
-         match annot with
-         | Desugared.Let_annot_none ->
-            Tyenv.ungeneralize (Mlty.Arrow (a, b)) >>= fun sch ->
-            return (sch, None)
-         | Desugared.Let_annot_schema sch ->
-            let sch = ml_schema sch in
-            return (sch, Some sch)
-       end >>= fun (sch, schopt) ->
-       (if toplevel then Tyenv.add_ml_value_poly else Tyenv.add_bound_poly)
-         f sch
-         (bind_functions ((f, schopt, y, a, c, b) :: acc) rem)
+    let prepare_types_for_binding a annot =
+      let a =
+        match a with
+        | Desugared.Arg_annot_none -> Mlty.fresh_type ()
+        | Desugared.Arg_annot_ty t -> ml_ty [] t
+      and b = Mlty.fresh_type () in
+      begin
+        match annot with
+        | Desugared.Let_annot_none ->
+           Tyenv.ungeneralize (Mlty.Arrow (a, b)) >>= fun sch ->
+           return (sch, None)
+        | Desugared.Let_annot_schema sch ->
+           let sch = ml_schema sch in
+           return (sch, Some sch)
+      end >>= fun sch_schopt -> return (a, b, sch_schopt)
+    in
+
+    let rec bind_functions_fold acc = function
+      | [] -> return (List.rev acc) >>= comp_in_extended_context
+
+      | Desugared.Letrec_clause (f, (y, a), annot, c) :: rem ->
+         prepare_types_for_binding a annot >>= fun (a, b, (sch, schopt)) ->
+         (if toplevel then Tyenv.add_ml_value_poly else Tyenv.add_bound_poly)
+           f sch
+           (bind_functions_fold ((f, schopt, y, a, c, b) :: acc) rem)
+    in
+    bind_functions_fold acc clauses
   in
 
   let rec check_bodies acc = function
@@ -758,11 +764,20 @@ and letrec_clauses
 
   in
 
-  bind_functions [] fycs >>=
-  check_bodies []  >>=
-  generalize_funs [] [] >>= fun (info, clauses) ->
-  m >>= fun x ->
-  return (info, clauses, x)
+  (* We want [m] to be run in the locally extended context. *)
+  bind_functions [] fycs
+    begin fun acc ->
+      check_bodies [] acc >>=
+      generalize_funs [] [] >>= fun (info, clauses) ->
+      m >>= fun x ->
+      return (info, clauses, x)
+    end
+
+  (* bind_functions [] fycs >>=
+   * check_bodies [] >>=
+   * generalize_funs [] [] >>= fun (info, clauses) ->
+   * m >>= fun x ->
+   * return (info, clauses, x) *)
 
 and boundary = function
   | Desugared.BoundaryIsType ->

--- a/stdlib/base.m31
+++ b/stdlib/base.m31
@@ -50,3 +50,5 @@ constant uip : forall (A : Type) (lhs rhs : A) (p q : lhs ≡ rhs), p ≡ q
 *)
 
 mltype mlempty = |
+
+let type_of t = match t with _ : A -> A end

--- a/stdlib/utils.m31
+++ b/stdlib/utils.m31
@@ -1,53 +1,55 @@
-require "base.m31"
+require base
 
 (** Reverse a list *)
 let rev =
   let rec rev acc lst = match lst with
-    | [] ⇒ acc
-    | ?x :: ?tl ⇒ rev (x :: acc) tl
+    | [] → acc
+    | x :: tl → rev (x :: acc) tl
     end
   in
-  fun x ⇒ rev [] x
+  fun x → rev [] x
 
 (** Fold over a list *)
-let rec fold f acc lst :> forall a b, (a -> b -> a) -> a -> list b -> a =
+let rec fold f acc lst :> mlforall a b, (a -> b -> a) -> a -> list b -> a =
 match lst with
-  | [] ⇒ acc
-  | ?x :: ?tl ⇒ fold f (f acc x) tl
+  | [] → acc
+  | x :: tl → fold f (f acc x) tl
   end
 
 (** `list_map f l` applies `f` to each element of `l`  *)
-let rec list_map f l = fold (fun acc x ⇒ f x :: acc) [] l |> rev
+let rec list_map f l
+  :> mlforall α β, (α → β) → list α → list β
+  = let l = fold (fun acc x → f x :: acc) [] l in rev l
 
 (** Find in an associative list. *)
-let rec assoc_find x lst = match lst with
-  | [] ⇒ None
-  | (x, ?v) :: _ ⇒ Some v
-  | (_,_) :: ?lst ⇒ assoc_find x lst
+let rec assoc_find x lst :> mlforall a b, a → list (a * b) → ML.option b = match lst with
+  | [] → ML.None
+  | (x, v) :: _ → ML.Some v
+  | (_,_) :: lst → assoc_find x lst
   end
 
 (** Append two lists, reverse the first one *)
-let rev_append l1 l2 = fold (fun acc x ⇒ x :: acc) l2 l1
+let rev_append l1 l2 = fold (fun acc x → x :: acc) l2 l1
 
 (** Append two lists *)
-let rec append l1 l2 =
+let rec append l1 l2 :> mlforall α, list α → list α → list α =
   match l1 with
-  | [] ⇒ l2
-  | ?x :: ?l1 ⇒ x :: (append l1 l2)
+  | [] → l2
+  | x :: l1 → x :: (append l1 l2)
   end
 
-(** Does an element appear in a list? *)
-let rec mem x lst =
+(** Does an element appear in a list *)
+let rec mem x lst :> mlforall α, α → list α → ML.bool =
   match lst with
-  | [] ⇒ mlfalse
-  | x :: _ ⇒ mltrue
-  | _ :: ?lst ⇒ mem x lst
+  | [] → ML.false
+  | y :: _ when base.(=) x y → ML.true
+  | _ :: lst → mem x lst
   end
 
 (* Update a key-value in an associative list, fail if the key is not present. *)
 let assoc_update x v lst =
   let rec aux acc lst = match lst with
-    | ((x as ?x), _) :: ?lst ⇒ rev_append acc ((x, v) :: lst)
-    | ?y :: ?lst ⇒ aux (y :: acc) lst
+    | (x, _) :: lst → rev_append acc ((x, v) :: lst)
+    | y :: lst → aux (y :: acc) lst
     end
   in aux [] lst

--- a/tests/types/local_let_rec.m31
+++ b/tests/types/local_let_rec.m31
@@ -1,0 +1,1 @@
+let _ = let rec f x  = () in f ;;


### PR DESCRIPTION
During the type checking of a list of mutual let-rec clauses, the variables
need to be added to the context temprorarily, but previously the temporary
bindings did not survive for long enough.