### PR TITLE
Runners

### DIFF
--- a/src/parser/builtin.ml
+++ b/src/parser/builtin.ml
@@ -51,12 +51,7 @@ let builtin_ops =
    unloc decl_coerce]
 
 let builtin_ml_values =
-  let un_ml_judgement = unloc (Sugared.ML_Judgement) in
-  let hyps_annot = unloc (Sugared.ML_TyApply (Name.PName Name.Builtin.list_name, [un_ml_judgement])) in
-  let empty_list = unloc (Sugared.Name (Name.PName Name.Builtin.nil_name)) in
-  let decl_hyps = Sugared.TopDynamic
-                    (Name.Builtin.hypotheses_name, Sugared.Arg_annot_ty hyps_annot, empty_list) in
-  [unloc decl_hyps]
+  []
 
 let initial =
   let ty_alpha = unloc (Sugared.ML_TyApply (Name.PName name_alpha, [])) in

--- a/src/parser/desugar.ml
+++ b/src/parser/desugar.ml
@@ -360,11 +360,12 @@ module Ctx = struct
     | None | Some (Bound _ | Value _ | TTConstructor _ | MLConstructor _) ->
        assert false
 
-  let get_ml_value x ctx =
-    match find_name x ctx with
-    | Some (Value v) -> v
-    | None | Some (Bound _ | TTConstructor _ | MLConstructor _ | Operation _) ->
-       assert false
+  (* This will be needed if and when there is a builtin global ML value that has to be looked up. *)
+  (* let get_ml_value x ctx =
+   *   match find_name x ctx with
+   *   | Some (Value v) -> v
+   *   | None | Some (Bound _ | TTConstructor _ | MLConstructor _ | Operation _) ->
+   *      assert false *)
 
   (* Get information about the given ML module. *)
   let get_ml_module ~at pth ctx =
@@ -925,16 +926,6 @@ let rec comp ctx {Location.it=c';at} =
      let c = comp ctx c in
      let sch = ml_schema ctx sch in
      locate (Desugared.MLAscribe (c, sch))
-
-  | Sugared.Now (x,c1,c2) ->
-     let x = comp ctx x
-     and c1 = comp ctx c1
-     and c2 = comp ctx c2 in
-     locate (Desugared.Now (x,c1,c2))
-
-  | Sugared.Current c ->
-     let c = comp ctx c in
-     locate (Desugared.Current c)
 
   | Sugared.Lookup c ->
      let c = comp ctx c in
@@ -1596,17 +1587,6 @@ let rec toplevel' ~loading ~basedir ctx {Location.it=cmd; at} =
      let c = comp ctx c in
      (ctx, locate1 (Desugared.TopComputation c))
 
-  | Sugared.TopDynamic (x, annot, c) ->
-     let c = comp ctx c in
-     let ctx = Ctx.add_ml_value ~at x ctx in
-     let annot = arg_annotation ctx annot in
-     (ctx, locate1 (Desugared.TopDynamic (x, annot, c)))
-
-  | Sugared.TopNow (x, c) ->
-     let x = comp ctx x in
-     let c = comp ctx c in
-     (ctx, locate1 (Desugared.TopNow (x, c)))
-
   | Sugared.Verbosity n ->
      (ctx, locate1 (Desugared.Verbosity n))
 
@@ -1732,6 +1712,4 @@ struct
   let equal_term = fst (Ctx.get_ml_operation Name.Builtin.equal_term initial_context)
   let equal_type = fst (Ctx.get_ml_operation Name.Builtin.equal_type initial_context)
   let coerce = fst (Ctx.get_ml_operation Name.Builtin.coerce initial_context)
-
-  let hypotheses = Ctx.get_ml_value Name.Builtin.hypotheses initial_context
 end

--- a/src/parser/desugar.ml
+++ b/src/parser/desugar.ml
@@ -1334,17 +1334,16 @@ and spine ~at ctx ({Location.it=c'; at=c_at} as c) cs =
 (* Desugar handler cases. *)
 and handler ~at ctx hcs =
   (* for every case | op p => c we do op binder => match binder with | p => c end *)
-  let rec fold val_cases op_cases finally_cases = function
+  let rec fold val_cases op_cases = function
     | [] ->
        List.rev val_cases,
-       List.map (fun (op, cs) -> (op, List.rev cs)) op_cases,
-       List.rev finally_cases
+       List.map (fun (op, cs) -> (op, List.rev cs)) op_cases
 
     | Sugared.CaseVal c :: hcs ->
        (* XXX if this handler is in a outer handler's operation case, should we use its yield?
           eg handle ... with | op => handler | val x => yield x end end *)
        let case = match_case ctx c in
-       fold (case::val_cases) op_cases finally_cases hcs
+       fold (case::val_cases) op_cases hcs
 
     | Sugared.CaseOp (op, ((ps,_,_) as c)) :: hcs ->
 
@@ -1355,20 +1354,15 @@ and handler ~at ctx hcs =
           let case = match_op_case ctx c in
           let my_cases = try List.assoc pth op_cases with Not_found -> [] in
           let my_cases = case::my_cases in
-          fold val_cases ((pth, my_cases) :: op_cases) finally_cases hcs
+          fold val_cases ((pth, my_cases) :: op_cases) hcs
 
        | (Bound _ | Value _ | Exception _ | TTConstructor _ | MLConstructor _) as info ->
           error ~at (OperationExpected (op, info))
 
        end
-
-    | Sugared.CaseFinally c :: hcs ->
-       let case = match_case ctx c in
-       fold val_cases op_cases (case::finally_cases) hcs
-
   in
-  let handler_val, handler_ops, handler_finally = fold [] [] [] hcs in
-  Location.mark ~at (Desugared.Handler (Desugared.{ handler_val ; handler_ops ; handler_finally }))
+  let handler_val, handler_ops = fold [] [] hcs in
+  Location.mark ~at (Desugared.Handler (Desugared.{ handler_val ; handler_ops }))
 
 (* Desugare an exception handler *)
 and exception_handler ~at ctx hnd =

--- a/src/parser/desugar.ml
+++ b/src/parser/desugar.ml
@@ -936,7 +936,7 @@ and check_linear_abstraction ~at ~forbidden = function
 let rec comp ctx {Location.it=c';at} =
   let locate x = Location.mark ~at x in
   match c' with
-  | Sugared.Handle (c, hcs) ->
+  | Sugared.Try (c, hcs) ->
      let c = comp ctx c
      and h = handler ~at ctx hcs in
      locate (Desugared.With (h, c))

--- a/src/parser/desugar.ml
+++ b/src/parser/desugar.ml
@@ -950,11 +950,6 @@ let rec comp ctx {Location.it=c';at} =
      let c = comp ctx c in
      locate (Desugared.Raise c)
 
-  | Sugared.Try (c, hnd) ->
-     let c = comp ctx c
-     and hnd = exception_handler ~at ctx hnd in
-     locate (Desugared.Try (c, hnd))
-
   | Sugared.Let (lst, c) ->
      let ctx, lst = let_clauses ~at ~toplevel:false ctx lst in
      let c = comp ctx c in
@@ -1367,10 +1362,6 @@ and handler ~at ctx hcs =
   in
   let handler_val, handler_ops, handler_exc = fold [] [] [] hcs in
   Location.mark ~at Desugared.(Handler {handler_val ; handler_ops; handler_exc })
-
-(* Desugare an exception handler *)
-and exception_handler ~at ctx hnd =
-  List.map (match_case ctx) hnd
 
 (* Desugar a match case *)
 and match_case ctx (p, g, c) =

--- a/src/parser/desugar.mli
+++ b/src/parser/desugar.mli
@@ -61,5 +61,4 @@ sig
   val equal_term : Path.t
   val equal_type : Path.t
   val coerce : Path.t
-  val hypotheses : Path.t
 end

--- a/src/parser/lexer.ml
+++ b/src/parser/lexer.ml
@@ -11,10 +11,8 @@ let reserved = [
   ("congruence", CONGRUENCE) ;
   ("context", CONTEXT) ;
   ("convert", CONVERT) ;
-  ("current", CURRENT) ;
   ("derive", DERIVE) ;
   ("derivation", MLDERIVATION) ;
-  ("dynamic", DYNAMIC) ;
   ("end", END) ;
   ("external", EXTERNAL) ;
   ("finally", FINALLY) ;
@@ -34,7 +32,6 @@ let reserved = [
   ("mlunit", MLUNIT) ;
   ("module", MODULE) ;
   ("natural", NATURAL) ;
-  ("now", NOW) ;
   ("occurs", OCCURS) ;
   ("of", OF) ;
   ("open", OPEN) ;

--- a/src/parser/lexer.ml
+++ b/src/parser/lexer.ml
@@ -14,6 +14,7 @@ let reserved = [
   ("derive", DERIVE) ;
   ("derivation", MLDERIVATION) ;
   ("end", END) ;
+  ("exception", EXCEPTION) ;
   ("external", EXTERNAL) ;
   ("finally", FINALLY) ;
   ("fresh", FRESH) ;
@@ -36,12 +37,14 @@ let reserved = [
   ("of", OF) ;
   ("open", OPEN) ;
   ("operation", OPERATION) ;
+  ("raise", RAISE) ;
   ("rec", REC) ;
   ("ref", REF) ;
   ("rule", RULE) ;
   ("type", TYPE) ;
   ("require", REQUIRE) ;
   ("struct", STRUCT) ;
+  ("try", TRY) ;
   ("val", VAL) ;
   ("verbosity", VERBOSITY) ;
   ("when", WHEN) ;

--- a/src/parser/lexer.ml
+++ b/src/parser/lexer.ml
@@ -18,7 +18,7 @@ let reserved = [
   ("external", EXTERNAL) ;
   ("fresh", FRESH) ;
   ("fun", FUN) ;
-  ("handle", HANDLE) ;
+  ("try", TRY) ;
   ("handler", HANDLER) ;
   ("in", IN) ;
   ("include", INCLUDE) ;

--- a/src/parser/lexer.ml
+++ b/src/parser/lexer.ml
@@ -16,7 +16,6 @@ let reserved = [
   ("end", END) ;
   ("exception", EXCEPTION) ;
   ("external", EXTERNAL) ;
-  ("finally", FINALLY) ;
   ("fresh", FRESH) ;
   ("fun", FUN) ;
   ("handle", HANDLE) ;

--- a/src/parser/lexer.ml
+++ b/src/parser/lexer.ml
@@ -43,7 +43,6 @@ let reserved = [
   ("type", TYPE) ;
   ("require", REQUIRE) ;
   ("struct", STRUCT) ;
-  ("try", TRY) ;
   ("val", VAL) ;
   ("verbosity", VERBOSITY) ;
   ("when", WHEN) ;

--- a/src/parser/lexer.ml
+++ b/src/parser/lexer.ml
@@ -46,7 +46,6 @@ let reserved = [
   ("verbosity", VERBOSITY) ;
   ("when", WHEN) ;
   ("with", WITH) ;
-  ("yield", YIELD) ;
 ]
 
 let name =

--- a/src/parser/parser.mly
+++ b/src/parser/parser.mly
@@ -29,7 +29,7 @@
 %token AS TYPE
 %token EQEQ
 
-%token EXCEPTION RAISE TRY
+%token EXCEPTION RAISE
 %token HANDLE WITH HANDLER BAR VAL
 %token SEMI
 
@@ -225,9 +225,6 @@ term_:
 
   | MATCH e=term WITH lst=match_cases END
     { Sugared.Match (e, lst) }
-
-  | TRY c=term WITH lst=match_cases END
-    { Sugared.Try (c, lst) }
 
   | HANDLE c=term WITH hcs=handler_cases END
     { Sugared.Handle (c, hcs) }

--- a/src/parser/parser.mly
+++ b/src/parser/parser.mly
@@ -29,6 +29,7 @@
 %token AS TYPE
 %token EQEQ
 
+%token EXCEPTION RAISE TRY
 %token HANDLE WITH HANDLER BAR VAL FINALLY
 %token SEMI
 
@@ -153,6 +154,12 @@ top_command_:
   | OPERATION op=op_name COLON opsig=op_mlsig
     { Sugared.DeclOperation (op, opsig) }
 
+  | EXCEPTION exc=exc_name
+    { Sugared.DeclException (exc, None) }
+
+  | EXCEPTION exc=exc_name OF t=mlty
+    { Sugared.DeclException (exc, Some t) }
+
   | VERBOSITY n=NUMERAL
     { Sugared.Verbosity n }
 
@@ -218,6 +225,9 @@ term_:
 
   | MATCH e=term WITH lst=match_cases END
     { Sugared.Match (e, lst) }
+
+  | TRY c=term WITH lst=match_cases END
+    { Sugared.Try (c, lst) }
 
   | HANDLE c=term WITH hcs=handler_cases END
     { Sugared.Handle (c, hcs) }
@@ -285,6 +295,9 @@ app_term: mark_location(app_term_) { $1 }
 app_term_:
   | e=substitution_term_
     { e }
+
+  | RAISE c=substitution_term
+    { Sugared.Raise c }
 
   | CONGRUENCE e1=substitution_term e2=substitution_term es=list(substitution_term)
     { Sugared.Congruence (e1, e2, es) }
@@ -376,6 +389,11 @@ ml_name:
 
 (* ML operation name *)
 op_name:
+  | NAME
+    { $1 }
+
+(* ML exception name *)
+exc_name:
   | NAME
     { $1 }
 

--- a/src/parser/parser.mly
+++ b/src/parser/parser.mly
@@ -29,7 +29,7 @@
 %token AS TYPE
 %token EQEQ
 
-%token HANDLE WITH HANDLER BAR VAL FINALLY YIELD
+%token HANDLE WITH HANDLER BAR VAL FINALLY
 %token SEMI
 
 %token NATURAL
@@ -331,9 +331,6 @@ prefix_term_:
 
   | NATURAL t=prefix_term
     { Sugared.Natural t }
-
-  | YIELD e=prefix_term
-    { Sugared.Yield e }
 
 (* simple_term: mark_location(simple_term_) { $1 } *)
 simple_term_:

--- a/src/parser/parser.mly
+++ b/src/parser/parser.mly
@@ -23,9 +23,6 @@
 (* Let binding *)
 %token LET REC AND IN
 
-(* Dynamic variables *)
-%token DYNAMIC NOW CURRENT
-
 (* Meta-level programming *)
 %token OPERATION
 %token MATCH WHEN END
@@ -144,12 +141,6 @@ top_command_:
   | LET REC lst=separated_nonempty_list(AND, recursive_clause)
     { Sugared.TopLetRec lst }
 
-  | DYNAMIC x=ml_name u=dyn_annotation EQ c=term
-    { Sugared.TopDynamic (x, u, c) }
-
-  | NOW x=app_term EQ c=term
-    { Sugared.TopNow (x,c) }
-
   (* | HANDLE lst=top_handler_cases END *)
   (*   { Sugared.TopHandle lst } *)
 
@@ -225,9 +216,6 @@ term_:
   | LET REC lst=separated_nonempty_list(AND, recursive_clause) IN c=term
     { Sugared.LetRec (lst, c) }
 
-  | NOW x=app_term EQ c1=term IN c2=term
-    { Sugared.Now (x,c1,c2) }
-
   | MATCH e=term WITH lst=match_cases END
     { Sugared.Match (e, lst) }
 
@@ -297,9 +285,6 @@ app_term: mark_location(app_term_) { $1 }
 app_term_:
   | e=substitution_term_
     { e }
-
-  | CURRENT c=substitution_term
-    { Sugared.Current c }
 
   | CONGRUENCE e1=substitution_term e2=substitution_term es=list(substitution_term)
     { Sugared.Congruence (e1, e2, es) }
@@ -532,13 +517,6 @@ let_annotation:
   | COLONGT sch=ml_schema
     { Sugared.Let_annot_schema sch }
 
-dyn_annotation:
-  |
-    { Sugared.Arg_annot_none }
-
-  | COLONGT t=mlty
-    { Sugared.Arg_annot_ty t }
-
 maybe_typed_binder:
   | LBRACE xs=anon_name(tt_name)+ RBRACE
     { List.map (fun x -> (x, None)) xs }
@@ -754,9 +732,6 @@ app_mlty_:
 
   | REF t=simple_mlty
     { Sugared.ML_Ref t }
-
-  | DYNAMIC t=simple_mlty
-    { Sugared.ML_Dynamic t }
 
   | c=long(ml_name) args=nonempty_list(simple_mlty)
     { Sugared.ML_TyApply (c, args) }

--- a/src/parser/parser.mly
+++ b/src/parser/parser.mly
@@ -30,7 +30,7 @@
 %token EQEQ
 
 %token EXCEPTION RAISE
-%token HANDLE WITH HANDLER BAR VAL
+%token TRY WITH HANDLER BAR VAL
 %token SEMI
 
 %token NATURAL
@@ -226,8 +226,8 @@ term_:
   | MATCH e=term WITH lst=match_cases END
     { Sugared.Match (e, lst) }
 
-  | HANDLE c=term WITH hcs=handler_cases END
-    { Sugared.Handle (c, hcs) }
+  | TRY c=term WITH hcs=handler_cases END
+    { Sugared.Try (c, hcs) }
 
   | FUN xs=ml_arg+ ARROW e=term
     { Sugared.Function (xs, e) }
@@ -235,7 +235,7 @@ term_:
   | DERIVE ps=nonempty_list(premise) ARROW e=term
     { Sugared.Derive (ps, e) }
 
-  | WITH h=term HANDLE c=term
+  | WITH h=term TRY c=term
     { Sugared.With (h, c) }
 
   | HANDLER hcs=handler_cases END

--- a/src/parser/parser.mly
+++ b/src/parser/parser.mly
@@ -30,7 +30,7 @@
 %token EQEQ
 
 %token EXCEPTION RAISE TRY
-%token HANDLE WITH HANDLER BAR VAL FINALLY
+%token HANDLE WITH HANDLER BAR VAL
 %token SEMI
 
 %token NATURAL
@@ -564,9 +564,6 @@ handler_case:
 
   | op=long(op_name) ps=prefix_pattern* pt=handler_checking ARROW t=term
     { Sugared.CaseOp (op, (ps, pt, t)) }
-
-  | FINALLY c=match_case
-    { Sugared.CaseFinally c }
 
 handler_checking:
   |

--- a/src/parser/parser.mly
+++ b/src/parser/parser.mly
@@ -562,6 +562,9 @@ handler_case:
   | VAL c=match_case
     { Sugared.CaseVal c }
 
+  | RAISE c=match_case
+    { Sugared.CaseExc c }
+
   | op=long(op_name) ps=prefix_pattern* pt=handler_checking ARROW t=term
     { Sugared.CaseOp (op, (ps, pt, t)) }
 

--- a/src/runtime/eval.ml
+++ b/src/runtime/eval.ml
@@ -524,8 +524,7 @@ and match_cases
 and match_op_cases ~at op cases vs checking =
   let rec fold = function
     | [] ->
-      Runtime.operation op ?checking vs >>= fun v ->
-      Runtime.continue v
+      Runtime.operation op ?checking vs
     | (ps, ptopt, c) :: cases ->
       Matching.match_op_pattern ps ptopt vs checking >>=
         begin function

--- a/src/runtime/eval.ml
+++ b/src/runtime/eval.ml
@@ -775,6 +775,13 @@ let rec toplevel ~quiet ~print_annot {Location.it=c; at} =
           (Path.print ~opens ~parentheses:true op)) ;
      return ()
 
+  | Syntax.DeclException (exc, topt) ->
+     Runtime.top_lookup_opens >>= fun opens ->
+     (if not quiet then
+        Format.printf "@[<hov 2>Exception %t is declared.@]@."
+          (Path.print ~opens ~parentheses:true exc)) ;
+     return ()
+
   | Syntax.DeclExternal (x, sch, s) ->
      begin
        match External.lookup s with

--- a/src/runtime/eval.ml
+++ b/src/runtime/eval.ml
@@ -27,7 +27,7 @@ let as_bool ~at v =
      else
      Runtime.(error ~at (BoolExpected v))
 
-  | Runtime.(Tag (_, _::_) | Judgement _ | Boundary _ | Derivation _ | Closure _ | Handler _ | Tuple _ | Ref _ | Dyn _ | String _) ->
+  | Runtime.(Tag (_, _::_) | Judgement _ | Boundary _ | Derivation _ | Closure _ | Handler _ | Tuple _ | Ref _ | String _) ->
      Runtime.(error ~at (BoolExpected v))
 
 let as_handler ~at v =
@@ -36,10 +36,6 @@ let as_handler ~at v =
 
 let as_ref ~at v =
   let e = Runtime.as_ref ~at v in
-  return e
-
-let as_dyn ~at v =
-  let e = Runtime.as_dyn ~at v in
   return e
 
 (** Main evaluation loop. *)
@@ -140,16 +136,6 @@ let rec comp {Location.it=c'; at} =
   | Syntax.LetRec (fxcs, c) ->
      letrec_bind fxcs (comp c)
 
-  | Syntax.Now (x,c1,c2) ->
-     let xloc = x.Location.at in
-     comp x >>= as_dyn ~at:xloc >>= fun x ->
-     comp c1 >>= fun v ->
-     Runtime.now x v (comp c2)
-
-  | Syntax.Current c ->
-     comp c >>= as_dyn ~at:(c.Location.at) >>= fun x ->
-     Runtime.lookup_dyn x
-
   | Syntax.Ref c ->
      comp c >>= fun v ->
      Runtime.mk_ref v
@@ -197,19 +183,14 @@ let rec comp {Location.it=c'; at} =
   | Syntax.Abstract (x, Some u, c) ->
      comp_as_is_type u >>= fun u ->
      Runtime.add_free x u
-       (fun a ->
-         Reflect.add_abstracting
-           (Nucleus.form_is_term_atom a)
-           begin comp c >>=
-             function
-             | Runtime.Judgement jdg -> Runtime.return_judgement (Nucleus.abstract_judgement a jdg)
+       (fun a -> comp c >>= function
+        | Runtime.Judgement jdg -> Runtime.return_judgement (Nucleus.abstract_judgement a jdg)
 
-             | Runtime.Boundary bdry -> Runtime.return_boundary (Nucleus.abstract_boundary a bdry)
+        | Runtime.Boundary bdry -> Runtime.return_boundary (Nucleus.abstract_boundary a bdry)
 
-             | Runtime.(Derivation _ | Closure _ | Handler _ | Tag _ | Tuple _ | Ref _ | Dyn _ | String _) as v ->
-                Runtime.(error ~at (JudgementOrBoundaryExpected v))
-           end)
-  
+        | Runtime.(Derivation _ | Closure _ | Handler _ | Tag _ | Tuple _ | Ref _ | String _) as v ->
+           Runtime.(error ~at (JudgementOrBoundaryExpected v)))
+
   | Syntax.AbstractAtom (a, c) ->
      comp_as_atom a >>= fun a ->
            begin comp c >>=
@@ -218,7 +199,7 @@ let rec comp {Location.it=c'; at} =
 
              | Runtime.Boundary bdry -> Runtime.return_boundary (Nucleus.abstract_boundary a bdry)
 
-             | Runtime.(Closure _ | Derivation _| Handler _ | Tag _ | Tuple _ | Ref _ | Dyn _ | String _) as v ->
+             | Runtime.(Closure _ | Derivation _| Handler _ | Tag _ | Tuple _ | Ref _ | String _) as v ->
                 Runtime.(error ~at (JudgementOrBoundaryExpected v))
            end
 
@@ -279,7 +260,7 @@ let rec comp {Location.it=c'; at} =
       | Runtime.Closure f ->
         comp c2 >>= fun v ->
         Runtime.apply_closure f v
-      | Runtime.(Judgement _ | Boundary _ | Derivation _ | Handler _ | Tag _ | Tuple _ | Ref _ | Dyn _ | String _) as h ->
+      | Runtime.(Judgement _ | Boundary _ | Derivation _ | Handler _ | Tag _ | Tuple _ | Ref _ | String _) as h ->
         Runtime.(error ~at (Inapplicable h))
     end
 
@@ -383,7 +364,6 @@ and check_judgement ({Location.it=c'; at} as c) bdry =
   | Syntax.Update _
   | Syntax.Fresh _
   | Syntax.AbstractAtom _
-  | Syntax.Current _
   | Syntax.String _
   | Syntax.Occurs _
   | Syntax.Congruence _
@@ -420,12 +400,6 @@ and check_judgement ({Location.it=c'; at} as c) bdry =
 
   | Syntax.LetRec (fxcs, c) ->
      letrec_bind fxcs (check_judgement c bdry)
-
-  | Syntax.Now (x,c1,c2) ->
-     let xloc = x.Location.at in
-     comp x >>= as_dyn ~at:xloc >>= fun x ->
-     comp c1 >>= fun v ->
-     Runtime.now x v (check_judgement c2 bdry)
 
   | Syntax.Match (c, cases) ->
      comp c >>=
@@ -652,8 +626,6 @@ and local_context lctx cmp =
        comp_as_is_type c >>= fun t ->
        Runtime.add_free x t
          (fun a ->
-            Reflect.add_abstracting
-              (Nucleus.form_is_term_atom a)
               (fold lctx >>= fun abstr ->
                return (Nucleus.abstract_boundary a abstr)
          ))
@@ -807,17 +779,6 @@ let rec toplevel ~quiet ~print_annot {Location.it=c; at} =
            (print_annot () sch)
            (Runtime.print_value ~penv v) ;
      return ()
-
-  | Syntax.TopDynamic (x, annot, c) ->
-     comp_value c >>= fun v ->
-     Runtime.add_dynamic x v
-
-  | Syntax.TopNow (x,c) ->
-     let xloc = x.Location.at in
-     comp_value x >>= fun x ->
-     let x = Runtime.as_dyn ~at:xloc x in
-     comp_value c >>= fun v ->
-     Runtime.top_now x v
 
   | Syntax.Open pth ->
      Runtime.top_open_path pth

--- a/src/runtime/eval.ml
+++ b/src/runtime/eval.ml
@@ -97,7 +97,7 @@ let rec comp {Location.it=c'; at} =
       in
       fold [] cs
 
-    | Syntax.Handler {Syntax.handler_val; handler_ops; handler_finally} ->
+    | Syntax.(Handler {handler_val; handler_ops}) ->
         let handler_val =
           begin match handler_val with
           | [] -> None
@@ -113,17 +113,8 @@ let rec comp {Location.it=c'; at} =
             in
             f)
           handler_ops
-        and handler_finally =
-          begin match handler_finally with
-          | [] -> None
-          | _ :: _ ->
-            let f v =
-              match_cases ~at handler_finally comp v
-            in
-            Some f
-          end
         in
-        Runtime.return_handler handler_val handler_ops handler_finally
+        Runtime.return_handler handler_val handler_ops
 
   | Syntax.Operation (op, cs) ->
      let rec fold vs = function

--- a/src/runtime/eval.ml
+++ b/src/runtime/eval.ml
@@ -162,10 +162,6 @@ let rec comp {Location.it=c'; at} =
      let exc = Runtime.as_exception ~at v in
      Runtime.raise_exception exc
 
-  | Syntax.Try (c, hnd) ->
-     let hnd = exception_handler ~at comp hnd in
-     Runtime.try_with hnd (comp c)
-
   | Syntax.Fresh (xopt, c) ->
      comp_as_is_type c >>= fun t ->
      let x = match xopt with Some x -> x | None -> Name.mk_name "x" in
@@ -397,10 +393,6 @@ and check_judgement ({Location.it=c'; at} as c) bdry =
           fold (v :: vs) cs
      in
      fold [] cs
-
-  | Syntax.Try (c, hnd) ->
-     let hnd = exception_handler ~at (fun c -> check_judgement c bdry) hnd in
-     Runtime.try_with hnd (check_judgement c bdry)
 
   | Syntax.Let (xcs, c) ->
      let_bind ~at xcs (check_judgement c bdry)

--- a/src/runtime/eval.ml
+++ b/src/runtime/eval.ml
@@ -97,7 +97,7 @@ let rec comp {Location.it=c'; at} =
       in
       fold [] cs
 
-    | Syntax.(Handler {handler_val; handler_ops}) ->
+    | Syntax.(Handler {handler_val; handler_ops; handler_exc}) ->
         let handler_val =
           begin match handler_val with
           | [] -> None
@@ -113,8 +113,9 @@ let rec comp {Location.it=c'; at} =
             in
             f)
           handler_ops
+        and handler_exc = exception_handler ~at comp handler_exc
         in
-        Runtime.return_handler handler_val handler_ops
+        Runtime.return_handler handler_val handler_ops handler_exc
 
   | Syntax.Operation (op, cs) ->
      let rec fold vs = function

--- a/src/runtime/eval.ml
+++ b/src/runtime/eval.ml
@@ -251,10 +251,6 @@ let rec comp {Location.it=c'; at} =
      let drv = Nucleus.form_derivation prems concl in
      Runtime.return (Runtime.Derivation drv)
 
-  | Syntax.Yield c ->
-    comp c >>= fun v ->
-    Runtime.continue v
-
   | Syntax.Apply (c1, c2) ->
     comp c1 >>= begin function
       | Runtime.Closure f ->
@@ -357,7 +353,6 @@ and check_judgement ({Location.it=c'; at} as c) bdry =
   | Syntax.TTApply _
   | Syntax.Tuple _
   | Syntax.With _
-  | Syntax.Yield _
   | Syntax.Apply _
   | Syntax.Ref _
   | Syntax.Lookup _

--- a/src/runtime/matching.ml
+++ b/src/runtime/matching.ml
@@ -154,22 +154,22 @@ let rec collect_pattern sgn xvs {Location.it=p'; at} v =
 
   (* mismatches *)
   | Syntax.Patt_MLConstructor _,
-    Runtime.(Judgement _ | Boundary _ | Derivation _ | Closure _ | Handler _ | Ref _ | Dyn _ | Tuple _ | String _)
+    Runtime.(Judgement _ | Boundary _ | Derivation _ | Closure _ | Handler _ | Ref _ | Tuple _ | String _)
 
   | Syntax.Patt_Abstract _,
-    Runtime.(Derivation _ | Closure _ | Handler _ | Tag _ | Ref _ | Dyn _ | Tuple _ | String _)
+    Runtime.(Derivation _ | Closure _ | Handler _ | Tag _ | Ref _ | Tuple _ | String _)
 
   | Syntax.(Patt_TTConstructor _ | Patt_GenAtom _ | Patt_IsType _ | Patt_IsTerm _ | Patt_EqType _ | Patt_EqTerm _),
-    Runtime.(Boundary _ | Derivation _ | Closure _ | Handler _ | Tag _ | Ref _ | Dyn _ | Tuple _ | String _)
+    Runtime.(Boundary _ | Derivation _ | Closure _ | Handler _ | Tag _ | Ref _ | Tuple _ | String _)
 
   | Syntax.(Patt_BoundaryIsType | Patt_BoundaryIsTerm _ | Patt_BoundaryEqType _ | Patt_BoundaryEqTerm _) ,
-    Runtime.(Judgement _ | Derivation _  | Closure _ | Handler _ | Tag _ | Ref _ | Dyn _ | Tuple _ | String _)
+    Runtime.(Judgement _ | Derivation _  | Closure _ | Handler _ | Tag _ | Ref _ | Tuple _ | String _)
 
   | Syntax.Patt_Tuple _,
-    Runtime.(Judgement _ | Boundary _ | Derivation _ | Closure _ | Handler _ | Tag _ | Ref _ | Dyn _ | String _)
+    Runtime.(Judgement _ | Boundary _ | Derivation _ | Closure _ | Handler _ | Tag _ | Ref _ | String _)
 
   | Syntax.Patt_String _,
-    Runtime.(Judgement _ | Boundary _ | Derivation _ | Closure _ | Handler _ | Tag _ | Ref _ | Dyn _ | Tuple _) ->
+    Runtime.(Judgement _ | Boundary _ | Derivation _ | Closure _ | Handler _ | Tag _ | Ref _ | Tuple _) ->
      Runtime.(error ~at (InvalidPatternMatch v))
 
 and collect_judgement sgn xvs p abstr =

--- a/src/runtime/reflect.ml
+++ b/src/runtime/reflect.ml
@@ -43,7 +43,7 @@ let as_option ~at = function
   | Runtime.Tag (t, []) when (Runtime.equal_tag t tag_none)  -> None
   | Runtime.Tag (t, [x]) when (Runtime.equal_tag t tag_some) -> Some x
   | Runtime.(Judgement _ | Boundary _ | Derivation _ | Closure _ | Handler _ |
-             Tag _ | Tuple _ | Ref _ | String _) as v ->
+             Exc _ | Tag _ | Tuple _ | Ref _ | String _) as v ->
      Runtime.(error ~at (OptionExpected v))
 
 let as_judgement_option ~at v =
@@ -51,7 +51,7 @@ let as_judgement_option ~at v =
   | None -> None
   | Some (Runtime.Judgement jdg) -> Some jdg
   | Some (Runtime.(Boundary _ | Closure _ | Derivation _ |
-          Handler _ | Tag _ | Tuple _ | Ref _ | String _) as v) ->
+          Handler _ | Exc _ | Tag _ | Tuple _ | Ref _ | String _) as v) ->
      Runtime.(error ~at (JudgementExpected v))
 
 (** Conversion between OCaml coercible and ML coercible *)

--- a/src/runtime/reflect.ml
+++ b/src/runtime/reflect.ml
@@ -43,7 +43,7 @@ let as_option ~at = function
   | Runtime.Tag (t, []) when (Runtime.equal_tag t tag_none)  -> None
   | Runtime.Tag (t, [x]) when (Runtime.equal_tag t tag_some) -> Some x
   | Runtime.(Judgement _ | Boundary _ | Derivation _ | Closure _ | Handler _ |
-             Tag _ | Tuple _ | Ref _ | Dyn _ | String _) as v ->
+             Tag _ | Tuple _ | Ref _ | String _) as v ->
      Runtime.(error ~at (OptionExpected v))
 
 let as_judgement_option ~at v =
@@ -51,7 +51,7 @@ let as_judgement_option ~at v =
   | None -> None
   | Some (Runtime.Judgement jdg) -> Some jdg
   | Some (Runtime.(Boundary _ | Closure _ | Derivation _ |
-          Handler _ | Tag _ | Tuple _ | Ref _ | Dyn _ | String _) as v) ->
+          Handler _ | Tag _ | Tuple _ | Ref _ | String _) as v) ->
      Runtime.(error ~at (JudgementExpected v))
 
 (** Conversion between OCaml coercible and ML coercible *)
@@ -96,14 +96,3 @@ let operation_coerce ~at jdg bdry =
   and v2 = Runtime.Boundary bdry in
   Runtime.operation coerce [v1;v2] >>= fun v ->
   return (as_judgement_option ~at v)
-
-let add_abstracting e m =
-  (* The given variable as an ML value *)
-  let v = Runtime.mk_judgement (Nucleus.(abstract_not_abstract (JudgementIsTerm e))) in
-  (* Get the ML list of [hypotheses] *)
-  Runtime.hypotheses >>= fun hyps_dyn ->
-  Runtime.lookup_dyn hyps_dyn >>= fun hyps ->
-  (* Add v to the front of that ML list *)
-  let hyps = list_cons v hyps in
-  (* Run computation m in this dynamic scope *)
-  Runtime.now hyps_dyn hyps m

--- a/src/runtime/reflect.mli
+++ b/src/runtime/reflect.mli
@@ -31,6 +31,3 @@ val operation_equal_type :
  *)
 val operation_coerce :
   at:Location.t -> Nucleus.judgement_abstraction -> Nucleus.boundary_abstraction -> Nucleus.judgement_abstraction option Runtime.comp
-
-(** A hack which will probably disappear: add an atom to the dynamic variable [hypotheses] *)
-val add_abstracting : Nucleus.is_term -> 'a Runtime.comp -> 'a Runtime.comp

--- a/src/runtime/runtime.ml
+++ b/src/runtime/runtime.ml
@@ -316,17 +316,6 @@ let return x _env = Return x
 
 let raise_exception exc _env = Exception exc
 
-let rec try_with hnd c env =
-  match c env with
-    | Return _ as r -> r
-
-    | Exception exc -> hnd exc env
-
-    | Operation ({op_cont={cont_val; cont_exc};_} as op_data) ->
-       let cont_val = fun v -> try_with hnd (cont_val v)
-       and cont_exc = fun exc -> try_with hnd (cont_exc exc) in
-       Operation {op_data with op_cont = {cont_val; cont_exc}}
-
 let return_judgement jdg = return (Judgement jdg)
 
 let return_boundary bdry = return (Boundary bdry)

--- a/src/runtime/runtime.ml
+++ b/src/runtime/runtime.ml
@@ -867,7 +867,7 @@ let rec handle_comp {handler_val; handler_ops; handler_finally} (r : value comp)
      begin
        try
          let f = Ident.find op handler_ops in
-         (apply_closure f {args=vs;checking=jt}) env
+         ((apply_closure f {args=vs;checking=jt}) >>= (fun v -> apply_cont cont v)) env
        with
          Not_found ->
            Operation (op, vs, jt, dynamic, cont), env.state

--- a/src/runtime/runtime.ml
+++ b/src/runtime/runtime.ml
@@ -196,7 +196,8 @@ and handler = {
   handler_finally: (value,value) closure option;
 }
 
-and 'a continuation = Continuation of (value -> state -> 'a result * state)
+and 'a continuation =
+  { cont_val : value -> state -> 'a result * state }
 
 type 'a toplevel = env -> 'a * env
 
@@ -260,8 +261,8 @@ let mk_closure f = Closure (Clos f)
 
 let apply_closure (Clos f) v env = f v env
 
-let mk_cont f env = Continuation (fun v state -> f v {env with state})
-let apply_cont (Continuation f) v {state;_} = f v state
+let mk_cont f env = {cont_val = fun v state -> f v {env with state}}
+let apply_cont {cont_val=f} v {state;_} = f v state
 
 (** References *)
 let mk_ref v env =

--- a/src/runtime/runtime.mli
+++ b/src/runtime/runtime.mli
@@ -17,10 +17,13 @@ type value =
   | Derivation of Nucleus.derivation           (** A hypothetical derivation *)
   | Closure of (value,value) closure           (** An ML function *)
   | Handler of handler                         (** Handler value *)
+  | Exc of exc                                 (** An exception *)
   | Tag of ml_constructor * value list         (** Application of a data constructor *)
   | Tuple of value list                        (** Tuple of values *)
   | Ref of value ref                           (** Ref cell *)
   | String of string                           (** String constant (opaque, not a list) *)
+
+and exc = Ident.t * value option
 
 and operation_args = { args : value list; checking : Nucleus.boundary_abstraction option }
 
@@ -105,6 +108,9 @@ val as_closure : at:Location.t -> value -> (value,value) closure
 (** Convert, or fail with [HandlerExpected] *)
 val as_handler : at:Location.t -> value -> handler
 
+(** Convert, or fail with [ExceptionExpected] *)
+val as_exception : at:Location.t -> value -> exc
+
 (** Convert, or fail with [RefExpected] *)
 val as_ref : at:Location.t -> value -> value ref
 
@@ -164,6 +170,7 @@ type error =
   | ClosureExpected of value
   | HandlerExpected of value
   | RefExpected of value
+  | ExceptionExpected of value
   | StringExpected of value
   | CoercibleExpected of value
   | InvalidConvert of Nucleus.judgement_abstraction * Nucleus.eq_type_abstraction
@@ -197,8 +204,10 @@ val bind: 'a comp -> ('a -> 'b comp)  -> 'b comp
 (** Return a value *)
 val return : 'a -> 'a comp
 
-(** Throw an exception *)
-val throw : Ident.t -> value option -> 'a comp
+val raise_exception : exc -> 'a comp
+
+(** Handle exceptions *)
+val try_with : (exc -> 'a comp) -> 'a comp -> 'a comp
 
 (** {b Monadic shorthand} *)
 

--- a/src/runtime/runtime.mli
+++ b/src/runtime/runtime.mli
@@ -11,9 +11,6 @@ type coercible =
 (** An ML reference cell. *)
 type ml_ref
 
-(** An ML dynamic variable. *)
-type ml_dyn
-
 type ml_constructor = Ident.t
 
 (** values are "finished" or "computed". They are inert pieces of data. *)
@@ -26,7 +23,6 @@ type value =
   | Tag of ml_constructor * value list         (** Application of a data constructor *)
   | Tuple of value list                        (** Tuple of values *)
   | Ref of ml_ref                              (** Ref cell *)
-  | Dyn of ml_dyn                              (** Dynamic variable *)
   | String of string                           (** String constant (opaque, not a list) *)
 
 and operation_args = { args : value list; checking : Nucleus.boundary_abstraction option }
@@ -115,9 +111,6 @@ val as_handler : at:Location.t -> value -> handler
 (** Convert, or fail with [RefExpected] *)
 val as_ref : at:Location.t -> value -> ml_ref
 
-(** Convert, or fail with [DynExpected] *)
-val as_dyn : at:Location.t -> value -> ml_dyn
-
 (** Convert, or fail with [StringExpected] *)
 val as_string : at:Location.t -> value -> string
 
@@ -174,7 +167,6 @@ type error =
   | ClosureExpected of value
   | HandlerExpected of value
   | RefExpected of value
-  | DynExpected of value
   | StringExpected of value
   | CoercibleExpected of value
   | InvalidConvert of Nucleus.judgement_abstraction * Nucleus.eq_type_abstraction
@@ -241,9 +233,6 @@ val operation : Ident.t -> ?checking:Nucleus.boundary_abstraction -> value list 
 (** Wrap the given computation with a handler. *)
 val handle_comp : handler -> value comp -> value comp
 
-(** Wrap the given computation with a dynamic variable binding. *)
-val now : ml_dyn -> value -> 'a comp -> 'a comp
-
 (** Lookup the current continuation. Only usable while handling an operation. *)
 val continue : value -> value comp
 
@@ -272,9 +261,6 @@ val lookup_bound : Path.index -> value comp
 (** Lookup a value *)
 val lookup_ml_value : Path.t -> value comp
 
-(** Lookup the current value of a dynamic variable. *)
-val lookup_dyn : ml_dyn -> value comp
-
 (** {6 Toplevel} *)
 
 (** state environment, no operations *)
@@ -300,12 +286,6 @@ val add_ml_value : value -> unit toplevel
 
 (** Add a list of mutually recursive definitions to the toplevel environment. *)
 val add_ml_value_rec : (value -> value comp) list -> unit toplevel
-
-(** Add a dynamic variable. *)
-val add_dynamic : Name.t -> value -> unit toplevel
-
-(** Modify the value bound by a dynamic variable *)
-val top_now : ml_dyn -> value -> unit toplevel
 
 (** Extend the signature with a new rule *)
 val add_rule : Ident.t -> Nucleus.primitive -> unit toplevel
@@ -357,9 +337,6 @@ val with_env : env -> 'a comp -> 'a comp
 val top_get_env : env toplevel
 
 val get_signature : env -> Nucleus.signature
-
-(** Get the [hypotheses]. *)
-val hypotheses : ml_dyn comp
 
 (** For matching *)
 val get_bound : Path.index -> env -> value

--- a/src/runtime/runtime.mli
+++ b/src/runtime/runtime.mli
@@ -222,6 +222,7 @@ val return_closure : (value -> value comp) -> value comp
 val return_handler :
    (value -> value comp) option ->
    (operation_args -> value comp) Ident.map ->
+   (exc -> value comp) ->
    value comp
 
 (** {b Monadic interface} *)

--- a/src/runtime/runtime.mli
+++ b/src/runtime/runtime.mli
@@ -222,7 +222,6 @@ val return_closure : (value -> value comp) -> value comp
 val return_handler :
    (value -> value comp) option ->
    (operation_args -> value comp) Ident.map ->
-   (value -> value comp) option ->
    value comp
 
 (** {b Monadic interface} *)

--- a/src/runtime/runtime.mli
+++ b/src/runtime/runtime.mli
@@ -206,9 +206,6 @@ val return : 'a -> 'a comp
 
 val raise_exception : exc -> 'a comp
 
-(** Handle exceptions *)
-val try_with : (exc -> 'a comp) -> 'a comp -> 'a comp
-
 (** {b Monadic shorthand} *)
 
 val return_unit : value comp

--- a/src/runtime/runtime.mli
+++ b/src/runtime/runtime.mli
@@ -233,9 +233,6 @@ val operation : Ident.t -> ?checking:Nucleus.boundary_abstraction -> value list 
 (** Wrap the given computation with a handler. *)
 val handle_comp : handler -> value comp -> value comp
 
-(** Lookup the current continuation. Only usable while handling an operation. *)
-val continue : value -> value comp
-
 (** Get the printing environment *)
 val lookup_penv : penv comp
 

--- a/src/runtime/runtime.mli
+++ b/src/runtime/runtime.mli
@@ -8,9 +8,6 @@ type coercible =
   | Convertible of Nucleus.eq_type_abstraction
   | Coercible of Nucleus.is_term_abstraction
 
-(** An ML reference cell. *)
-type ml_ref
-
 type ml_constructor = Ident.t
 
 (** values are "finished" or "computed". They are inert pieces of data. *)
@@ -22,7 +19,7 @@ type value =
   | Handler of handler                         (** Handler value *)
   | Tag of ml_constructor * value list         (** Application of a data constructor *)
   | Tuple of value list                        (** Tuple of values *)
-  | Ref of ml_ref                              (** Ref cell *)
+  | Ref of value ref                           (** Ref cell *)
   | String of string                           (** String constant (opaque, not a list) *)
 
 and operation_args = { args : value list; checking : Nucleus.boundary_abstraction option }
@@ -109,7 +106,7 @@ val as_closure : at:Location.t -> value -> (value,value) closure
 val as_handler : at:Location.t -> value -> handler
 
 (** Convert, or fail with [RefExpected] *)
-val as_ref : at:Location.t -> value -> ml_ref
+val as_ref : at:Location.t -> value -> value ref
 
 (** Convert, or fail with [StringExpected] *)
 val as_string : at:Location.t -> value -> string
@@ -222,10 +219,10 @@ val apply_closure : ('a,'b) closure -> 'a -> 'b comp
 val mk_ref : value -> value comp
 
 (** A computation that dereferences the given reference cell. *)
-val lookup_ref : ml_ref -> value comp
+val lookup_ref : value ref -> value comp
 
 (** A computation that updates the given reference cell with the given value. *)
-val update_ref : ml_ref -> value -> unit comp
+val update_ref : value ref -> value -> unit comp
 
 (** A computation that invokes the specified operation. *)
 val operation : Ident.t -> ?checking:Nucleus.boundary_abstraction -> value list -> value comp

--- a/src/runtime/runtime.mli
+++ b/src/runtime/runtime.mli
@@ -169,6 +169,7 @@ type error =
   | InvalidConvert of Nucleus.judgement_abstraction * Nucleus.eq_type_abstraction
   | InvalidCoerce of Nucleus.judgement_abstraction * Nucleus.boundary_abstraction
   | UnhandledOperation of Ident.t * value list
+  | UncaughtException of Ident.t * value option
   | InvalidPatternMatch of value
 
 (** The exception that is raised on runtime error *)
@@ -190,9 +191,14 @@ val mk_closure : (value -> value comp) -> value
 
 (** {b Monadic structure} *)
 
+(** Monadic bind *)
 val bind: 'a comp -> ('a -> 'b comp)  -> 'b comp
+
+(** Return a value *)
 val return : 'a -> 'a comp
 
+(** Throw an exception *)
+val throw : Ident.t -> value option -> 'a comp
 
 (** {b Monadic shorthand} *)
 
@@ -203,6 +209,7 @@ val return_judgement : Nucleus.judgement_abstraction -> value comp
 val return_boundary : Nucleus.boundary_abstraction -> value comp
 
 val return_closure : (value -> value comp) -> value comp
+
 val return_handler :
    (value -> value comp) option ->
    (operation_args -> value comp) Ident.map ->

--- a/src/syntax/desugared.mli
+++ b/src/syntax/desugared.mli
@@ -77,7 +77,6 @@ and comp' =
   | AbstractAtom of comp * comp
   | Substitute of comp * comp
   | Derive of premise list * comp
-  | Yield of comp
   | String of string
   | Occurs of comp * comp
   | Congruence of comp * comp * comp list

--- a/src/syntax/desugared.mli
+++ b/src/syntax/desugared.mli
@@ -60,6 +60,9 @@ and comp' =
   | Tuple of comp list
   | Operation of Path.t * comp list
   | With of comp * comp
+  | MLException of Path.t * comp option
+  | Raise of comp
+  | Try of comp * exception_case list
   | Let of let_clause list * comp
   | LetRec of letrec_clause list * comp
   | MLAscribe of comp * ml_schema
@@ -103,6 +106,10 @@ and handler = {
   handler_finally : match_case list;
 }
 
+and exception_case =
+  | ExceptionCaseSimple of Path.t * comp
+  | ExceptionCasePattern of Path.t * match_case
+
 and match_case = pattern * comp option * comp
 
 (** Match multiple patterns at once, with shared pattern variables *)
@@ -124,6 +131,7 @@ and toplevel' =
   | DefMLType of (Path.t * (Name.t option list * ml_tydef)) list
   | DefMLTypeRec of (Path.t * (Name.t option list * ml_tydef)) list
   | DeclOperation of Path.t * (ml_ty list * ml_ty)
+  | DeclException of Path.t * ml_ty option
   | DeclExternal of Name.t * ml_schema * string
   | TopLet of let_clause list
   | TopLetRec of letrec_clause list

--- a/src/syntax/desugared.mli
+++ b/src/syntax/desugared.mli
@@ -102,9 +102,8 @@ and letrec_clause =
   | Letrec_clause of Name.t * (Name.t * arg_annotation) * let_annotation * comp
 
 and handler = {
-  handler_val: match_case list;
-  handler_ops: (Path.t * match_op_case list) list ;
-  handler_finally : match_case list;
+  handler_val: match_case list ;
+  handler_ops: (Path.t * match_op_case list) list
 }
 
 and match_case = pattern * comp option * comp

--- a/src/syntax/desugared.mli
+++ b/src/syntax/desugared.mli
@@ -63,7 +63,7 @@ and comp' =
   | With of comp * comp
   | MLException of Path.t * comp option
   | Raise of comp
-  | Try of comp * match_case list
+  | Try of comp * exception_case list
   | Let of let_clause list * comp
   | LetRec of letrec_clause list * comp
   | MLAscribe of comp * ml_schema
@@ -103,10 +103,13 @@ and letrec_clause =
 
 and handler = {
   handler_val: match_case list ;
-  handler_ops: (Path.t * match_op_case list) list
+  handler_ops: (Path.t * match_op_case list) list ;
+  handler_exc : exception_case list
 }
 
 and match_case = pattern * comp option * comp
+
+and exception_case = match_case
 
 (** Match multiple patterns at once, with shared pattern variables *)
 and match_op_case = pattern list * pattern option * comp

--- a/src/syntax/desugared.mli
+++ b/src/syntax/desugared.mli
@@ -63,8 +63,6 @@ and comp' =
   | Let of let_clause list * comp
   | LetRec of letrec_clause list * comp
   | MLAscribe of comp * ml_schema
-  | Now of comp * comp * comp
-  | Current of comp
   | Lookup of comp
   | Update of comp * comp
   | Ref of comp
@@ -131,8 +129,6 @@ and toplevel' =
   | TopLet of let_clause list
   | TopLetRec of letrec_clause list
   | TopComputation of comp
-  | TopDynamic of Name.t * arg_annotation * comp
-  | TopNow of comp * comp
   | Verbosity of int
   | Open of Path.t
   | MLModule of Name.t * toplevel list

--- a/src/syntax/desugared.mli
+++ b/src/syntax/desugared.mli
@@ -9,7 +9,7 @@ and ml_ty' =
   | ML_Apply of Path.t * ml_ty list
   | ML_Handler of ml_ty * ml_ty
   | ML_Ref of ml_ty
-  | ML_Dynamic of ml_ty
+  | ML_Exn
   | ML_Judgement
   | ML_Boundary
   | ML_Derivation
@@ -46,6 +46,7 @@ and pattern' =
   | Patt_BoundaryEqType of pattern * pattern
   | Patt_BoundaryEqTerm of pattern * pattern * pattern
   | Patt_MLConstructor of Path.ml_constructor * pattern list
+  | Patt_MLException of Path.t * pattern option
   | Patt_Tuple of pattern list
   | Patt_String of string
 
@@ -62,7 +63,7 @@ and comp' =
   | With of comp * comp
   | MLException of Path.t * comp option
   | Raise of comp
-  | Try of comp * exception_case list
+  | Try of comp * match_case list
   | Let of let_clause list * comp
   | LetRec of letrec_clause list * comp
   | MLAscribe of comp * ml_schema
@@ -105,10 +106,6 @@ and handler = {
   handler_ops: (Path.t * match_op_case list) list ;
   handler_finally : match_case list;
 }
-
-and exception_case =
-  | ExceptionCaseSimple of Path.t * comp
-  | ExceptionCasePattern of Path.t * match_case
 
 and match_case = pattern * comp option * comp
 

--- a/src/syntax/desugared.mli
+++ b/src/syntax/desugared.mli
@@ -63,7 +63,6 @@ and comp' =
   | With of comp * comp
   | MLException of Path.t * comp option
   | Raise of comp
-  | Try of comp * exception_case list
   | Let of let_clause list * comp
   | LetRec of letrec_clause list * comp
   | MLAscribe of comp * ml_schema

--- a/src/syntax/sugared.mli
+++ b/src/syntax/sugared.mli
@@ -73,7 +73,6 @@ and comp' =
   | Handle of comp * handle_case list
   | With of comp * comp
   | Raise of comp
-  | Try of comp * match_case list
   | List of comp list
   | Tuple of comp list
   | Match of comp * match_case list

--- a/src/syntax/sugared.mli
+++ b/src/syntax/sugared.mli
@@ -19,7 +19,7 @@ and ml_ty' =
   | ML_TyApply of path * ml_ty list
   | ML_Handler of ml_ty * ml_ty
   | ML_Ref of ml_ty
-  | ML_Dynamic of ml_ty
+  | ML_Exn
   | ML_Judgement
   | ML_Boundary
   | ML_Derivation
@@ -73,7 +73,7 @@ and comp' =
   | Handle of comp * handle_case list
   | With of comp * comp
   | Raise of comp
-  | Try of comp * exception_case list
+  | Try of comp * match_case list
   | List of comp list
   | Tuple of comp list
   | Match of comp * match_case list
@@ -117,10 +117,6 @@ and handle_case =
   | CaseVal of match_case (* val p -> c *)
   | CaseOp of path * match_op_case (* op p1 ... pn -> c *)
   | CaseFinally of match_case (* finally p -> c *)
-
-and exception_case =
-  | ExceptionCaseSimple of path * comp
-  | ExceptionCasePattern of path * match_case
 
 and match_case = pattern * comp option * comp
 

--- a/src/syntax/sugared.mli
+++ b/src/syntax/sugared.mli
@@ -72,6 +72,8 @@ and comp' =
   | Handler of handle_case list
   | Handle of comp * handle_case list
   | With of comp * comp
+  | Raise of comp
+  | Try of comp * exception_case list
   | List of comp list
   | Tuple of comp list
   | Match of comp * match_case list
@@ -86,8 +88,6 @@ and comp' =
   | BoundaryAscribe of comp * comp
   | TypeAscribe of comp * comp
   | Abstract of (Name.t * comp option) list * comp
-  (* Multi-argument substitutions are *not* treated as parallel substitutions
-     but desugared to consecutive substitutions. *)
   | AbstractAtom of comp * comp
   | Substitute of comp * comp list
   | Derive of premise list * comp
@@ -112,11 +112,15 @@ and let_clause =
    (irrefutable) pattern. Thus, [ml_arg] should be defined using patterns in place of variable names. *)
 and letrec_clause = Name.t * ml_arg * ml_arg list * let_annotation * comp
 
-(** Handle cases *)
+(** Handler cases *)
 and handle_case =
   | CaseVal of match_case (* val p -> c *)
   | CaseOp of path * match_op_case (* op p1 ... pn -> c *)
   | CaseFinally of match_case (* finally p -> c *)
+
+and exception_case =
+  | ExceptionCaseSimple of path * comp
+  | ExceptionCasePattern of path * match_case
 
 and match_case = pattern * comp option * comp
 
@@ -147,6 +151,7 @@ and toplevel' =
   | DefMLType of (Name.t * (Name.t option list * ml_tydef)) list
   | DefMLTypeRec of (Name.t * (Name.t option list * ml_tydef)) list
   | DeclOperation of Name.t * (ml_ty list * ml_ty)
+  | DeclException of Name.t * ml_ty option
   | DeclExternal of Name.t * ml_schema * string
   | TopLet of let_clause list
   | TopLetRec of letrec_clause list

--- a/src/syntax/sugared.mli
+++ b/src/syntax/sugared.mli
@@ -70,7 +70,7 @@ and comp' =
   | Name of path
   | Function of ml_arg list * comp
   | Handler of handle_case list
-  | Handle of comp * handle_case list
+  | Try of comp * handle_case list
   | With of comp * comp
   | Raise of comp
   | List of comp list

--- a/src/syntax/sugared.mli
+++ b/src/syntax/sugared.mli
@@ -78,8 +78,6 @@ and comp' =
   | Let of let_clause list  * comp
   | LetRec of letrec_clause list * comp
   | MLAscribe of comp * ml_schema
-  | Now of comp * comp * comp
-  | Current of comp
   | Lookup of comp
   | Update of comp * comp
   | Ref of comp
@@ -154,8 +152,6 @@ and toplevel' =
   | TopLet of let_clause list
   | TopLetRec of letrec_clause list
   | TopComputation of comp
-  | TopDynamic of Name.t * arg_annotation * comp
-  | TopNow of comp * comp
   | Verbosity of int
   | Require of Name.t list
   | Include of path

--- a/src/syntax/sugared.mli
+++ b/src/syntax/sugared.mli
@@ -116,7 +116,6 @@ and letrec_clause = Name.t * ml_arg * ml_arg list * let_annotation * comp
 and handle_case =
   | CaseVal of match_case (* val p -> c *)
   | CaseOp of path * match_op_case (* op p1 ... pn -> c *)
-  | CaseFinally of match_case (* finally p -> c *)
 
 and match_case = pattern * comp option * comp
 

--- a/src/syntax/sugared.mli
+++ b/src/syntax/sugared.mli
@@ -116,8 +116,11 @@ and letrec_clause = Name.t * ml_arg * ml_arg list * let_annotation * comp
 and handle_case =
   | CaseVal of match_case (* val p -> c *)
   | CaseOp of path * match_op_case (* op p1 ... pn -> c *)
+  | CaseExc of exception_case (* raise p -> c *)
 
 and match_case = pattern * comp option * comp
+
+and exception_case = match_case
 
 and match_op_case = pattern list * pattern option * comp
 

--- a/src/syntax/sugared.mli
+++ b/src/syntax/sugared.mli
@@ -92,7 +92,6 @@ and comp' =
   | Substitute of comp * comp list
   | Derive of premise list * comp
   | Spine of comp * comp list
-  | Yield of comp
   | String of string
   | Congruence of comp * comp * comp list
   | Context of comp

--- a/src/syntax/syntax.mli
+++ b/src/syntax/syntax.mli
@@ -57,7 +57,6 @@ and comp' =
   | Update of comp * comp
   | Ref of comp
   | Sequence of comp * comp
-  | Try of comp * exception_case list
   | Raise of comp
   | Fresh of Name.t option * comp
   | Match of comp * match_case list

--- a/src/syntax/syntax.mli
+++ b/src/syntax/syntax.mli
@@ -5,6 +5,9 @@ type ml_constructor = Ident.t
 (** An operation is referred to by a unique identifier *)
 type operation = Ident.t
 
+(** An exception is referred to by a unique identifier *)
+type exc = Ident.t
+
 (** A rule/constructor is referred to by a unique identifier *)
 type tt_constructor = Ident.t
 
@@ -28,6 +31,7 @@ and pattern' =
   | Patt_BoundaryIsTerm of pattern
   | Patt_BoundaryEqType of pattern * pattern
   | Patt_BoundaryEqTerm of pattern * pattern * pattern
+  | Patt_MLException of exc * pattern option
   | Patt_MLConstructor of ml_constructor * pattern list
   | Patt_Tuple of pattern list
   | Patt_String of string
@@ -49,6 +53,8 @@ and comp' =
   | Update of comp * comp
   | Ref of comp
   | Sequence of comp * comp
+  | Try of comp * exception_cases Ident.map
+  | Raise of comp
   | Fresh of Name.t option * comp
   | Match of comp * match_case list
   | BoundaryAscribe of comp * comp
@@ -91,6 +97,10 @@ and handler = {
   handler_ops: match_op_case list Ident.map;
   handler_finally : match_case list;
 }
+
+and exception_cases =
+  | ExceptionCaseSimple of comp
+  | ExceptionCasePattern of match_case list
 
 and match_case = pattern * comp option * comp
 

--- a/src/syntax/syntax.mli
+++ b/src/syntax/syntax.mli
@@ -60,7 +60,6 @@ and comp' =
   | AbstractAtom of comp * comp
   | Substitute of comp * comp
   | Derive of premise list * comp
-  | Yield of comp
   | String of string
   | Occurs of comp * comp
   | Congruence of comp * comp * comp list

--- a/src/syntax/syntax.mli
+++ b/src/syntax/syntax.mli
@@ -98,8 +98,7 @@ and letrec_clause =
 
 and handler = {
   handler_val: match_case list;
-  handler_ops: match_op_case list Ident.map;
-  handler_finally : match_case list;
+  handler_ops: match_op_case list Ident.map
 }
 
 and exception_case = match_case

--- a/src/syntax/syntax.mli
+++ b/src/syntax/syntax.mli
@@ -6,6 +6,9 @@ type ml_constructor = Ident.t
 type operation = Ident.t
 
 (** An exception is referred to by a unique identifier *)
+type ml_exception = Ident.t
+
+(** An exception is referred to by a unique identifier *)
 type exc = Ident.t
 
 (** A rule/constructor is referred to by a unique identifier *)
@@ -45,6 +48,7 @@ and comp' =
   | Handler of handler
   | MLConstructor of ml_constructor * comp list
   | Tuple of comp list
+  | MLException of ml_exception * comp option
   | Operation of operation * comp list
   | With of comp * comp
   | Let of let_clause list * comp
@@ -53,7 +57,7 @@ and comp' =
   | Update of comp * comp
   | Ref of comp
   | Sequence of comp * comp
-  | Try of comp * exception_cases Ident.map
+  | Try of comp * exception_case list
   | Raise of comp
   | Fresh of Name.t option * comp
   | Match of comp * match_case list
@@ -98,9 +102,7 @@ and handler = {
   handler_finally : match_case list;
 }
 
-and exception_cases =
-  | ExceptionCaseSimple of comp
-  | ExceptionCasePattern of match_case list
+and exception_case = match_case
 
 and match_case = pattern * comp option * comp
 

--- a/src/syntax/syntax.mli
+++ b/src/syntax/syntax.mli
@@ -97,8 +97,9 @@ and letrec_clause =
   | Letrec_clause of comp
 
 and handler = {
-  handler_val: match_case list;
-  handler_ops: match_op_case list Ident.map
+  handler_val: match_case list ;
+  handler_ops: match_op_case list Ident.map ;
+  handler_exc : exception_case list
 }
 
 and exception_case = match_case

--- a/src/syntax/syntax.mli
+++ b/src/syntax/syntax.mli
@@ -125,6 +125,7 @@ and toplevel' =
   | DefMLType of Path.t list (* we only need the names *)
   | DefMLTypeRec of Path.t list
   | DeclOperation of Path.t * (Mlty.ty list * Mlty.ty)
+  | DeclException of Path.t * Mlty.ty option
   | DeclExternal of Name.t * Mlty.ty_schema * string
   | TopLet of (Name.t * Mlty.ty_schema) list list * let_clause list
   | TopLetRec of (Name.t * Mlty.ty_schema) list * letrec_clause list

--- a/src/syntax/syntax.mli
+++ b/src/syntax/syntax.mli
@@ -45,8 +45,6 @@ and comp' =
   | With of comp * comp
   | Let of let_clause list * comp
   | LetRec of letrec_clause list * comp
-  | Now of comp * comp * comp
-  | Current of comp
   | Lookup of comp
   | Update of comp * comp
   | Ref of comp
@@ -122,8 +120,6 @@ and toplevel' =
   | TopLet of (Name.t * Mlty.ty_schema) list list * let_clause list
   | TopLetRec of (Name.t * Mlty.ty_schema) list * letrec_clause list
   | TopComputation of comp * Mlty.ty_schema
-  | TopDynamic of Name.t * Mlty.ty_schema * comp
-  | TopNow of comp * comp
   | Verbosity of int
   | Open of Path.t
   | MLModule of Name.t * toplevel list

--- a/src/typing/context.ml
+++ b/src/typing/context.ml
@@ -16,11 +16,13 @@ sig
 
   val add_ml_type : Ident.t * Mlty.ty_def -> t -> t
   val add_ml_operation : Ident.t * (Mlty.ty list * Mlty.ty) -> t -> t
+  val add_ml_exception : Ident.t * Mlty.ty option -> t -> t
   val add_tt_constructor : Ident.t -> t -> t
   val add_ml_value : Mlty.ty_schema -> t -> t
 
   val get_ml_type : Path.t -> t -> Ident.t * Mlty.ty_def
   val get_ml_operation : Path.t -> t -> Ident.t * (Mlty.ty list * Mlty.ty)
+  val get_ml_exception : Path.t -> t -> Ident.t * Mlty.ty option
   val get_tt_constructor : Path.t -> t -> Ident.t
   val get_ml_value : Path.t -> t -> Mlty.ty_schema
 
@@ -60,6 +62,7 @@ struct
       ml_modules : ml_module table;
       ml_types : (Ident.t * Mlty.ty_def) table;
       ml_operations : (Ident.t * (Mlty.ty list * Mlty.ty)) table;
+      ml_exceptions : (Ident.t * Mlty.ty option) table;
       tt_constructors : Ident.t table;
       ml_values : Mlty.ty_schema table;
   }
@@ -69,6 +72,7 @@ struct
     { ml_modules = empty;
       ml_types = empty;
       ml_operations = empty;
+      ml_exceptions = empty;
       tt_constructors = empty;
       ml_values = empty
     }
@@ -102,6 +106,9 @@ struct
   let add_ml_operation info =
     at_current (fun mdl -> { mdl with ml_operations = add info mdl.ml_operations })
 
+  let add_ml_exception info =
+    at_current (fun mdl -> { mdl with ml_exceptions = add info mdl.ml_exceptions })
+
   let add_tt_constructor info =
     at_current (fun mdl -> { mdl with tt_constructors = add info mdl.tt_constructors })
 
@@ -127,6 +134,9 @@ struct
 
   let get_ml_operation =
     get_path (fun (Path.Level (_, k)) mdl -> get k mdl.ml_operations)
+
+  let get_ml_exception =
+    get_path (fun (Path.Level (_, k)) mdl -> get k mdl.ml_exceptions)
 
   let get_tt_constructor =
     get_path (fun (Path.Level (_, k)) mdl -> get k mdl.tt_constructors)
@@ -178,6 +188,9 @@ let lookup_ml_value pth ctx =
 let lookup_ml_operation pth ctx =
   SymbolTable.get_ml_operation pth ctx.table
 
+let lookup_ml_exception pth ctx =
+  SymbolTable.get_ml_exception pth ctx.table
+
 let lookup_tt_constructor pth ctx =
   SymbolTable.get_tt_constructor pth ctx.table
 
@@ -206,6 +219,10 @@ let add_ml_type t d ctx =
 let add_ml_operation op opty ctx =
   let op = Ident.create op in
   { ctx with table = SymbolTable.add_ml_operation (op,opty) ctx.table }
+
+let add_ml_exception exc tyopt ctx =
+  let exc = Ident.create exc in
+  { ctx with table = SymbolTable.add_ml_exception (exc, tyopt) ctx.table }
 
 let add_bound name schema ctx =
   { ctx with ml_bound = schema :: ctx.ml_bound }

--- a/src/typing/context.mli
+++ b/src/typing/context.mli
@@ -28,9 +28,6 @@ val lookup_ml_constructor : Path.ml_constructor -> t -> Ident.t * Mlty.ty list *
 (** Lookup the (M)L type of a TT constructor. *)
 val lookup_tt_constructor : Path.t -> t -> Ident.t
 
-(** Lookup the type of the current continuation. *)
-val lookup_continuation : t -> Mlty.ty * Mlty.ty
-
 (** Declare a new TT constructor. *)
 val add_tt_constructor : Ident.t -> t -> t
 
@@ -45,9 +42,6 @@ val add_bound : Name.t -> Mlty.ty_schema -> t -> t
 
 (** Add an ML value with the given schema. *)
 val add_ml_value : Name.t -> Mlty.ty_schema -> t -> t
-
-(** Creates the context for evaluating the operation handling of [op] *)
-val op_cases : Path.t -> output:Mlty.ty -> t -> Ident.t * Mlty.ty list * t
 
 (** Start processing a fresh current module *)
 val push_ml_module : t -> t

--- a/src/typing/context.mli
+++ b/src/typing/context.mli
@@ -22,6 +22,9 @@ val lookup_ml_value : Path.t -> t -> Mlty.ty
 (** Lookup the type of an operation. *)
 val lookup_ml_operation : Path.t -> t -> Ident.t * (Mlty.ty list * Mlty.ty)
 
+(** Lookup the type of an exception. *)
+val lookup_ml_exception : Path.t -> t -> Ident.t * Mlty.ty option
+
 (** Lookup the type of an ML constructor. *)
 val lookup_ml_constructor : Path.ml_constructor -> t -> Ident.t * Mlty.ty list * Mlty.ty
 
@@ -36,6 +39,9 @@ val add_ml_type : Path.t -> Mlty.ty_def -> t -> t
 
 (** Declare a new operation. *)
 val add_ml_operation : Path.t -> Mlty.ty list * Mlty.ty -> t -> t
+
+(** Declare a new exception. *)
+val add_ml_exception : Path.t -> Mlty.ty option -> t -> t
 
 (** Add a locally bound value with the given schema. *)
 val add_bound : Name.t -> Mlty.ty_schema -> t -> t

--- a/src/typing/mlty.mli
+++ b/src/typing/mlty.mli
@@ -28,8 +28,8 @@ type ty =
   | Arrow of ty * ty
   | Handler of ty * ty
   | Apply of Path.t * ty list
+  | Exn
   | Ref of ty
-  | Dynamic of ty
 
 (** The unit type encoded as an empty product. *)
 val unit_ty : ty

--- a/src/typing/substitution.ml
+++ b/src/typing/substitution.ml
@@ -17,6 +17,7 @@ let apply (s : t) t =
   then t
   else begin
       let rec app = function
+        | Mlty.Exn
         | Mlty.Judgement
         | Mlty.Boundary
         | Mlty.Derivation
@@ -51,9 +52,6 @@ let apply (s : t) t =
            let t = app t in
            Mlty.Ref t
 
-        | Mlty.Dynamic t ->
-           let t = app t in
-           Mlty.Dynamic t
       in
       app t
     end

--- a/src/typing/tyenv.ml
+++ b/src/typing/tyenv.ml
@@ -113,8 +113,6 @@ let lookup_ml_constructor c env =
 let lookup_tt_constructor c env =
   return (Context.lookup_tt_constructor c env.context) env
 
-let lookup_continuation env =
-  return (Context.lookup_continuation env.context) env
 
 (* Whnf for meta instantiations and type aliases *)
 let rec whnf ctx s = function
@@ -301,10 +299,6 @@ let as_dynamic ~at t env =
   | Mlty.(Judgement | Boundary | Derivation | String | Param _ |
           Prod _ | Handler _ | Arrow _ | Apply _ | Ref _) ->
      Mlty.(error ~at (DynamicExpected t))
-
-let op_cases op ~output m env =
-  let oid, argts, context = Context.op_cases op ~output env.context in
-  m oid argts {env with context}
 
 let generalizes_to ~at t (ps, u) env =
   let (), env = add_equation ~at t u env in

--- a/src/typing/tyenv.mli
+++ b/src/typing/tyenv.mli
@@ -39,6 +39,9 @@ val lookup_ml_value : Path.t -> Mlty.ty tyenvM
    returns. *)
 val lookup_ml_operation : Path.t -> (Ident.t * (Mlty.ty list * Mlty.ty)) tyenvM
 
+(** Lookup an ML exception and return its typing information. *)
+val lookup_ml_exception : Path.t -> (Ident.t * Mlty.ty option) tyenvM
+
 (** Lookup an ML constructor and return the expected types of its arguments and the type
    it returns. *)
 val lookup_ml_constructor : Path.ml_constructor -> (Ident.t * Mlty.ty list * Mlty.ty) tyenvM
@@ -66,9 +69,6 @@ val as_handler : at:Location.t -> Mlty.ty -> (Mlty.ty * Mlty.ty) tyenvM
 
 (** Express the given type as a reference type. *)
 val as_ref : at:Location.t -> Mlty.ty -> Mlty.ty tyenvM
-
-(** Express the given type as a dynamic variable type. *)
-val as_dynamic : at:Location.t -> Mlty.ty -> Mlty.ty tyenvM
 
 (** Generalize the given type as much as possible in the current environment, possibly
    solving unification problems. *)
@@ -112,6 +112,9 @@ val add_ml_type : Path.t -> Mlty.ty_def -> unit tyenvM
 
 (** Declare a new operation. *)
 val add_ml_operation : Path.t -> Mlty.ty list * Mlty.ty -> unit tyenvM
+
+(** Declare a new exception. *)
+val add_ml_exception : Path.t -> Mlty.ty option -> unit tyenvM
 
 (** Monadically wrap a computation with [Context.push_ml_module] and [Context.pop_ml_module]. *)
 val as_module : 'a tyenvM -> 'a tyenvM

--- a/src/typing/tyenv.mli
+++ b/src/typing/tyenv.mli
@@ -46,10 +46,6 @@ val lookup_ml_constructor : Path.ml_constructor -> (Ident.t * Mlty.ty list * Mlt
 (** Lookup a TT constructor and return its expected form. *)
 val lookup_tt_constructor : Path.t -> Ident.t tyenvM
 
-(** Lookup the continuation and return the expected type of its argument and the type it
-   returns. *)
-val lookup_continuation : (Mlty.ty * Mlty.ty) tyenvM
-
 (** Add a TT constructor to the typing context, globally forever. *)
 val add_tt_constructor : Ident.t -> unit tyenvM
 
@@ -73,12 +69,6 @@ val as_ref : at:Location.t -> Mlty.ty -> Mlty.ty tyenvM
 
 (** Express the given type as a dynamic variable type. *)
 val as_dynamic : at:Location.t -> Mlty.ty -> Mlty.ty tyenvM
-
-(** [op_cases op output m] runs [m] with the expected types of the arguments of [op] and
-   the continuation having the appropriate type. *)
-val op_cases :
-  Path.t -> output:Mlty.ty ->
-    (Ident.t -> Mlty.ty list -> 'a tyenvM) -> 'a tyenvM
 
 (** Generalize the given type as much as possible in the current environment, possibly
    solving unification problems. *)

--- a/src/typing/typecheck.ml
+++ b/src/typing/typecheck.ml
@@ -39,7 +39,6 @@ let rec generalizable c =
     | Ref _
     | Fresh _
     | AbstractAtom _
-    | Try _
     | Match _
     | BoundaryAscribe _
     | TypeAscribe _
@@ -374,11 +373,6 @@ let rec infer_comp ({Location.it=c; at} : Desugared.comp) : (Syntax.comp * Mlty.
      check_comp c Mlty.Exn >>= fun c ->
      let t = Mlty.fresh_type () in
      return (locate ~at (Syntax.Raise c), t)
-
-  | Desugared.Try (c, hnd) ->
-     infer_comp c >>= fun (c, tc) ->
-     check_match_cases ~at Mlty.Exn tc hnd >>= fun hnd ->
-     return (locate ~at (Syntax.Try (c, hnd)), tc)
 
   | Desugared.With (h, c) ->
     infer_comp h >>= fun (h, th) ->

--- a/src/typing/typecheck.ml
+++ b/src/typing/typecheck.ml
@@ -15,40 +15,45 @@ type generalizable =
 let rec generalizable c =
   match c.Location.it with
   (* yes *)
-  | (Syntax.Bound _ | Syntax.Value _ | Syntax.Function _
-    | Syntax.Handler _| Syntax.String _) ->
+  | Syntax.(Bound _ | Value _ | Function _ | Handler _| String _ | Raise _) ->
      Generalizable
+
   | Syntax.MLConstructor (_, cs) | Syntax.Tuple cs ->
-    if List.for_all (fun c -> generalizable c = Generalizable) cs
-    then Generalizable
-    else Ungeneralizable
+     if List.for_all (fun c -> generalizable c = Generalizable) cs
+     then
+       Generalizable
+     else
+       Ungeneralizable
+
   | Syntax.Let (_, c)
   | Syntax.LetRec (_, c)
   | Syntax.Sequence (_, c) -> generalizable c
 
   (* no *)
-  | Syntax.Operation _
-  | Syntax.With _
-  | Syntax.Lookup _
-  | Syntax.Update _
-  | Syntax.Ref _
-  | Syntax.Fresh _
-  | Syntax.AbstractAtom _
-  | Syntax.Match _
-  | Syntax.BoundaryAscribe _
-  | Syntax.TypeAscribe _
-  | Syntax.TTConstructor _
-  | Syntax.TTApply _
-  | Syntax.Abstract _
-  | Syntax.Substitute _
-  | Syntax.Derive _
-  | Syntax.Apply _
-  | Syntax.Occurs _
-  | Syntax.Congruence _
-  | Syntax.Convert _
-  | Syntax.Context _
-  | Syntax.Natural _
-  | Syntax.MLBoundary _
+  | Syntax.(
+      Operation _
+    | With _
+    | Lookup _
+    | Update _
+    | Ref _
+    | Fresh _
+    | AbstractAtom _
+    | Try _
+    | Match _
+    | BoundaryAscribe _
+    | TypeAscribe _
+    | TTConstructor _
+    | TTApply _
+    | Abstract _
+    | Substitute _
+    | Derive _
+    | Apply _
+    | Occurs _
+    | Congruence _
+    | Convert _
+    | Context _
+    | Natural _
+    | MLBoundary _)
   -> Ungeneralizable
 
 (* Instantite the bound parameters in a type with the given ones. *)

--- a/src/typing/typecheck.ml
+++ b/src/typing/typecheck.ml
@@ -42,7 +42,6 @@ let rec generalizable c =
   | Syntax.Abstract _
   | Syntax.Substitute _
   | Syntax.Derive _
-  | Syntax.Yield _
   | Syntax.Apply _
   | Syntax.Occurs _
   | Syntax.Congruence _
@@ -464,11 +463,6 @@ let rec infer_comp ({Location.it=c; at} : Desugared.comp) : (Syntax.comp * Mlty.
 
   | Desugared.Spine (c, cs) ->
      infer_spine ~at c cs
-
-  | Desugared.Yield c ->
-    Tyenv.lookup_continuation >>= fun (a, b) ->
-    check_comp c a >>= fun c ->
-    return (locate ~at (Syntax.Yield c), b)
 
   | Desugared.String s -> return (locate ~at (Syntax.String s), Mlty.String)
 

--- a/src/utils/ident.ml
+++ b/src/utils/ident.ml
@@ -32,6 +32,8 @@ let add = IdentMap.add
 
 let find = IdentMap.find
 
+let find_opt = IdentMap.find_opt
+
 let mem = IdentMap.mem
 
 let map = IdentMap.map

--- a/src/utils/ident.mli
+++ b/src/utils/ident.mli
@@ -30,6 +30,9 @@ val add : t -> 'a -> 'a map -> 'a map
 (** Map the given key to its value, raise [Not_found] if the key is not found *)
 val find :  t -> 'a map -> 'a
 
+(** Map the given key to its value, return [None] if the key is not found *)
+val find_opt :  t -> 'a map -> 'a option
+
 (** Is the given key bound in the map? *)
 val mem : t -> 'a map -> bool
 

--- a/tests/modules/module_include.m31.ref
+++ b/tests/modules/module_include.m31.ref
@@ -1,5 +1,5 @@
 Processing module A
-val x :> ref mlstring = ref<0>
+val x :> ref mlstring = ref "A.x"
 Processing module B
 - : mlstring = "A.x"
 - : mlstring = "A.x"

--- a/tests/nucleus/alpha_equality.m31
+++ b/tests/nucleus/alpha_equality.m31
@@ -6,6 +6,6 @@ rule u : P a
 rule B type
 rule ξ : A ≡ B
 rule ζ : B ≡ A
-let a' = handle a : B with ML.coerce _ _ -> yield (ML.Some (convert a ξ)) end
-let Q = handle P (a' : A) with ML.coerce _ _ -> yield (ML.Some (convert a' ζ)) end
+let a' = handle a : B with ML.coerce _ _ -> ML.Some (convert a ξ) end
+let Q = handle P (a' : A) with ML.coerce _ _ -> ML.Some (convert a' ζ) end
 let u' = u : Q

--- a/tests/nucleus/alpha_equality.m31
+++ b/tests/nucleus/alpha_equality.m31
@@ -6,6 +6,6 @@ rule u : P a
 rule B type
 rule ξ : A ≡ B
 rule ζ : B ≡ A
-let a' = handle a : B with ML.coerce _ _ -> ML.Some (convert a ξ) end
-let Q = handle P (a' : A) with ML.coerce _ _ -> ML.Some (convert a' ζ) end
+let a' = try a : B with ML.coerce _ _ -> ML.Some (convert a ξ) end
+let Q = try P (a' : A) with ML.coerce _ _ -> ML.Some (convert a' ζ) end
 let u' = u : Q

--- a/tests/nucleus/boundary.m31
+++ b/tests/nucleus/boundary.m31
@@ -24,7 +24,7 @@ rule ξ : A ≡ B ;;
 handle
   a :? (?? : B)
 with
-  ML.coerce _ _ -> yield (ML.Some (convert a ξ))
+  ML.coerce _ _ -> ML.Some (convert a ξ)
 end ;;
 
 rule P (_ : A) type ;;
@@ -33,5 +33,5 @@ rule ζ (x : A) (y : A) : P x ≡ P y ;;
 handle
   a :? {x : A} P x ≡ P x as ??
 with
-  | ML.coerce _ _ -> yield (ML.Some ({z : A} ζ z z))
+  | ML.coerce _ _ -> ML.Some ({z : A} ζ z z)
 end

--- a/tests/nucleus/boundary.m31
+++ b/tests/nucleus/boundary.m31
@@ -21,7 +21,7 @@ a ≡ b : A as ?? ;;
 
 rule ξ : A ≡ B ;;
 
-handle
+try
   a :? (?? : B)
 with
   ML.coerce _ _ -> ML.Some (convert a ξ)
@@ -30,7 +30,7 @@ end ;;
 rule P (_ : A) type ;;
 rule ζ (x : A) (y : A) : P x ≡ P y ;;
 
-handle
+try
   a :? {x : A} P x ≡ P x as ??
 with
   | ML.coerce _ _ -> ML.Some ({z : A} ζ z z)

--- a/tests/nucleus/print_assumptions.m31.ref
+++ b/tests/nucleus/print_assumptions.m31.ref
@@ -1,4 +1,4 @@
-val r :> ref (ML.option _α) = ref<0>
+val r :> ref (ML.option _α) = ref ML.None
 val j :> judgement = ?A₀ type, {_ : ?A₀} ?B₁ type, {x : ?A₀} {_ :
   ?B₁ {x}} ?f₂ : ?A₀, a₃ : ?A₀, b₄ : ?B₁ {a₃} ⊢ ?f₂
   {a₃} {b₄}

--- a/tests/runtime/exception.m31
+++ b/tests/runtime/exception.m31
@@ -15,7 +15,7 @@ f (Cow "horn") ;;
 f Horn ;;
 f Tail ;;
 
-handle
+try
   ("foo", "bar")
 with
 | raise (Cow s) -> ("cow", s)
@@ -23,7 +23,7 @@ with
 end
 ;;
 
-handle
+try
   raise Horn
 with
 | raise (Cow s) -> ("cow", s)
@@ -31,8 +31,8 @@ with
 end
 ;;
 
-handle
-  handle
+try
+  try
     raise Tail
   with
   | raise (Cow s) -> ("cow", s)
@@ -43,8 +43,8 @@ with
 end
 ;;
 
-handle
-  handle
+try
+  try
     raise Tail
   with
   | raise e -> raise Horn

--- a/tests/runtime/exception.m31
+++ b/tests/runtime/exception.m31
@@ -1,0 +1,56 @@
+exception Cow of mlstring ;;
+exception Horn ;;
+exception Tail ;;
+
+let f e =
+  match e with
+  | Cow s -> Cow s
+  | Horn -> Cow "horn"
+  | Tail when ML.false -> Cow "wrong_tail"
+  | Tail -> Cow "tail"
+  end
+;;
+
+f (Cow "horn") ;;
+f Horn ;;
+f Tail ;;
+
+try
+  ("foo", "bar")
+with
+| Cow s -> ("cow", s)
+| Horn when ML.true -> ("horn", "")
+end
+;;
+
+try
+  raise Horn
+with
+| Cow s -> ("cow", s)
+| Horn when ML.true -> ("horn", "")
+end
+;;
+
+try
+  try
+    raise Tail
+  with
+  | Cow s -> ("cow", s)
+  | Horn when ML.true -> ("horn", "")
+  end
+with
+| Tail -> ("tail", "")
+end
+;;
+
+try
+  try
+    raise Tail
+  with
+  | e -> raise Horn
+  end
+with
+| Tail -> "tail"
+| Horn -> "horn"
+end
+;;

--- a/tests/runtime/exception.m31
+++ b/tests/runtime/exception.m31
@@ -15,42 +15,42 @@ f (Cow "horn") ;;
 f Horn ;;
 f Tail ;;
 
-try
+handle
   ("foo", "bar")
 with
-| Cow s -> ("cow", s)
-| Horn when ML.true -> ("horn", "")
+| raise (Cow s) -> ("cow", s)
+| raise Horn when ML.true -> ("horn", "")
 end
 ;;
 
-try
+handle
   raise Horn
 with
-| Cow s -> ("cow", s)
-| Horn when ML.true -> ("horn", "")
+| raise (Cow s) -> ("cow", s)
+| raise Horn when ML.true -> ("horn", "")
 end
 ;;
 
-try
-  try
+handle
+  handle
     raise Tail
   with
-  | Cow s -> ("cow", s)
-  | Horn when ML.true -> ("horn", "")
+  | raise (Cow s) -> ("cow", s)
+  | raise Horn when ML.true -> ("horn", "")
   end
 with
-| Tail -> ("tail", "")
+| raise Tail -> ("tail", "")
 end
 ;;
 
-try
-  try
+handle
+  handle
     raise Tail
   with
-  | e -> raise Horn
+  | raise e -> raise Horn
   end
 with
-| Tail -> "tail"
-| Horn -> "horn"
+| raise Tail -> "tail"
+| raise Horn -> "horn"
 end
 ;;

--- a/tests/runtime/exception.m31.ref
+++ b/tests/runtime/exception.m31.ref
@@ -1,0 +1,11 @@
+Exception Cow is declared.
+Exception Horn is declared.
+Exception Tail is declared.
+val f :> exn → exn = <function>
+- : exn = Cow "horn"
+- : exn = Cow "horn"
+- : exn = Cow "tail"
+- : mlstring * mlstring = ("foo", "bar")
+- : mlstring * mlstring = ("horn", "")
+- : mlstring * mlstring = ("tail", "")
+- : mlstring = "horn"

--- a/tests/runtime/handler.m31
+++ b/tests/runtime/handler.m31
@@ -6,13 +6,13 @@ rule B type ;;
 handle
   auto () : A
 with
-| auto () : ML.Some (?? : X) -> yield a
-| auto () : ML.None -> yield B
+| auto () : ML.Some (?? : X) -> a
+| auto () : ML.None -> B
 end ;;
 
 handle
   auto ()
 with
-| auto () : ML.Some (?? : X) -> yield a
-| auto () : ML.None -> yield B
+| auto () : ML.Some (?? : X) -> a
+| auto () : ML.None -> B
 end

--- a/tests/runtime/handler.m31
+++ b/tests/runtime/handler.m31
@@ -3,14 +3,14 @@ rule A type ;;
 rule a : A ;;
 rule B type ;;
 
-handle
+try
   auto () : A
 with
 | auto () : ML.Some (?? : X) -> a
 | auto () : ML.None -> B
 end ;;
 
-handle
+try
   auto ()
 with
 | auto () : ML.Some (?? : X) -> a

--- a/tests/runtime/handler_exception.m31
+++ b/tests/runtime/handler_exception.m31
@@ -1,17 +1,14 @@
 exception Cow of mlstring ;;
 operation moo : mlunit -> mlstring ;;
 
-try
-  handle
-    try
-      let x = moo () in
-      ("operation", x)
-    with
-    | Cow c -> ("correct", c)
-    end
+handle
+  try
+     let x = moo () in
+     ("operation", x)
   with
-  | moo () -> raise (Cow "moo")
+  | Cow c -> ("correct", c)
   end
 with
-| Cow c -> ("wrong", c)
+| moo () -> raise (Cow "moo")
+| raise (Cow c) -> ("wrong", c)
 end

--- a/tests/runtime/handler_exception.m31
+++ b/tests/runtime/handler_exception.m31
@@ -1,8 +1,8 @@
 exception Cow of mlstring ;;
 operation moo : mlunit -> mlstring ;;
 
-handle
-  handle
+try
+  try
      let x = moo () in
      ("operation", x)
   with

--- a/tests/runtime/handler_exception.m31
+++ b/tests/runtime/handler_exception.m31
@@ -2,11 +2,11 @@ exception Cow of mlstring ;;
 operation moo : mlunit -> mlstring ;;
 
 handle
-  try
+  handle
      let x = moo () in
      ("operation", x)
   with
-  | Cow c -> ("correct", c)
+  | raise (Cow c) -> ("correct", c)
   end
 with
 | moo () -> raise (Cow "moo")

--- a/tests/runtime/handler_exception.m31
+++ b/tests/runtime/handler_exception.m31
@@ -1,0 +1,17 @@
+exception Cow of mlstring ;;
+operation moo : mlunit -> mlstring ;;
+
+try
+  handle
+    try
+      let x = moo () in
+      ("operation", x)
+    with
+    | Cow c -> ("correct", c)
+    end
+  with
+  | moo () -> raise (Cow "moo")
+  end
+with
+| Cow c -> ("wrong", c)
+end

--- a/tests/runtime/handler_exception.m31.ref
+++ b/tests/runtime/handler_exception.m31.ref
@@ -1,0 +1,3 @@
+Exception Cow is declared.
+Operation moo is declared.
+- : mlstring * mlstring = ("correct", "moo")


### PR DESCRIPTION
This PR makes Andromeda more aligned with [Coop](https://github.com/andrejbauer/coop) by making handlers less general, and by introducing exceptions as a primitive notions, as in Coop.

We now have exceptions, which are declared as in OCaml by

```exception ExcName of t```

and raised with `raise e`. There is only one kind of handlers, which handle value cases, operations, and exceptions:

```
handler
| val v -> c_val
| op p1 .... pn -> c_op
| raise exc -> c_exc
end
```

Operations **always** return to the calling site, even when they raise an exception (this is Coop behavior). That is, if `c_op` raises an exception, the exception will propagate to the point at which the operation `op` was called. Thus operations are a lot less general than they used to be, as they use the continuation linearly (they're even less general than Coop, where signals can be used to abort an operation). This makes a very strong guarantee on handlers, namely that they will always be able to finalize properly. For instance, a handler might keep a list of meta-variables that *must* be cleaned up properly.

Also, instead of writing `handle ... with ...` we now have `try ... with ...`, and instead of `with ... handle ...` we have `with ... try ...`.
