### PR TITLE
s/Pervasives/Stdlib/g for OCaml >= 4.08.0, closes #470

### DIFF
--- a/.travis-ocaml.sh
+++ b/.travis-ocaml.sh
@@ -52,8 +52,8 @@ export OPAMYES=1
 # opam init -a ${BASE_REMOTE}
 opam init
 eval $(opam config env)
-opam switch install 4.06.1
-opam switch 4.06.1
+opam switch install 4.08.1
+opam switch 4.08.1
 eval $(opam config env)
 
 # install andromeda dependencies

--- a/.travis-ocaml.sh
+++ b/.travis-ocaml.sh
@@ -32,7 +32,7 @@ esac
 
 # sudo add-apt-repository \
 #      "deb mirror://mirrors.ubuntu.com/mirrors.txt trusty main restricted universe"
-# sudo add-apt-repository --yes ppa:${ppa}
+sudo add-apt-repository --yes ppa:${ppa}
 sudo apt-get update -qq
 sudo apt-get install -y \
      $(full_apt_version ocaml $OCAML_VERSION) \

--- a/.travis-ocaml.sh
+++ b/.travis-ocaml.sh
@@ -21,17 +21,8 @@ OCAML_VERSION=${OCAML_VERSION:-latest}
 # the base opam repository to use for bootstrapping and catch-all namespace
 BASE_REMOTE=${BASE_REMOTE:-git://github.com/ocaml/opam-repository}
 
-case "$OCAML_VERSION" in
-    3.12) ppa=avsm/ocaml312+opam12 ;;
-    4.00) ppa=avsm/ocaml40+opam12  ;;
-    4.01) ppa=avsm/ocaml41+opam12  ;;
-    4.02) ppa=avsm/ocaml42+opam12  ;;
-    latest) ppa=avsm/ppa-opam-experimental;;
-    *)    echo Unknown compiler version; exit 1;;
-esac
-
-# sudo add-apt-repository \
-#      "deb mirror://mirrors.ubuntu.com/mirrors.txt trusty main restricted universe"
+# Add Anil's Ubuntu repo for Opam 2
+ppa=avsm/ppa
 sudo add-apt-repository --yes ppa:${ppa}
 sudo apt-get update -qq
 sudo apt-get install -y \

--- a/.travis-ocaml.sh
+++ b/.travis-ocaml.sh
@@ -52,13 +52,12 @@ export OPAMYES=1
 # opam init -a ${BASE_REMOTE}
 opam init
 eval $(opam config env)
-opam switch list-available || opam switch --all || opam switch --list || true
-opam switch install 4.08.1
-opam switch 4.08.1
+opam switch install 4.07.0
+opam switch 4.07.0
 eval $(opam config env)
 
-# install andromeda dependencies
-! [ -z "$M31_DEPS" ] && opam install $M31_DEPS
+# install Andromeda as recommended on the website ; pulls in dependencies
+opam pin add andromeda .
 
 # run
 ${BUILD_CMD}

--- a/.travis-ocaml.sh
+++ b/.travis-ocaml.sh
@@ -1,48 +1,20 @@
 BUILD_CMD=${BUILD_CMD:-make all}
-## basic OCaml and opam installation
-
-full_apt_version () {
-  package=$1
-  version=$2
-  case "${version}" in
-      latest) echo -n "${package}" ;;
-      *) echo -n "${package}="
-         apt-cache show $package \
-             | sed -n "s/^Version: \(${version}\)/\1/p" \
-             | head -1
-  esac
-}
 
 set -uex
-
-# the ocaml version to test
-OCAML_VERSION=${OCAML_VERSION:-latest}
-
-# the base opam repository to use for bootstrapping and catch-all namespace
-BASE_REMOTE=${BASE_REMOTE:-git://github.com/ocaml/opam-repository}
 
 # Add Anil's Ubuntu repo for Opam 2
 ppa=avsm/ppa
 sudo add-apt-repository --yes ppa:${ppa}
 sudo apt-get update -qq
-sudo apt-get install -y \
-     $(full_apt_version ocaml $OCAML_VERSION) \
-     $(full_apt_version ocaml-base $OCAML_VERSION) \
-     $(full_apt_version ocaml-native-compilers $OCAML_VERSION) \
-     $(full_apt_version ocaml-compiler-libs $OCAML_VERSION) \
-     $(full_apt_version ocaml-interp $OCAML_VERSION) \
-     $(full_apt_version ocaml-base-nox $OCAML_VERSION) \
-     $(full_apt_version ocaml-nox $OCAML_VERSION) \
-     $(full_apt_version camlp4 $OCAML_VERSION) \
-     $(full_apt_version camlp4-extra $OCAML_VERSION) \
-     $(full_apt_version opam latest)
-
+# Install Ocaml & Opam
+sudo apt-get install -y ocaml opam
 ocaml -version
 opam --version
+# Set up Opam
 export OPAMYES=1
-# opam init -a ${BASE_REMOTE}
 opam init
 eval $(opam config env)
+# Install a recent OCaml
 opam switch install 4.07.0
 opam switch 4.07.0
 eval $(opam config env)

--- a/.travis-ocaml.sh
+++ b/.travis-ocaml.sh
@@ -52,6 +52,7 @@ export OPAMYES=1
 # opam init -a ${BASE_REMOTE}
 opam init
 eval $(opam config env)
+opam switch list-available || opam switch --all || opam switch --list || true
 opam switch install 4.08.1
 opam switch 4.08.1
 eval $(opam config env)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: bionic
 language: c
 sudo: required
 install: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ sudo: required
 install: true
 script: bash -ex .travis-ocaml.sh
 env:
-  - M31_DEPS="menhir sedlex" BUILD_CMD="make all test"
+  - BUILD_CMD="make all test"

--- a/andromeda.opam
+++ b/andromeda.opam
@@ -9,7 +9,7 @@ dev-repo: "git://github.com/Andromedans/andromeda"
 license: "BSD-2-Clause"
 synopsis: "¸¸.•*¨*• A Prover for Type Theories à la Martin-Löf •*¨*•.¸¸"
 depends: [
-  ("ocaml" { >= "4.07.0" } | "stdlib-shims")
+  "ocaml" { >= "4.07.0" }
   "ocamlbuild" {build}
   "ocamlfind" {build}
   "menhir"

--- a/andromeda.opam
+++ b/andromeda.opam
@@ -9,6 +9,7 @@ dev-repo: "git://github.com/Andromedans/andromeda"
 license: "BSD-2-Clause"
 synopsis: "¸¸.•*¨*• A Prover for Type Theories à la Martin-Löf •*¨*•.¸¸"
 depends: [
+  ("ocaml" { >= "4.07.0" } | "stdlib-shims")
   "ocamlbuild" {build}
   "ocamlfind" {build}
   "menhir"

--- a/src/parser/desugar.ml
+++ b/src/parser/desugar.ml
@@ -202,7 +202,7 @@ let print_error err ppf = match err with
 
 exception Error of error Location.located
 
-let error ~at err = Pervasives.raise (Error (Location.mark ~at err))
+let error ~at err = Stdlib.raise (Error (Location.mark ~at err))
 
 module Ctx = struct
 
@@ -1704,7 +1704,7 @@ let initial_context, initial_commands =
   with
   | Error {Location.it=err;_} ->
     Print.error "Error in built-in code:@ %t.@." (print_error err) ;
-    Pervasives.exit 1
+    Stdlib.exit 1
 
 module Builtin =
 struct

--- a/src/parser/ulexbuf.ml
+++ b/src/parser/ulexbuf.ml
@@ -22,7 +22,7 @@ let print_error err ppf = match err with
 
 exception Error of error Location.located
 
-let error ~at err = Pervasives.raise (Error (Location.mark ~at err))
+let error ~at err = Stdlib.raise (Error (Location.mark ~at err))
 
 let create_lexbuf ?(fn="?") stream =
   let pos_end =

--- a/src/runtime/external.ml
+++ b/src/runtime/external.ml
@@ -26,7 +26,7 @@ let externals =
      Runtime.mk_closure (fun v ->
          Runtime.return_closure (fun w ->
              try
-               let c = Pervasives.compare v w in
+               let c = Stdlib.compare v w in
                Runtime.return
                  (if c < 0 then Reflect.mlless
                   else if c > 0 then Reflect.mlgreater
@@ -71,7 +71,7 @@ let externals =
     ));
 
     ("exit", (* forall a, mlunit -> a *)
-     Runtime.mk_closure (fun _ -> Pervasives.exit 0));
+     Runtime.mk_closure (fun _ -> Stdlib.exit 0));
 
     ("magic", (* forall a b, a -> b *)
      Runtime.mk_closure (fun v -> Runtime.return v));

--- a/src/runtime/runtime.ml
+++ b/src/runtime/runtime.ml
@@ -37,7 +37,7 @@ struct
   module TableMap = Map.Make(
                      struct
                        type t = int
-                       let compare = Pervasives.compare
+                       let compare = Stdlib.compare
                      end)
 
   type 'v table = {

--- a/src/typing/context.ml
+++ b/src/typing/context.ml
@@ -34,7 +34,7 @@ struct
   module TableMap = Map.Make(
                      struct
                        type t = int
-                       let compare = Pervasives.compare
+                       let compare = Stdlib.compare
                      end)
 
   type 'a table = {

--- a/src/typing/mlty.ml
+++ b/src/typing/mlty.ml
@@ -5,7 +5,7 @@ type meta = {
   mutable meta_shown : string option ;
 }
 
-let meta_compare {meta_index=i;_} {meta_index=j;_} = Pervasives.compare i j
+let meta_compare {meta_index=i;_} {meta_index=j;_} = Stdlib.compare i j
 
 let eq_meta {meta_index=i;_} {meta_index=j;_} = (i = j)
 
@@ -80,7 +80,7 @@ type error =
 
 exception Error of error Location.located
 
-let error ~at err = Pervasives.raise (Error (Location.mark ~at err))
+let error ~at err = Stdlib.raise (Error (Location.mark ~at err))
 
 (** We expect that most type metavariables are never shown to the user,
     and thus we reindex the ones that are shown to the user. We could

--- a/src/utils/ident.ml
+++ b/src/utils/ident.ml
@@ -17,7 +17,7 @@ let path {path; _} = path
 
 let equal {stamp=i;_} {stamp=j;_} = (i = j)
 
-let compare {stamp=i;_} {stamp=j;_} = Pervasives.compare i j
+let compare {stamp=i;_} {stamp=j;_} = Stdlib.compare i j
 
 module IdentMap = Map.Make(struct
                         type nonrec t = t

--- a/src/utils/path.ml
+++ b/src/utils/path.ml
@@ -15,9 +15,9 @@ module PathSet = Set.Make(
                          match x, y with
                          | Direct _, Module _ -> -1
                          | Module _, Direct _ -> 1
-                         | Direct (Level (_, i)), Direct (Level (_, j)) -> Pervasives.compare i j
+                         | Direct (Level (_, i)), Direct (Level (_, j)) -> Stdlib.compare i j
                          | Module (p, Level(_, i)), Module (q, Level (_, j)) ->
-                            let c = Pervasives.compare i j in
+                            let c = Stdlib.compare i j in
                             if c <> 0 then c
                             else compare p q
                      end)

--- a/src/utils/store.ml
+++ b/src/utils/store.ml
@@ -30,7 +30,7 @@ struct
 
   module KeyMap = Map.Make (struct
                              type t = key
-                             let compare = Pervasives.compare
+                             let compare = Stdlib.compare
                            end)
 
   type 'a t = {store : 'a KeyMap.t; counter : int}


### PR DESCRIPTION
This will move the minimal OCaml version to 4.07.0 (I think), but use of
Pervasives is deprecated since 4.08.0, which causes compilation to fail, as
kindly reported by @mikeshulman in #470.