### PR TITLE
Rules as derivations

### DIFF
--- a/src/nucleus/form.ml
+++ b/src/nucleus/form.ml
@@ -169,43 +169,66 @@ let form_eq_type_rap sgn drv =
 let form_eq_term_rap sgn drv =
   form_rule_rap sgn (Instantiate_meta.eq_term ~lvl:0) drv
 
+(* A rather finicky and dangerous operation that directly makes a derivation out
+   of a primitive rule, by directly manipulating bound meta-variables. *)
+let rule_as_derivation sgn cnstr =
+  (* look up the rule *)
+  let rl = Signature.lookup_rule cnstr sgn in
+  (* compute the arity of the rule *)
+  let arity =
+    let rec count = function
+      | Conclusion _ -> 0
+      | Premise (_, bdry) -> 1 + count bdry
+    in
+    count rl
+  in
+  let rec fold k args = function
+    | Conclusion bdry ->
+       let args = List.rev args in
+       let jdg =
+         match bdry with
+         | BoundaryIsType () -> JudgementIsType (Mk.type_constructor cnstr args)
+         | BoundaryIsTerm _ -> JudgementIsTerm (Mk.term_constructor cnstr args)
+         | BoundaryEqType (t1, t2) ->
+            let asmp = Collect_assumptions.arguments args in
+            JudgementEqType (Mk.eq_type asmp t1 t2)
+         | BoundaryEqTerm (e1, e2, t) ->
+            let asmp = Collect_assumptions.arguments args in
+            JudgementEqTerm (Mk.eq_term asmp e1 e2 t)
+       in
+       Conclusion jdg
 
-
-(* (\** Form a rap from a derivation *\)
- * let form_derivation_rap sgn drv =
- *   let rec fold args = function
- *     | Premise (_, prem, drv) ->
- *        let bdry = Instantiate_meta.abstraction Form_rule.instantiate_premise ~lvl:0 args prem in
- *        let rap abstr =
- *          if not (Check.judgement_boundary_abstraction sgn abstr bdry)
- *          then Error.raise InvalidArgument ;
- *          let arg = Judgement.to_argument abstr in
- *          let args = arg :: args in
- *          fold args drv
- *        in
- *        RapMore (bdry, rap)
- *
- *     | Conclusion (JudgementIsType t_schema) ->
- *        let t = Instantiate_meta.is_type ~lvl:0 args t_schema in
- *        RapDone (JudgementIsType t)
- *
- *     | Conclusion (JudgementIsTerm e_schema) ->
- *        let e = Instantiate_meta.is_term ~lvl:0 args e_schema in
- *        RapDone (JudgementIsTerm e)
- *
- *     | Conclusion (JudgementEqType eq_schema) ->
- *        (\* order of arguments not important in [Collect_assumptions.arguments],
- *           we could try avoiding a list reversal caused by [Indices.to_list]. *\)
- *        let eq = Instantiate_meta.eq_type ~lvl:0 args eq_schema in
- *        RapDone (JudgementEqType eq)
- *
- *     | Conclusion (JudgementEqTerm eq_schema) ->
- *        (\* order of arguments not important in [Collect_assumptions.arguments],
- *           we could try avoiding a list reversal caused by [Indices.to_list]. *\)
- *        let eq = Instantiate_meta.eq_term ~lvl:0 args eq_schema in
- *        RapDone (JudgementEqTerm eq)
- *   in
- *   fold [] drv *)
+    | Premise (prem, bdry) ->
+       (* compute the k-th argument *)
+       let rec mk_arg i args = function
+         | NotAbstract bdry ->
+            let args = List.rev args in
+            let jdg =
+              match bdry with
+              | BoundaryIsType () -> JudgementIsType (Mk.type_meta (MetaBound k) args)
+              | BoundaryIsTerm _ -> JudgementIsTerm (Mk.term_meta (MetaBound k) args)
+              | BoundaryEqType (t1, t2) ->
+                 let t1 = Shift_meta.is_type (k+1) t1
+                 and t2 = Shift_meta.is_type (k+1) t2 in
+                 let asmp = Collect_assumptions.term_arguments ~lvl:k args in
+                 JudgementEqType (Mk.eq_type asmp t1 t2)
+              | BoundaryEqTerm (e1, e2, t) ->
+                 let e1 = Shift_meta.is_term (k+1) e1
+                 and e2 = Shift_meta.is_term (k+1) e2
+                 and t = Shift_meta.is_type (k+1) t in
+                 let asmp = Collect_assumptions.term_arguments ~lvl:k args in
+                 JudgementEqTerm (Mk.eq_term asmp e1 e2 t)
+            in
+            Arg_NotAbstract jdg
+         | Abstract (x, t, bdry) ->
+            let args = (TermBoundVar i) :: args in
+            Arg_Abstract (x, mk_arg (i+1) args bdry)
+       in
+       let arg = mk_arg 0 [] prem.meta_boundary in
+       let drv = fold (k-1) (arg :: args) bdry in
+       Premise (prem, drv)
+  in
+  fold (arity-1) [] rl
 
 (** Formation of a term from an atom *)
 let form_is_term_atom = Mk.atom

--- a/src/nucleus/nucleus.ml
+++ b/src/nucleus/nucleus.ml
@@ -48,6 +48,7 @@ let form_eq_type_rap = Form.form_eq_type_rap
 let form_eq_term_rap = Form.form_eq_term_rap
 
 let form_derivation_rap = Form.form_derivation_rap
+let rule_as_derivation = Form.rule_as_derivation
 
 (** Miscelaneous constructions *)
 let form_is_term_atom = Form.form_is_term_atom

--- a/src/nucleus/nucleus.mli
+++ b/src/nucleus/nucleus.mli
@@ -122,6 +122,9 @@ val form_rule : meta list -> boundary -> primitive
 (** Form a derived rule from a given list of meta-variables and a boundary *)
 val form_derivation : meta list -> judgement -> derivation
 
+(** Form a derivation that corresponds to a primitive rule *)
+val rule_as_derivation : signature -> Ident.t -> derivation
+
 (** Functions that expose abstract types. These are harmless because there is no way
     to map back into the absract types. *)
 val expose_is_term : is_term -> Nucleus_types.is_term

--- a/src/parser/desugar.ml
+++ b/src/parser/desugar.ml
@@ -1049,8 +1049,10 @@ let rec comp ctx {Location.it=c';at} =
      | Value pth -> locate (Desugared.Value pth)
 
      | TTConstructor (pth, arity) ->
-        check_tt_arity ~at x 0 arity ;
-        locate (Desugared.TTConstructor (pth, []))
+        if arity = 0 then
+          locate (Desugared.TTConstructor (pth, []))
+        else
+          locate (Desugared.AsDerivation pth)
 
      | MLConstructor (pth, arity) ->
         check_ml_arity ~at x 0 arity ;

--- a/src/runtime/eval.ml
+++ b/src/runtime/eval.ml
@@ -80,6 +80,11 @@ let rec comp {Location.it=c'; at} =
           return (Runtime.Exc (exc, Some v))
        end
 
+    | Syntax.AsDerivation cnstr ->
+       Runtime.lookup_signature >>= fun sgn ->
+       let drv = Nucleus.rule_as_derivation sgn cnstr in
+       return (Runtime.Derivation drv)
+
     | Syntax.TTConstructor (cnstr, cs) ->
        Runtime.lookup_signature >>= fun sgn ->
        let rap = Nucleus.form_constructor_rap sgn cnstr in
@@ -371,6 +376,7 @@ and check_judgement ({Location.it=c'; at} as c) bdry =
   | Syntax.TypeAscribe _
   | Syntax.MLConstructor _
   | Syntax.TTConstructor _
+  | Syntax.AsDerivation _
   | Syntax.MLException _
   | Syntax.TTApply _
   | Syntax.Tuple _

--- a/src/syntax/desugared.mli
+++ b/src/syntax/desugared.mli
@@ -74,6 +74,7 @@ and comp' =
   | Match of comp * match_case list
   | BoundaryAscribe of comp * comp
   | TypeAscribe of comp * comp
+  | AsDerivation of Path.t
   | TTConstructor of Path.t * comp list
   | Spine of comp * comp list
   | Abstract of Name.t * comp option * comp

--- a/src/syntax/syntax.mli
+++ b/src/syntax/syntax.mli
@@ -62,6 +62,7 @@ and comp' =
   | Match of comp * match_case list
   | BoundaryAscribe of comp * comp
   | TypeAscribe of comp * comp
+  | AsDerivation of tt_constructor
   | TTConstructor of tt_constructor * comp list
   | TTApply of comp * comp list
   | Apply of comp * comp

--- a/tests/nucleus/rule_as_derivation.m31
+++ b/tests/nucleus/rule_as_derivation.m31
@@ -1,0 +1,14 @@
+rule bull type ;;
+bull ;;
+rule tail : bull ;;
+tail ;;
+rule eq : tail ≡ tail : bull ;;
+eq ;;
+rule Id (A type) (a : A) (b : A) type ;;
+Id ;;
+rule Pi (A type) ({x : A} B type) type ;;
+Pi ;;
+rule cow (A type) (a : A) ({x : A} a ≡ x : A as ξ) type ;;
+cow ;;
+rule reflect (A type) (a : A) (b : A) (p : Id A a b) : a ≡ b : A ;;
+reflect ;;

--- a/tests/nucleus/rule_as_derivation.m31.ref
+++ b/tests/nucleus/rule_as_derivation.m31.ref
@@ -1,0 +1,16 @@
+Rule bull is postulated.
+- : judgement = ⊢ bull type
+Rule tail is postulated.
+- : judgement = ⊢ tail
+Rule eq is postulated.
+- : judgement = ⊢ tail ≡ tail : bull
+Rule Id is postulated.
+- : derivation = derive (A type) (a : A) (b : A) → Id A a b type
+Rule Pi is postulated.
+- : derivation = derive (A type) ({_ : A} B type) → Pi A ({x} B {x}) type
+Rule cow is postulated.
+- : derivation = derive (A type) (a : A) ({x : A} a ≡ x : A as ξ) → cow
+  A a ({x} a ≡ x : A) type
+Rule reflect is postulated.
+- : derivation = derive (A type) (a : A) (b : A) (p : Id A a b) → a ≡ b :
+  A


### PR DESCRIPTION
If a primitive rule `R` is used in a non-applied form, then it is automatically converted to a derivation. For example:

```
# rule Pi (A type) ({_ : A} _ type) type
Rule Pi is postulated.
# Pi
- : derivation = derive (A type) ({_ : A} _ type) → Pi A ({x₀} _ {x₀})
  type
```
Previously, typing `Pi` like that would just give an error (saying that `Pi` must be applied exactly once).