### PR TITLE
Fix variable name m31-ml-variable-rx in andromeda-smie.el

### DIFF
--- a/etc/andromeda-smie.el
+++ b/etc/andromeda-smie.el
@@ -3,7 +3,7 @@
 (require 'smie)
 
 ;; TODO: add vdash here! in sedlex, it comes from `math'
-(defvar m31--name-re m31-meta-variable-rx)
+(defvar m31--name-re m31-ml-variable-rx)
 (defvar m31--quoted-string-re (rx (seq ?\" (1+ (not (any ?\"))) ?\")))
 
 (defvar m31--reserved


### PR DESCRIPTION
The current `m31-meta-variable-rx` gives `File mode specification error: (void-variable m31-meta-variable-rx)`.  Since `m31-ml-variable-rx` exists and seems to work, I guessed that it was probably the correct name.