### PR TITLE
Abstracted atoms

### DIFF
--- a/src/parser/desugar.ml
+++ b/src/parser/desugar.ml
@@ -959,6 +959,11 @@ let rec comp ctx {Location.it=c';at} =
      let c = comp ctx c in
      locate (Desugared.Fresh (xopt, c))
 
+   | Sugared.AbstractAtom (c1,c2) ->
+     let c1 = comp ctx c1
+     and c2 = comp ctx c2 in
+     locate (Desugared.AbstractAtom (c1,c2))
+
   | Sugared.Match (c, cases) ->
      let c = comp ctx c
      and cases = List.map (match_case ctx) cases in

--- a/src/parser/lexer.ml
+++ b/src/parser/lexer.ml
@@ -4,6 +4,7 @@ open Parser
 let reserved = [
   ("_", UNDERSCORE) ;
   ("_atom", UATOM) ;
+  ("abstract", ABSTRACT);
   ("and", AND) ;
   ("as", AS) ;
   ("boundary", MLBOUNDARY) ;
@@ -52,9 +53,9 @@ let reserved = [
 
 let name =
   [%sedlex.regexp? (('_' | alphabetic),
-                 Star ('_' | alphabetic
-                      | 185 | 178 | 179 | 8304 .. 8351 (* sub-/super-scripts *)
-                      | '0'..'9' | '\'')) | math]
+                    Star ('_' | alphabetic
+                         | 185 | 178 | 179 | 8304 .. 8351 (* sub-/super-scripts *)
+                         | '0'..'9' | '\'')) | math]
 
 let digit = [%sedlex.regexp? '0'..'9']
 let numeral = [%sedlex.regexp? Plus digit]
@@ -150,10 +151,10 @@ and token_aux ({ Ulexbuf.stream;_ } as lexbuf) =
   | eof                      -> f (); EOF
 
   | name               -> f ();
-    let n = Ulexbuf.lexeme lexbuf in
-    begin try List.assoc n reserved
-    with Not_found -> NAME (Name.mk_name n)
-    end
+     let n = Ulexbuf.lexeme lexbuf in
+     begin try List.assoc n reserved
+     with Not_found -> NAME (Name.mk_name n)
+     end
 
   | numeral                  -> f (); let k = safe_int_of_string lexbuf in NUMERAL k
 
@@ -166,10 +167,10 @@ and token_aux ({ Ulexbuf.stream;_ } as lexbuf) =
 and comments level ({ Ulexbuf.stream;_ } as lexbuf) =
   match%sedlex stream with
   | end_longcomment ->
-    if level = 0 then
-      begin Ulexbuf.update_pos lexbuf; token lexbuf end
-    else
-      comments (level-1) lexbuf
+     if level = 0 then
+       begin Ulexbuf.update_pos lexbuf; token lexbuf end
+     else
+       comments (level-1) lexbuf
 
   | start_longcomment -> comments (level+1) lexbuf
   | '\n'        -> Ulexbuf.new_line lexbuf; comments level lexbuf
@@ -201,8 +202,8 @@ let run
   | Sedlexing.MalFormed ->
      let at = at_of lexbuf in
      Ulexbuf.error ~at Ulexbuf.MalformedUTF8
-  (* | Sedlexing.InvalidCodepoint _ -> *)
-  (*    assert false (\* Shouldn't happen with UTF8 *\) *)
+(* | Sedlexing.InvalidCodepoint _ -> *)
+(*    assert false (\* Shouldn't happen with UTF8 *\) *)
 
 
 let read_file ?line_limit parse fn =

--- a/src/parser/parser.mly
+++ b/src/parser/parser.mly
@@ -55,7 +55,7 @@
 %token FUN
 
 (* TT commands *)
-%token FRESH CONVERT CONGRUENCE CONTEXT OCCURS DERIVE
+%token FRESH CONVERT CONGRUENCE CONTEXT OCCURS DERIVE ABSTRACT
 
 (* Toplevel directives *)
 %token VERBOSITY
@@ -248,6 +248,9 @@ term_:
 
   | FRESH x=opt_name(ml_name) COLON t=ty_term
     { Sugared.Fresh (x, t) }
+
+  | ABSTRACT c1=nonempty_list(term) IN c2=term
+    {Sugared.AbstractComp (c1, c2)}
 
   | e=app_term COLONQT bdry=ty_term
     { Sugared.BoundaryAscribe (e, bdry) }

--- a/src/parser/parser.mly
+++ b/src/parser/parser.mly
@@ -55,11 +55,7 @@
 %token FUN
 
 (* TT commands *)
-<<<<<<< HEAD
 %token FRESH CONVERT CONGRUENCE CONTEXT OCCURS DERIVE ABSTRACT
-=======
-%token ABSTRACT FRESH CONVERT CONGRUENCE CONTEXT OCCURS
->>>>>>> b0e48f50f2ee9d31343cd5142d8082d260ab2b07
 
 (* Toplevel directives *)
 %token VERBOSITY

--- a/src/parser/parser.mly
+++ b/src/parser/parser.mly
@@ -249,8 +249,8 @@ term_:
   | FRESH x=opt_name(ml_name) COLON t=ty_term
     { Sugared.Fresh (x, t) }
 
-  | ABSTRACT c1=nonempty_list(term) IN c2=term
-    {Sugared.AbstractComp (c1, c2)}
+  | ABSTRACT c1=prefix_term c2=prefix_term
+    { Sugared.AbstractAtom (c1, c2) }
 
   | e=app_term COLONQT bdry=ty_term
     { Sugared.BoundaryAscribe (e, bdry) }

--- a/src/parser/parser.mly
+++ b/src/parser/parser.mly
@@ -249,9 +249,6 @@ term_:
   | FRESH x=opt_name(ml_name) COLON t=ty_term
     { Sugared.Fresh (x, t) }
 
-  | ABSTRACT c1=prefix_term c2=prefix_term
-    { Sugared.AbstractAtom (c1, c2) }
-
   | e=app_term COLONQT bdry=ty_term
     { Sugared.BoundaryAscribe (e, bdry) }
 
@@ -312,6 +309,9 @@ app_term_:
 
   | CONVERT c1=substitution_term c2=substitution_term
     { Sugared.Convert (c1, c2) }
+
+  | ABSTRACT c1=prefix_term c2=prefix_term
+    { Sugared.AbstractAtom (c1, c2) }
 
   | OCCURS c1=substitution_term c2=substitution_term
     { Sugared.Occurs (c1, c2) }

--- a/src/runtime/eval.ml
+++ b/src/runtime/eval.ml
@@ -218,7 +218,7 @@ let rec comp {Location.it=c'; at} =
 
              | Runtime.Boundary bdry -> Runtime.return_boundary (Nucleus.abstract_boundary a bdry)
 
-             | Runtime.(Closure _ | Handler _ | Tag _ | Tuple _ | Ref _ | Dyn _ | String _) as v ->
+             | Runtime.(Closure _ | Derivation _| Handler _ | Tag _ | Tuple _ | Ref _ | Dyn _ | String _) as v ->
                 Runtime.(error ~at (JudgementExpected v))
            end
 

--- a/src/runtime/eval.ml
+++ b/src/runtime/eval.ml
@@ -207,7 +207,7 @@ let rec comp {Location.it=c'; at} =
              | Runtime.Boundary bdry -> Runtime.return_boundary (Nucleus.abstract_boundary a bdry)
 
              | Runtime.(Derivation _ | Closure _ | Handler _ | Tag _ | Tuple _ | Ref _ | Dyn _ | String _) as v ->
-                Runtime.(error ~at (JudgementExpected v))
+                Runtime.(error ~at (JudgementOrBoundaryExpected v))
            end)
   
   | Syntax.AbstractAtom (a, c) ->
@@ -219,7 +219,7 @@ let rec comp {Location.it=c'; at} =
              | Runtime.Boundary bdry -> Runtime.return_boundary (Nucleus.abstract_boundary a bdry)
 
              | Runtime.(Closure _ | Derivation _| Handler _ | Tag _ | Tuple _ | Ref _ | Dyn _ | String _) as v ->
-                Runtime.(error ~at (JudgementExpected v))
+                Runtime.(error ~at (JudgementOrBoundaryExpected v))
            end
 
   | Syntax.Substitute (c1, c2) ->

--- a/src/runtime/eval.ml
+++ b/src/runtime/eval.ml
@@ -218,11 +218,7 @@ let rec comp {Location.it=c'; at} =
 
              | Runtime.Boundary bdry -> Runtime.return_boundary (Nucleus.abstract_boundary a bdry)
 
-<<<<<<< HEAD
              | Runtime.(Closure _ | Derivation _| Handler _ | Tag _ | Tuple _ | Ref _ | Dyn _ | String _) as v ->
-=======
-             | Runtime.(Closure _ | Handler _ | Tag _ | Tuple _ | Ref _ | Dyn _ | String _) as v ->
->>>>>>> b0e48f50f2ee9d31343cd5142d8082d260ab2b07
                 Runtime.(error ~at (JudgementExpected v))
            end
 

--- a/src/runtime/eval.ml
+++ b/src/runtime/eval.ml
@@ -209,6 +209,18 @@ let rec comp {Location.it=c'; at} =
              | Runtime.(Derivation _ | Closure _ | Handler _ | Tag _ | Tuple _ | Ref _ | Dyn _ | String _) as v ->
                 Runtime.(error ~at (JudgementExpected v))
            end)
+  
+  | Syntax.AbstractAtom (a, c) ->
+     comp_as_atom a >>= fun a ->
+           begin comp c >>=
+             function
+             | Runtime.Judgement jdg -> Runtime.return_judgement (Nucleus.abstract_judgement a jdg)
+
+             | Runtime.Boundary bdry -> Runtime.return_boundary (Nucleus.abstract_boundary a bdry)
+
+             | Runtime.(Closure _ | Handler _ | Tag _ | Tuple _ | Ref _ | Dyn _ | String _) as v ->
+                Runtime.(error ~at (JudgementExpected v))
+           end
 
   | Syntax.Substitute (c1, c2) ->
      (*
@@ -370,6 +382,7 @@ and check_judgement ({Location.it=c'; at} as c) bdry =
   | Syntax.Lookup _
   | Syntax.Update _
   | Syntax.Fresh _
+  | Syntax.AbstractAtom _
   | Syntax.Current _
   | Syntax.String _
   | Syntax.Occurs _

--- a/src/runtime/runtime.ml
+++ b/src/runtime/runtime.ml
@@ -228,6 +228,7 @@ type error =
   | EqTermExpected of value
   | AbstractionExpected
   | JudgementExpected of value
+  | JudgementOrBoundaryExpected of value
   | DerivationExpected of value
   | ClosureExpected of value
   | HandlerExpected of value
@@ -849,6 +850,9 @@ let print_error ~penv err ppf =
 
   | JudgementExpected v ->
      Format.fprintf ppf "expected a judgement but got %s" (name_of v)
+
+  | JudgementOrBoundaryExpected v ->
+     Format.fprintf ppf "expected a judgement or a boundary but got %s" (name_of v)
 
   | DerivationExpected v ->
      Format.fprintf ppf "expected a derivation but got %s" (name_of v)

--- a/src/runtime/runtime.mli
+++ b/src/runtime/runtime.mli
@@ -169,6 +169,7 @@ type error =
   | EqTermExpected of value
   | AbstractionExpected
   | JudgementExpected of value
+  | JudgementOrBoundaryExpected of value
   | DerivationExpected of value
   | ClosureExpected of value
   | HandlerExpected of value

--- a/src/syntax/desugared.mli
+++ b/src/syntax/desugared.mli
@@ -76,6 +76,7 @@ and comp' =
   | TTConstructor of Path.t * comp list
   | Spine of comp * comp list
   | Abstract of Name.t * comp option * comp
+  | AbstractComp of (comp list) * comp
   | Substitute of comp * comp
   | Derive of premise list * comp
   | Yield of comp
@@ -88,10 +89,10 @@ and comp' =
   | MLBoundary of boundary
 
 and boundary =
-   | BoundaryIsType
-   | BoundaryIsTerm of comp
-   | BoundaryEqType of comp * comp
-   | BoundaryEqTerm of comp * comp * comp
+  | BoundaryIsType
+  | BoundaryIsTerm of comp
+  | BoundaryEqType of comp * comp
+  | BoundaryEqTerm of comp * comp * comp
 
 and let_clause =
   | Let_clause of pattern * let_annotation * comp (* [let (?p :> t) = c] *)

--- a/src/syntax/desugared.mli
+++ b/src/syntax/desugared.mli
@@ -76,7 +76,7 @@ and comp' =
   | TTConstructor of Path.t * comp list
   | Spine of comp * comp list
   | Abstract of Name.t * comp option * comp
-  | AbstractComp of (comp list) * comp
+  | AbstractAtom of comp * comp
   | Substitute of comp * comp
   | Derive of premise list * comp
   | Yield of comp

--- a/src/syntax/sugared.mli
+++ b/src/syntax/sugared.mli
@@ -90,7 +90,7 @@ and comp' =
   | Abstract of (Name.t * comp option) list * comp
   (* Multi-argument substitutions are *not* treated as parallel substitutions
      but desugared to consecutive substitutions. *)
-  | AbstractComp of (comp list) * comp
+  | AbstractAtom of comp * comp
   | Substitute of comp * comp list
   | Derive of premise list * comp
   | Spine of comp * comp list

--- a/src/syntax/sugared.mli
+++ b/src/syntax/sugared.mli
@@ -90,6 +90,7 @@ and comp' =
   | Abstract of (Name.t * comp option) list * comp
   (* Multi-argument substitutions are *not* treated as parallel substitutions
      but desugared to consecutive substitutions. *)
+  | AbstractComp of (comp list) * comp
   | Substitute of comp * comp list
   | Derive of premise list * comp
   | Spine of comp * comp list

--- a/src/syntax/syntax.mli
+++ b/src/syntax/syntax.mli
@@ -59,7 +59,7 @@ and comp' =
   | TTApply of comp * comp list
   | Apply of comp * comp
   | Abstract of Name.t * comp option * comp
-  | AbstractComp of (comp list) * comp
+  | AbstractAtom of comp * comp
   | Substitute of comp * comp
   | Derive of premise list * comp
   | Yield of comp

--- a/src/syntax/syntax.mli
+++ b/src/syntax/syntax.mli
@@ -59,6 +59,7 @@ and comp' =
   | TTApply of comp * comp list
   | Apply of comp * comp
   | Abstract of Name.t * comp option * comp
+  | AbstractComp of (comp list) * comp
   | Substitute of comp * comp
   | Derive of premise list * comp
   | Yield of comp
@@ -72,16 +73,16 @@ and comp' =
 
 (** The boundary of the conclusion of a premise or a rule *)
 and boundary =
-   | BoundaryIsType
-   | BoundaryIsTerm of comp
-   | BoundaryEqType of comp * comp
-   | BoundaryEqTerm of comp * comp * comp
+  | BoundaryIsType
+  | BoundaryIsTerm of comp
+  | BoundaryEqType of comp * comp
+  | BoundaryEqTerm of comp * comp * comp
 
 (** A let-clause is given by a list of names with their types, a pattern that
-   binds these variables (so the variables list needs to match the pattern!),
-   and the body of the definition.
+    binds these variables (so the variables list needs to match the pattern!),
+    and the body of the definition.
 
-   The names and types are used only for printing during runtime. *)
+    The names and types are used only for printing during runtime. *)
 and let_clause =
   | Let_clause of pattern * comp
 

--- a/src/typing/typecheck.ml
+++ b/src/typing/typecheck.ml
@@ -35,6 +35,7 @@ let rec generalizable c =
   | Syntax.Update _
   | Syntax.Ref _
   | Syntax.Fresh _
+  | Syntax.AbstractAtom _
   | Syntax.Match _
   | Syntax.BoundaryAscribe _
   | Syntax.TypeAscribe _
@@ -414,6 +415,11 @@ let rec infer_comp ({Location.it=c; at} : Desugared.comp) : (Syntax.comp * Mlty.
   | Desugared.Fresh (xopt, c) ->
      check_comp c Mlty.Judgement >>= fun c ->
      return (locate ~at (Syntax.Fresh (xopt, c)), Mlty.Judgement)
+
+   | Desugared.AbstractAtom (c1, c2) ->
+     check_comp c1 Mlty.Judgement >>= fun c1 ->
+     check_comp c2 Mlty.Judgement >>= fun c2 ->
+     return (locate ~at (Syntax.AbstractAtom (c1, c2)), Mlty.Judgement)
 
   | Desugared.Match (c, cases) ->
     infer_comp c >>= fun (c, tc) ->

--- a/tests/runtime/abstract_atoms.m31
+++ b/tests/runtime/abstract_atoms.m31
@@ -1,4 +1,13 @@
 rule A type;;
-let abstr = {z : A} z;;
-let a = match abstr with {y : Y} w :> judgement -> y end;;
+
+let x = fresh x : A in abstract x x;;
+
+let b = fresh b : A in abstract b (? : A);;
+
+let abstr_jdg = {z : A} z;;
+let a = match abstr_jdg with {y : Y} w :> judgement -> y end;;
 let abstr1 = abstract a a;;
+
+let abstr_bdry = {x : A} {y : A} ? : A ;;
+let (atom, bdry) = match abstr_bdry with {y : Y} w :> boundary -> (y, w) end;;
+let abstr2 = abstract atom bdry;;

--- a/tests/runtime/abstract_atoms.m31
+++ b/tests/runtime/abstract_atoms.m31
@@ -1,0 +1,4 @@
+rule A type;;
+let abstr = {z : A} z;;
+let a = match abstr with {y : Y} w :> judgement -> y end;;
+let abstr1 = abstract a a;;

--- a/tests/runtime/abstract_atoms.m31.ref
+++ b/tests/runtime/abstract_atoms.m31.ref
@@ -1,0 +1,4 @@
+Rule A is postulated.
+val abstr :> judgement = ⊢ {z : A} z
+val a :> judgement = ?z₀ : A ⊢ ?z₀
+val abstr1 :> judgement = ⊢ {z : A} z

--- a/tests/runtime/abstract_atoms.m31.ref
+++ b/tests/runtime/abstract_atoms.m31.ref
@@ -1,4 +1,10 @@
 Rule A is postulated.
-val abstr :> judgement = ⊢ {z : A} z
+- : judgement = ⊢ {x : A} x
+- : boundary = ⊢ {_ : A} (? : A)
+val abstr_jdg :> judgement = ⊢ {z : A} z
 val a :> judgement = ?z₀ : A ⊢ ?z₀
 val abstr1 :> judgement = ⊢ {z : A} z
+val abstr_bdry :> boundary = ⊢ {_ : A} {_ : A} (? : A)
+val atom :> judgement = ?x₁ : A ⊢ ?x₁
+val bdry :> boundary = ⊢ {_ : A} (? : A)
+val abstr2 :> boundary = ⊢ {_ : A} {_ : A} (? : A)


### PR DESCRIPTION
This is a fix of the issue #469 
I am a bit unsure if the function check_judgement in src/runtime/eval.ml should do something else in case Syntax.AbstracAtom? We will evaluate to an abstracted judgement, but morally it is a judgement with an abstracted boundary...
