### PR TITLE
Abstract types

### DIFF
--- a/src/parser/desugar.ml
+++ b/src/parser/desugar.ml
@@ -1615,6 +1615,10 @@ let rec toplevel' ~loading ~basedir ctx {Location.it=cmd; at} =
      let pth, ctx = Ctx.add_exception ~at exc (ml_exception_arity tyopt) ctx in
      (ctx, locate1 (Desugared.DeclException (pth, tyopt)))
 
+  | Sugared.DefMLTypeAbstract t ->
+     let t_pth, ctx = Ctx.add_ml_type ~at t (0, None) ctx in
+     (ctx, locate1 (Desugared.DefMLTypeAbstract t_pth))
+
   | Sugared.DefMLType defs ->
      let ctx, defs = mlty_defs ~at ctx defs in
      (ctx, locate1 (Desugared.DefMLType defs))

--- a/src/parser/desugar.ml
+++ b/src/parser/desugar.ml
@@ -1615,9 +1615,9 @@ let rec toplevel' ~loading ~basedir ctx {Location.it=cmd; at} =
      let pth, ctx = Ctx.add_exception ~at exc (ml_exception_arity tyopt) ctx in
      (ctx, locate1 (Desugared.DeclException (pth, tyopt)))
 
-  | Sugared.DefMLTypeAbstract t ->
-     let t_pth, ctx = Ctx.add_ml_type ~at t (0, None) ctx in
-     (ctx, locate1 (Desugared.DefMLTypeAbstract t_pth))
+  | Sugared.DefMLTypeAbstract (t, params) ->
+     let t_pth, ctx = Ctx.add_ml_type ~at t (List.length params, None) ctx in
+     (ctx, locate1 (Desugared.DefMLTypeAbstract (t_pth, params)))
 
   | Sugared.DefMLType defs ->
      let ctx, defs = mlty_defs ~at ctx defs in

--- a/src/parser/parser.mly
+++ b/src/parser/parser.mly
@@ -793,8 +793,8 @@ mlty_def_body:
     { Sugared.ML_Sum lst }
 
 mlty_constructor:
-  | c=constr_name OF lst=separated_nonempty_list(WITH, mlty)
-    { (c, lst) }
+  | c=constr_name OF t=mlty
+    { (c, [t]) }
 
   | c=constr_name
     { (c, []) }

--- a/src/parser/parser.mly
+++ b/src/parser/parser.mly
@@ -145,8 +145,8 @@ top_command_:
   | WITH lst=top_operation_cases END
     { Sugared.TopWith lst }
 
-  | MLTYPE t=ml_name
-    { Sugared.DefMLTypeAbstract t }
+  | MLTYPE t=ml_name xs=list(opt_name(ml_name))
+    { Sugared.DefMLTypeAbstract (t, xs) }
 
   | MLTYPE lst=mlty_defs
     { Sugared.DefMLType lst }

--- a/src/parser/parser.mly
+++ b/src/parser/parser.mly
@@ -142,8 +142,8 @@ top_command_:
   | LET REC lst=separated_nonempty_list(AND, recursive_clause)
     { Sugared.TopLetRec lst }
 
-  (* | HANDLE lst=top_handler_cases END *)
-  (*   { Sugared.TopHandle lst } *)
+  | WITH lst=top_operation_cases END
+    { Sugared.TopWith lst }
 
   | MLTYPE lst=mlty_defs
     { Sugared.DefMLType lst }
@@ -564,6 +564,17 @@ handler_case:
 
   | op=long(op_name) ps=prefix_pattern* pt=handler_checking ARROW t=term
     { Sugared.CaseOp (op, (ps, pt, t)) }
+
+top_operation_case:
+  | OPERATION op=long(op_name) ps=prefix_pattern* pt=handler_checking ARROW t=term
+    { (op, (ps, pt, t)) }
+
+top_operation_cases:
+  | BAR lst=separated_nonempty_list(BAR, top_operation_case)
+    { lst }
+
+  | lst=separated_list(BAR, top_operation_case)
+    { lst }
 
 handler_checking:
   |

--- a/src/parser/parser.mly
+++ b/src/parser/parser.mly
@@ -145,6 +145,9 @@ top_command_:
   | WITH lst=top_operation_cases END
     { Sugared.TopWith lst }
 
+  | MLTYPE t=ml_name
+    { Sugared.DefMLTypeAbstract t }
+
   | MLTYPE lst=mlty_defs
     { Sugared.DefMLType lst }
 

--- a/src/runtime/eval.ml
+++ b/src/runtime/eval.ml
@@ -791,6 +791,9 @@ let rec toplevel ~quiet ~print_annot {Location.it=c; at} =
      let print_annot = print_annot () in
      topletrec_bind ~at ~quiet ~print_annot info fxcs
 
+  | Syntax.TopWith lst ->
+     failwith "eval TopWith"
+
   | Syntax.TopComputation (c, sch) ->
      comp_value c >>= fun v ->
      Runtime.top_lookup_penv >>= fun penv ->

--- a/src/runtime/eval.ml
+++ b/src/runtime/eval.ml
@@ -536,25 +536,19 @@ and match_cases
   in
   fold cases
 
-and match_op_cases op cases (Runtime.{args; checking} as op_args) =
-  let rec fold cases =
+and match_op_cases op cases =
+  let rec fold cases (Runtime.{args; checking} as op_args) =
     match cases with
     | [] -> Runtime.operation op ?checking args
-    | case :: cases ->
-       begin match match_op_case case op_args with
-       | Some c -> c
-       | None -> fold cases
-       end
+    | case :: cases -> match_op_case (fold cases) case op_args
   in
   fold cases
 
-and match_op_case (ps, ptopt, c) (Runtime.{args; checking} as op_args) : Runtime.value Runtime.comp option =
+and match_op_case other (ps, ptopt, c) (Runtime.{args; checking} as op_args) =
   Matching.match_op_pattern ps ptopt args checking >>=
     function
-    | Some vs ->
-       let r = List.fold_left (fun cmp v -> Runtime.add_bound v cmp) (comp c) vs in
-       Some r
-    | None -> None
+    | Some vs -> List.fold_left (fun cmp v -> Runtime.add_bound v cmp) (comp c) vs
+    | None -> other op_args
 
 (** Run [c] and convert the result to a derivation. *)
 and comp_as_derivation c =
@@ -797,7 +791,8 @@ let rec toplevel ~quiet ~print_annot {Location.it=c; at} =
      let rec fold = function
        | [] -> return ()
        | (op, case) :: cases ->
-          Runtime.top_add_handle op (match_op_case case) >>= fun () ->
+          let case other = match_op_case other case in
+          Runtime.top_add_handle op case >>= fun () ->
           fold cases
      in
      fold cases

--- a/src/runtime/eval.ml
+++ b/src/runtime/eval.ml
@@ -742,6 +742,12 @@ let rec toplevel ~quiet ~print_annot {Location.it=c; at} =
         Format.printf "@[<hov 2>Rule %t is postulated.@]@." (Ident.print ~opens ~parentheses:false x));
      Runtime.top_add_rule x rule
 
+  | Syntax.DefMLTypeAbstract t ->
+     Runtime.top_lookup_opens >>= fun opens ->
+     (if not quiet then
+        Format.printf "@[<hov 2>ML type %t declared.@]@." (Path.print ~opens ~parentheses:true t)) ;
+     return ()
+
   | Syntax.DefMLType lst
   | Syntax.DefMLTypeRec lst ->
      Runtime.top_lookup_opens >>= fun opens ->

--- a/src/runtime/eval.ml
+++ b/src/runtime/eval.ml
@@ -792,7 +792,7 @@ let rec toplevel ~quiet ~print_annot {Location.it=c; at} =
        | [] -> return ()
        | (op, case) :: cases ->
           let case other = match_op_case other case in
-          Runtime.top_add_handle op case >>= fun () ->
+          Runtime.top_add_handle ~at op case >>= fun () ->
           fold cases
      in
      fold cases

--- a/src/runtime/external.ml
+++ b/src/runtime/external.ml
@@ -5,14 +5,14 @@ let (>>=) = Runtime.bind
 let externals =
   [
     ("print", (* forall a, a -> mlunit *)
-     Runtime.mk_closure (fun v ->
+     Runtime.mk_closure_external (fun v ->
          Runtime.lookup_penv >>= fun penv ->
          Format.printf "%t@." (Runtime.print_value ~penv v) ;
          Runtime.return_unit
     ));
 
     ("print_json", (* forall a, a -> mlunit *)
-     Runtime.mk_closure (fun v ->
+     Runtime.mk_closure_external (fun v ->
          let j = Runtime.Json.value v in
          (* Temporarily set printing depth to infinity *)
          let b = Format.get_max_boxes () in
@@ -23,7 +23,7 @@ let externals =
     ));
 
     ("compare", (* forall a, a -> a -> ML.order *)
-     Runtime.mk_closure (fun v ->
+     Runtime.mk_closure_external (fun v ->
          Runtime.return_closure (fun w ->
              try
                let c = Stdlib.compare v w in
@@ -38,7 +38,7 @@ let externals =
     ));
 
     ("time", (* forall a, mlunit -> (a -> a) *)
-     Runtime.mk_closure (fun _ ->
+     Runtime.mk_closure_external (fun _ ->
          let time0 = ref (Sys.time ()) in
          Runtime.return_closure
            (fun v ->
@@ -48,7 +48,7 @@ let externals =
     ));
 
     ("config", (* mlstring -> mlunit *)
-     Runtime.mk_closure (fun v ->
+     Runtime.mk_closure_external (fun v ->
          let s = Runtime.as_string ~at:Location.unknown v in
          match s with
          | "ascii" ->
@@ -71,10 +71,10 @@ let externals =
     ));
 
     ("exit", (* forall a, mlunit -> a *)
-     Runtime.mk_closure (fun _ -> Stdlib.exit 0));
+     Runtime.mk_closure_external (fun _ -> Stdlib.exit 0));
 
     ("magic", (* forall a b, a -> b *)
-     Runtime.mk_closure (fun v -> Runtime.return v));
+     Runtime.mk_closure_external (fun v -> Runtime.return v));
   ]
 
 let lookup s =

--- a/src/runtime/matching.ml
+++ b/src/runtime/matching.ml
@@ -269,23 +269,20 @@ let match_pattern' sgn p v =
 
 let top_match_pattern p v =
   let (>>=) = Runtime.top_bind in
-  Runtime.top_get_env >>= fun env ->
-  let sgn = Runtime.get_signature env in
+  Runtime.top_lookup_signature >>= fun sgn ->
   let r = match_pattern' sgn p v in
   Runtime.top_return r
 
 let match_pattern p v =
   (* collect values of pattern variables *)
-  Runtime.get_env >>= fun env ->
-  let sgn = Runtime.get_signature env in
+  Runtime.lookup_signature >>= fun sgn ->
   let r = match_pattern' sgn p v in
   return r
 
 let collect_boundary_pattern = collect_pattern
 
 let match_op_pattern ps p_bdry vs bdry =
-  Runtime.get_env >>= fun env ->
-  let sgn = Runtime.get_signature env in
+  Runtime.lookup_signature >>= fun sgn ->
   let r =
     begin
       try

--- a/src/runtime/matching.ml
+++ b/src/runtime/matching.ml
@@ -269,20 +269,23 @@ let match_pattern' sgn p v =
 
 let top_match_pattern p v =
   let (>>=) = Runtime.top_bind in
-  Runtime.top_lookup_signature >>= fun sgn ->
+  Runtime.top_get_env >>= fun env ->
+  let sgn = Runtime.get_signature env in
   let r = match_pattern' sgn p v in
   Runtime.top_return r
 
 let match_pattern p v =
   (* collect values of pattern variables *)
-  Runtime.lookup_signature >>= fun sgn ->
+  Runtime.get_env >>= fun env ->
+  let sgn = Runtime.get_signature env in
   let r = match_pattern' sgn p v in
   return r
 
 let collect_boundary_pattern = collect_pattern
 
 let match_op_pattern ps p_bdry vs bdry =
-  Runtime.lookup_signature >>= fun sgn ->
+  Runtime.get_env >>= fun env ->
+  let sgn = Runtime.get_signature env in
   let r =
     begin
       try

--- a/src/runtime/runtime.ml
+++ b/src/runtime/runtime.ml
@@ -967,6 +967,16 @@ let rec handle_comp {handler_val; handler_ops; handler_exc} (r : value comp) : v
           Operation {op_id; op_args; op_boundary; op_dynamic_env; op_cont}
      end
 
+let top_add_handle op_id op_case ({top_handler;_} as topenv) =
+  let g_op =
+    match Ident.find_opt op_id top_handler with
+    | None -> (??)
+    | Some g_op -> g_op
+  in
+  let top_handler = Ident.add op_id (op_case g_op) top_handler in
+  (), { topenv with top_handler }
+
+
 let top_handle ~at c ({top_handler=hnd;_} as topenv) =
   let rec handle env = function
 

--- a/src/runtime/runtime.ml
+++ b/src/runtime/runtime.ml
@@ -266,7 +266,7 @@ let mk_string s = String s
 let mk_closure0 f {lexical;_} = Clos (fun v env -> f v {env with lexical})
 let mk_closure_ref g r = Clos (fun v env -> g v {env with lexical = (!r).lexical})
 
-let mk_closure f = Closure (Clos f)
+let mk_closure_external f = Closure (Clos f)
 
 let apply_closure (Clos f) v env = f v env
 
@@ -970,7 +970,7 @@ let rec handle_comp {handler_val; handler_ops; handler_exc} (r : value comp) : v
 let top_add_handle op_id op_case ({top_handler;_} as topenv) =
   let g_op =
     match Ident.find_opt op_id top_handler with
-    | None -> (??)
+    | None -> failwith "top_add_handle"
     | Some g_op -> g_op
   in
   let top_handler = Ident.add op_id (op_case g_op) top_handler in

--- a/src/runtime/runtime.ml
+++ b/src/runtime/runtime.ml
@@ -203,7 +203,7 @@ and 'a continuation =
 
 type topenv = {
   top_runtime : env ;
-  top_handler : (operation_args, value) closure Ident.map ;
+  top_handler : (operation_args, value comp option) closure list Ident.map ;
 }
 
 type 'a toplevel = topenv -> 'a * topenv
@@ -647,24 +647,6 @@ let top_open_path pth ({top_runtime;_} as topenv) =
 let top_lookup_signature topenv =
   get_signature topenv.top_runtime, topenv
 
-(* A hack, until we have proper type-driven printing routines. At that point we should consider
-   equipping type definitions with custom printers, so that not only lists but other datatypes
-   can have their own printers. (And we're not going to implement Haskell classes.) *)
-(* let rec as_list_opt =
- *   let (_, tag_nil) = Desugar.Builtin.nil
- *   and (_, tag_cons) = Desugar.Builtin.cons in
- *   function
- *   | Tag (t, []) when equal_tag t tag_nil -> Some []
- *   | Tag (t, [x;xs]) when equal_tag t tag_cons ->
- *      begin
- *        match as_list_opt xs with
- *        | None -> None
- *        | Some xs -> Some (x :: xs)
- *      end
- *   | (IsTerm _ | IsType _ | EqTerm _ | EqType _ |
- *      Closure _ | Handler _ | Exc _ | Tag _ | Tuple _ | Ref _ | String _) ->
- *      None *)
-
 (** In the future this routine will be type-driven. One consequence is that
     constructor tags will be printed by looking up their names in type
     definitions. *)
@@ -967,18 +949,17 @@ let rec handle_comp {handler_val; handler_ops; handler_exc} (r : value comp) : v
           Operation {op_id; op_args; op_boundary; op_dynamic_env; op_cont}
      end
 
-let top_add_handle op_id op_case ({top_handler;_} as topenv) =
-  let g_op =
+let top_add_handle op_id op_case ({top_handler; top_runtime} as topenv) =
+  let op_cases =
     match Ident.find_opt op_id top_handler with
-    | None -> failwith "top_add_handle"
-    | Some g_op -> g_op
+    | None -> []
+    | Some op_cases -> op_cases
   in
-  let top_handler = Ident.add op_id (op_case g_op) top_handler in
+  let top_handler = Ident.add op_id (op_case :: op_cases) top_handler in
   (), { topenv with top_handler }
 
-
-let top_handle ~at c ({top_handler=hnd;_} as topenv) =
-  let rec handle env = function
+let top_handle ~at c ({top_handler=hnd; top_runtime=env} as topenv) =
+  let rec handle = function
 
     | Return v -> v, { topenv with top_runtime=env }
 
@@ -986,19 +967,27 @@ let top_handle ~at c ({top_handler=hnd;_} as topenv) =
        error ~at (UncaughtException (exc_id, v))
 
     | Operation {op_id; op_args; op_boundary; op_dynamic_env; op_cont} ->
-       begin match Ident.find_opt op_id hnd with
-
-       | Some f_op ->
-         let env = {env with dynamic = op_dynamic_env} in
-         let r = apply_closure f_op {args=op_args; checking=op_boundary} in
-         handle env (bind_cont r op_cont env)
-
-       | None ->
-          error ~at (UnhandledOperation (op_id, op_args))
-       end
+       let args = {args=op_args; checking=op_boundary} in
+       let rec fold = function
+         | [] -> error ~at (UnhandledOperation (op_id, op_args))
+         | case :: cases ->
+             case args >>= function
+            | None -> fold cases
+            | Some c ->
+               let env = { env with dynamic = op_dynamic_env } in
+               let r = bind_cont c op_cont env in
+               handle r
+            end
+       in
+       let cases =
+         match Ident.find_opt op_id hnd with
+         | None -> []
+         | Some cases -> cases
+       in
+       fold cases
   in
   let r = c topenv.top_runtime in
-  handle topenv.top_runtime r
+  handle r
 
 (** Equality *)
 let rec equal_value v1 v2 =

--- a/src/runtime/runtime.mli
+++ b/src/runtime/runtime.mli
@@ -301,8 +301,11 @@ val top_add_ml_value_rec : (value -> value comp) list -> unit toplevel
 (** Extend the signature with a new rule *)
 val top_add_rule : Ident.t -> Nucleus.primitive -> unit toplevel
 
+(** A top-level handler case is handled by a map which get operation arguments
+   and computes an option. If the option is [None] then it did not match, if it
+   is [Some c] then it matched and we should proceed with computation [c]. *)
 val top_add_handle :
-  Ident.t -> ((operation_args, value) closure -> (operation_args, value) closure) -> unit toplevel
+  Ident.t -> (operation_args -> value comp option comp) -> unit toplevel
 
 (** Handle a computation at the toplevel. *)
 val top_handle : at:Location.t -> 'a comp -> 'a toplevel

--- a/src/runtime/runtime.mli
+++ b/src/runtime/runtime.mli
@@ -301,11 +301,8 @@ val top_add_ml_value_rec : (value -> value comp) list -> unit toplevel
 (** Extend the signature with a new rule *)
 val top_add_rule : Ident.t -> Nucleus.primitive -> unit toplevel
 
-(** A top-level handler case is handled by a map which get operation arguments
-   and computes an option. If the option is [None] then it did not match, if it
-   is [Some c] then it matched and we should proceed with computation [c]. *)
 val top_add_handle :
-  Ident.t -> (operation_args -> value comp option comp) -> unit toplevel
+  Ident.t -> ((operation_args, value) closure -> (operation_args, value) closure) -> unit toplevel
 
 (** Handle a computation at the toplevel. *)
 val top_handle : at:Location.t -> 'a comp -> 'a toplevel

--- a/src/runtime/runtime.mli
+++ b/src/runtime/runtime.mli
@@ -270,10 +270,10 @@ val lookup_ml_value : Path.t -> value comp
 
 (** {6 Toplevel} *)
 
-(** state environment, no operations *)
-type 'a toplevel
+(** {b Monadic structure of top-level} *)
 
-(** {b Monadic structure } *)
+(** Top-level computation monad *)
+type 'a toplevel
 
 val top_bind : 'a toplevel -> ('a -> 'b toplevel) -> 'b toplevel
 val top_return : 'a -> 'a toplevel
@@ -284,18 +284,19 @@ val top_return_closure : ('a -> 'b comp) -> ('a,'b) closure toplevel
 
 val top_fold : ('a -> 'b -> 'a toplevel) -> 'a -> 'b list -> 'a toplevel
 
-val as_ml_module : 'a toplevel -> 'a toplevel
+(** Evaluate a top-level computation as an ML module *)
+val top_as_ml_module : unit toplevel -> unit toplevel
 
 (** {b Monadic interface} *)
 
 (** Add a bound variable with the given name to the environment. *)
-val add_ml_value : value -> unit toplevel
+val top_add_ml_value : value -> unit toplevel
 
 (** Add a list of mutually recursive definitions to the toplevel environment. *)
-val add_ml_value_rec : (value -> value comp) list -> unit toplevel
+val top_add_ml_value_rec : (value -> value comp) list -> unit toplevel
 
 (** Extend the signature with a new rule *)
-val add_rule : Ident.t -> Nucleus.primitive -> unit toplevel
+val top_add_rule : Ident.t -> Nucleus.primitive -> unit toplevel
 
 (** Handle a computation at the toplevel. *)
 val top_handle : at:Location.t -> 'a comp -> 'a toplevel
@@ -314,17 +315,17 @@ val top_lookup_signature : Nucleus.signature toplevel
 
 (** {6 Running a toplevel computation} *)
 
-(** toplevel environment *)
+(** Toplevel environment *)
 type topenv
 
 (** The empty toplevel environment. *)
 val empty : topenv
 
 (** Get the current printing environment. *)
-val get_penv : topenv -> penv
+val top_get_penv : topenv -> penv
 
 (** Get the current printing environment for the nucleus *)
-val get_nucleus_penv : topenv -> Nucleus.print_environment
+val top_get_nucleus_penv : topenv -> Nucleus.print_environment
 
 (** Execute a toplevel command in the given environment. *)
 val exec : 'a toplevel -> topenv -> 'a * topenv

--- a/src/runtime/runtime.mli
+++ b/src/runtime/runtime.mli
@@ -302,7 +302,8 @@ val top_add_ml_value_rec : (value -> value comp) list -> unit toplevel
 val top_add_rule : Ident.t -> Nucleus.primitive -> unit toplevel
 
 val top_add_handle :
-  Ident.t -> ((operation_args, value) closure -> (operation_args, value) closure) -> unit toplevel
+  at:Location.t ->   Ident.t ->
+  ((operation_args -> value comp) -> (operation_args -> value comp)) -> unit toplevel
 
 (** Handle a computation at the toplevel. *)
 val top_handle : at:Location.t -> 'a comp -> 'a toplevel

--- a/src/runtime/runtime.mli
+++ b/src/runtime/runtime.mli
@@ -194,6 +194,9 @@ val error : at:Location.t -> error -> 'a
 (** computations provide a dynamically scoped environment and operations *)
 type 'a comp
 
+(** Convert a function to a closure. Only use this when the function does not access its
+    lexical scope, i.e., when it is an external OCaml function that does not care what
+    lexical environment it is run in. *)
 val mk_closure : (value -> value comp) -> value
 
 (** {b Monadic structure} *)
@@ -297,6 +300,8 @@ val top_add_ml_value_rec : (value -> value comp) list -> unit toplevel
 
 (** Extend the signature with a new rule *)
 val top_add_rule : Ident.t -> Nucleus.primitive -> unit toplevel
+
+val top_add_handle : Ident.t -> (operation_args, value) closure -> unit toplevel
 
 (** Handle a computation at the toplevel. *)
 val top_handle : at:Location.t -> 'a comp -> 'a toplevel

--- a/src/runtime/runtime.mli
+++ b/src/runtime/runtime.mli
@@ -194,10 +194,10 @@ val error : at:Location.t -> error -> 'a
 (** computations provide a dynamically scoped environment and operations *)
 type 'a comp
 
-(** Convert a function to a closure. Only use this when the function does not access its
-    lexical scope, i.e., when it is an external OCaml function that does not care what
-    lexical environment it is run in. *)
-val mk_closure : (value -> value comp) -> value
+(** Convert an external function to a closure. Only use this when the function
+   does not access its lexical scope, i.e., when it is an external OCaml
+   function that does not care what lexical environment it is run in. *)
+val mk_closure_external : (value -> value comp) -> value
 
 (** {b Monadic structure} *)
 
@@ -301,7 +301,8 @@ val top_add_ml_value_rec : (value -> value comp) list -> unit toplevel
 (** Extend the signature with a new rule *)
 val top_add_rule : Ident.t -> Nucleus.primitive -> unit toplevel
 
-val top_add_handle : Ident.t -> (operation_args, value) closure -> unit toplevel
+val top_add_handle :
+  Ident.t -> ((operation_args, value) closure -> (operation_args, value) closure) -> unit toplevel
 
 (** Handle a computation at the toplevel. *)
 val top_handle : at:Location.t -> 'a comp -> 'a toplevel

--- a/src/runtime/toplevel.ml
+++ b/src/runtime/toplevel.ml
@@ -28,11 +28,11 @@ let print_error state err ppf =
      Format.fprintf ppf "%t:@.@[<hov 2>Type error:@ %t@]" (Location.print at) (Mlty.print_error err)
 
   | RuntimeError {Location.it=err; at} ->
-     let penv = Runtime.get_penv state.runtime in
+     let penv = Runtime.top_get_penv state.runtime in
      Format.fprintf ppf "%t:@.@[<hov 2>Runtime error:@ %t@]" (Location.print at) (Runtime.print_error ~penv err)
 
   | NucleusError err ->
-     let penv = Runtime.get_nucleus_penv state.runtime in
+     let penv = Runtime.top_get_nucleus_penv state.runtime in
      Format.fprintf ppf "@[<hov 2>Nucleus error:@ %t@]" (Nucleus.print_error ~penv err)
 
 let wrap_error f x =

--- a/src/syntax/desugared.mli
+++ b/src/syntax/desugared.mli
@@ -128,7 +128,7 @@ type ml_tydef =
 type toplevel = toplevel' located
 and toplevel' =
   | Rule of Path.t * premise list * boundary
-  | DefMLTypeAbstract of Path.t
+  | DefMLTypeAbstract of Path.t * Name.t option list
   | DefMLType of (Path.t * (Name.t option list * ml_tydef)) list
   | DefMLTypeRec of (Path.t * (Name.t option list * ml_tydef)) list
   | DeclOperation of Path.t * (ml_ty list * ml_ty)

--- a/src/syntax/desugared.mli
+++ b/src/syntax/desugared.mli
@@ -110,6 +110,8 @@ and match_case = pattern * comp option * comp
 
 and exception_case = match_case
 
+and top_operation_case = Path.t * match_op_case
+
 (** Match multiple patterns at once, with shared pattern variables *)
 and match_op_case = pattern list * pattern option * comp
 
@@ -133,6 +135,7 @@ and toplevel' =
   | DeclExternal of Name.t * ml_schema * string
   | TopLet of let_clause list
   | TopLetRec of letrec_clause list
+  | TopWith of top_operation_case list
   | TopComputation of comp
   | Verbosity of int
   | Open of Path.t

--- a/src/syntax/desugared.mli
+++ b/src/syntax/desugared.mli
@@ -128,6 +128,7 @@ type ml_tydef =
 type toplevel = toplevel' located
 and toplevel' =
   | Rule of Path.t * premise list * boundary
+  | DefMLTypeAbstract of Path.t
   | DefMLType of (Path.t * (Name.t option list * ml_tydef)) list
   | DefMLTypeRec of (Path.t * (Name.t option list * ml_tydef)) list
   | DeclOperation of Path.t * (ml_ty list * ml_ty)

--- a/src/syntax/sugared.mli
+++ b/src/syntax/sugared.mli
@@ -147,6 +147,7 @@ and toplevel' =
   | RuleIsTerm of Name.t * premise list * comp
   | RuleEqType of Name.t * premise list * (comp * comp)
   | RuleEqTerm of Name.t * premise list * (comp * comp * comp)
+  | DefMLTypeAbstract of Name.t
   | DefMLType of (Name.t * (Name.t option list * ml_tydef)) list
   | DefMLTypeRec of (Name.t * (Name.t option list * ml_tydef)) list
   | DeclOperation of Name.t * (ml_ty list * ml_ty)

--- a/src/syntax/sugared.mli
+++ b/src/syntax/sugared.mli
@@ -123,6 +123,8 @@ and exception_case = match_case
 
 and match_op_case = pattern list * pattern option * comp
 
+and top_operation_case = path * match_op_case
+
 (** The local context of a premise to a rule. *)
 and local_context = (Name.t * comp) list
 
@@ -152,6 +154,7 @@ and toplevel' =
   | DeclExternal of Name.t * ml_schema * string
   | TopLet of let_clause list
   | TopLetRec of letrec_clause list
+  | TopWith of top_operation_case list
   | TopComputation of comp
   | Verbosity of int
   | Require of Name.t list

--- a/src/syntax/sugared.mli
+++ b/src/syntax/sugared.mli
@@ -147,7 +147,7 @@ and toplevel' =
   | RuleIsTerm of Name.t * premise list * comp
   | RuleEqType of Name.t * premise list * (comp * comp)
   | RuleEqTerm of Name.t * premise list * (comp * comp * comp)
-  | DefMLTypeAbstract of Name.t
+  | DefMLTypeAbstract of Name.t * Name.t option list
   | DefMLType of (Name.t * (Name.t option list * ml_tydef)) list
   | DefMLTypeRec of (Name.t * (Name.t option list * ml_tydef)) list
   | DeclOperation of Name.t * (ml_ty list * ml_ty)

--- a/src/syntax/syntax.mli
+++ b/src/syntax/syntax.mli
@@ -123,6 +123,7 @@ type ml_tydef =
 type toplevel = toplevel' located
 and toplevel' =
   | Rule of tt_constructor * premise list * boundary
+  | DefMLTypeAbstract of Path.t
   | DefMLType of Path.t list (* we only need the names *)
   | DefMLTypeRec of Path.t list
   | DeclOperation of Path.t * (Mlty.ty list * Mlty.ty)

--- a/src/syntax/syntax.mli
+++ b/src/syntax/syntax.mli
@@ -130,6 +130,7 @@ and toplevel' =
   | DeclExternal of Name.t * Mlty.ty_schema * string
   | TopLet of (Name.t * Mlty.ty_schema) list list * let_clause list
   | TopLetRec of (Name.t * Mlty.ty_schema) list * letrec_clause list
+  | TopWith of (operation * match_op_case) list
   | TopComputation of comp * Mlty.ty_schema
   | Verbosity of int
   | Open of Path.t

--- a/src/typing/context.ml
+++ b/src/typing/context.ml
@@ -202,6 +202,7 @@ let lookup_ml_type_id pth ctx = fst (lookup_ml_type pth ctx)
 let lookup_ml_constructor (t_pth, Path.Level (c_name, c_lvl)) ctx =
   match lookup_ml_type t_pth ctx with
   | _, Mlty.Alias _ -> assert false
+  | _, Mlty.Abstract _ -> assert false
   | _, Mlty.Sum (ps, cs) ->
      let (c_id, ts) = List.nth cs c_lvl in
      let pus = List.map (fun p -> (p, Mlty.fresh_type ())) ps in
@@ -233,6 +234,7 @@ let add_ml_value _name schema ctx =
 let unfold ctx t_pth ts =
   match lookup_ml_type t_pth ctx with
     | _, Mlty.Sum _ -> None
+    | _, Mlty.Abstract _ -> None
     | _, Mlty.Alias (ps, t) ->
        let pus = List.combine ps ts in
        Some (Mlty.instantiate pus t)

--- a/src/typing/mlty.ml
+++ b/src/typing/mlty.ml
@@ -62,6 +62,7 @@ type 'a forall = param list * 'a
 type ty_schema = ty forall
 
 type ty_def =
+  | Abstract of unit forall
   | Alias of ty forall
   | Sum of (Ident.t * ty list) list forall
 

--- a/src/typing/mlty.mli
+++ b/src/typing/mlty.mli
@@ -51,6 +51,7 @@ type ty_schema = ty forall
 
 (** The type of type definitions. *)
 type ty_def =
+  | Abstract of unit forall
   | Alias of ty forall
   | Sum of (Ident.t * ty list) list forall
 

--- a/src/typing/typecheck.ml
+++ b/src/typing/typecheck.ml
@@ -903,6 +903,9 @@ let rec toplevel' ({Location.it=c; at} : Desugared.toplevel) =
      Tyenv.add_tt_constructor r >>= fun () ->
      return_located ~at (Syntax.Rule (r, ps, bdry))
 
+  | Desugared.DefMLTypeAbstract t_pth ->
+     return_located ~at (Syntax.DefMLTypeAbstract t_pth)
+
   (* Desugar is the only place where recursion/nonrecursion matters,
      so [DefMLType] and [DefMLTypeRec] behave the same way in typechecking. *)
   | Desugared.DefMLType tydefs ->

--- a/src/typing/typecheck.ml
+++ b/src/typing/typecheck.ml
@@ -944,6 +944,9 @@ let rec toplevel' ({Location.it=c; at} : Desugared.toplevel) =
      letrec_clauses ~toplevel:true clauses (return ()) >>= fun (info, clauses, ()) ->
      return_located ~at (Syntax.TopLetRec (info, clauses))
 
+  | Desugared.TopWith lst ->
+     (??)
+
   | Desugared.TopComputation c ->
      infer_comp c >>= fun (c, t) ->
      begin

--- a/src/typing/typecheck.ml
+++ b/src/typing/typecheck.ml
@@ -903,8 +903,10 @@ let rec toplevel' ({Location.it=c; at} : Desugared.toplevel) =
      Tyenv.add_tt_constructor r >>= fun () ->
      return_located ~at (Syntax.Rule (r, ps, bdry))
 
-  | Desugared.DefMLTypeAbstract t_pth ->
-     return_located ~at (Syntax.DefMLTypeAbstract t_pth)
+  | Desugared.DefMLTypeAbstract (t, params) ->
+     let params = List.map (fun _ -> Mlty.fresh_param ()) params in
+     Tyenv.add_ml_type t (Mlty.Abstract (params, ())) >>= fun () ->
+     return_located ~at (Syntax.DefMLTypeAbstract t)
 
   (* Desugar is the only place where recursion/nonrecursion matters,
      so [DefMLType] and [DefMLTypeRec] behave the same way in typechecking. *)

--- a/src/typing/typecheck.ml
+++ b/src/typing/typecheck.ml
@@ -639,35 +639,39 @@ and match_cases ~at t = function
 
 and match_op_cases op cases =
   Tyenv.lookup_ml_operation op >>= fun (oid, (ts, t_out)) ->
-  let rec fold_cases cases = function
-    | [] -> return (oid, List.rev cases)
-    | (ps, popt, c) :: rem ->
-       let rec fold_args ps_out xts ps ts =
-         match ps, ts with
-
-         | [], [] ->
-            let ps_out = List.rev ps_out in
-            begin match popt with
-            | None -> return (None, xts)
-            | Some p ->
-               let t = Mlty.Apply (Desugar.Builtin.option, [Mlty.Boundary]) in
-               check_pattern p t >>= fun (p, xts_p) ->
-               return (Some p, xts @ xts_p)
-            end >>= fun (popt, xts) ->
-            Tyenv.add_bounds_mono xts
-              (check_comp c t_out >>= fun c -> return (ps_out, popt, c))
-
-         | p::ps, t::ts ->
-            check_pattern p t >>= fun (p, xts_p) ->
-            fold_args (p :: ps_out) (xts @ xts_p) ps ts
-
-         | [], _::_ | _::_, [] ->
-            assert false
-       in
-       fold_args [] [] ps ts >>= fun case ->
-       fold_cases (case :: cases) rem
+  let rec fold_cases cases' = function
+    | [] -> return (oid, List.rev cases')
+    | case :: cases ->
+       match_op_case ts t_out case >>= fun case ->
+       fold_cases (case :: cases') cases
   in
   fold_cases [] cases
+
+and match_op_case ts t_out (ps, popt, c) =
+  let rec fold_args ps_out xts ps ts =
+    match ps, ts with
+
+    | [], [] ->
+       let ps_out = List.rev ps_out in
+       begin match popt with
+       | None -> return (None, xts)
+       | Some p ->
+          let t = Mlty.Apply (Desugar.Builtin.option, [Mlty.Boundary]) in
+          check_pattern p t >>= fun (p, xts_p) ->
+          return (Some p, xts @ xts_p)
+       end >>= fun (popt, xts) ->
+       Tyenv.add_bounds_mono xts
+         (check_comp c t_out >>= fun c -> return (ps_out, popt, c))
+
+    | p::ps, t::ts ->
+       check_pattern p t >>= fun (p, xts_p) ->
+       fold_args (p :: ps_out) (xts @ xts_p) ps ts
+
+    | [], _::_ | _::_, [] ->
+       assert false
+  in
+  fold_args [] [] ps ts
+
 
 and check_comp c t =
   infer_comp c >>= fun (c, t') ->
@@ -945,7 +949,16 @@ let rec toplevel' ({Location.it=c; at} : Desugared.toplevel) =
      return_located ~at (Syntax.TopLetRec (info, clauses))
 
   | Desugared.TopWith lst ->
-     (??)
+     let rec fold lst' = function
+       | [] ->
+          let lst' = List.rev lst' in
+          return_located ~at (Syntax.TopWith lst')
+       | (op, case) :: lst ->
+          Tyenv.lookup_ml_operation op >>= fun (oid, (ts, t_out)) ->
+          match_op_case ts t_out case >>= fun case ->
+          fold ((oid, case) :: lst') lst
+     in
+     fold [] lst
 
   | Desugared.TopComputation c ->
      infer_comp c >>= fun (c, t) ->

--- a/tests/runtime/top_handler.m31
+++ b/tests/runtime/top_handler.m31
@@ -1,0 +1,25 @@
+operation auto : judgement ;;
+
+rule A type ;;
+rule a : A ;;
+rule B type ;;
+rule b : B ;;
+
+rule prod (X type) (Y type) type ;;
+rule pair (X type) (Y type) (x : X) (y : Y) : prod X Y ;;
+
+exception Auto_cannot_infer ;;
+
+(* this looks cool, but it's not useful at large scale because
+   one loses control over what's going on *)
+with
+| operation auto : ML.None -> raise Auto_cannot_infer
+| operation auto : ML.Some (?? : A) -> a
+| operation auto : ML.Some (?? : B) -> b
+| operation auto : ML.Some (?? : prod X Y) -> pair X Y auto auto
+end ;;
+
+(auto : A) ;;
+(auto : prod A B) ;;
+(auto : prod (prod A B) A) ;;
+auto ;;

--- a/tests/runtime/top_handler.m31.ref
+++ b/tests/runtime/top_handler.m31.ref
@@ -1,0 +1,13 @@
+Operation auto is declared.
+Rule A is postulated.
+Rule a is postulated.
+Rule B is postulated.
+Rule b is postulated.
+Rule prod is postulated.
+Rule pair is postulated.
+Exception Auto_cannot_infer is declared.
+- : judgement = ⊢ a
+- : judgement = ⊢ pair A B a b
+- : judgement = ⊢ pair (prod A B) A (pair A B a b) a
+File "./runtime/top_handler.m31", line 25, characters 1-4:
+Runtime error: uncaught exception Auto_cannot_infer

--- a/tests/types/abstract_type.m31
+++ b/tests/types/abstract_type.m31
@@ -1,1 +1,8 @@
 mltype cow ;;
+
+mltype pretty _ ;;
+
+let f (x :> pretty cow) = x ;;
+
+[f; f] ;;
+

--- a/tests/types/abstract_type.m31
+++ b/tests/types/abstract_type.m31
@@ -1,0 +1,1 @@
+mltype cow ;;

--- a/tests/types/abstract_type.m31.ref
+++ b/tests/types/abstract_type.m31.ref
@@ -1,0 +1,1 @@
+ML type cow declared.

--- a/tests/types/abstract_type.m31.ref
+++ b/tests/types/abstract_type.m31.ref
@@ -1,1 +1,4 @@
 ML type cow declared.
+ML type pretty declared.
+val f :> pretty cow → pretty cow = <function>
+- : list (pretty cow → pretty cow) = <function> :: <function> :: []

--- a/tests/types/typedefs.m31
+++ b/tests/types/typedefs.m31
@@ -11,9 +11,9 @@ mltype fruit = ananas | banana
 mltype part a = ear | tail | paw of a * a | wing
 
 mltype rec rodent a =
-  | Hare of part (rodent (a * fruit)) with a with a
+  | Hare of part (rodent (a * fruit)) * a * a
   | Squirrel of part fruit * part fruit
 
 and insect =
   | Bee
-  | Ant of part fruit with rodent insect -> part (part fruit)
+  | Ant of part fruit * (rodent insect -> part (part fruit))


### PR DESCRIPTION
We may now delcare an abstract ML type (i.e., one without a definition):

   mltype cow ;;

This will allow us to streamline definitions of abstract and primitive ML types (`judgement`, `mlstring`, etc.).