### PR TITLE
some tests for equality checker

### DIFF
--- a/tests/equality-checker.m31
+++ b/tests/equality-checker.m31
@@ -1,0 +1,77 @@
+require eq ;;
+
+(* Unit type *)
+rule unit type;;
+rule tt : unit;;
+rule unit_ext (x : unit) (y : unit): x ≡ y : unit;;
+
+eq.add_rule unit_ext;;
+
+(* Simple products *)
+
+rule prod (A type) (B type) type ;;
+rule pair (A type) (B type) (x : A) (y : B) : prod A B ;;
+rule fst (A type) (B type) (_ : prod A B) : A ;;
+rule snd (A type) (B type) (_ : prod A B) : B ;;
+
+rule β_fst (A type) (B type) (x : A) (y : B) : fst A B (pair A B x y) ≡ x : A ;;
+rule β_snd (A type) (B type) (x : A) (y : B) : snd A B (pair A B x y) ≡ y : B ;;
+
+rule prod_ext (A type) (B type) (u : prod A B) (v : prod A B)
+              (fst A B u ≡ fst A B v : A as ξ)
+              (snd A B u ≡ snd A B v : B as ζ)
+              :
+              u ≡ v : prod A B  ;;
+
+eq.add_rule β_fst;;
+eq.add_rule β_snd;;
+eq.add_rule prod_ext;;
+        
+rule U type;;
+rule V type;;
+rule p : prod U V;;
+rule u : U;;
+rule v : V;;
+
+eq.normalize (fst U V (pair U V u v));;
+eq.normalize (snd U V (pair U V u v));;
+
+eq.prove (p ≡ pair U V (fst U V p) (snd U V p) : prod U V as ??);;
+
+(* Natural numbers *)
+
+rule ℕ type;;
+
+rule z : ℕ;;
+
+rule s (n : ℕ) : ℕ;;
+
+rule ℕ_ind
+  ({x : ℕ} C type)
+  (base : C{z})
+  ({n : ℕ} {c_n : C{n}} step : C{s n})
+  (k : ℕ)
+  : C{k}
+
+rule ℕ_β_z
+  ({x : ℕ} C type)
+  (base : C{z})
+  ({n : ℕ} {c_n : C{n}} step : C{s n})
+  : ℕ_ind C base step z == base : C{z}
+
+rule ℕ_β_s
+  ({x : ℕ} C type)
+  (base : C{z})
+  ({n : ℕ} {c_n : C{n}} step : C{s n})
+  (k : ℕ)
+  : ℕ_ind C base step (s k) == step { k, ℕ_ind C base step k } : C { s k };;
+
+eq.add_rule ℕ_β_s;;
+eq.add_rule ℕ_β_z;;
+
+let plus = derive (n : ℕ) (m : ℕ) -> ℕ_ind ({_} ℕ) n ({k : ℕ} {c_k : ℕ} s c_k) m ;;
+let foo = plus (z) (s z);;
+eq.normalize foo;;
+eq.normalize (ℕ_ind ({_} ℕ) z ({c_n _} s c_n) z);;
+eq.normalize (s (ℕ_ind ({_} ℕ) z ({c_n _} s c_n) z));;
+eq.prove (plus (s z) (s z) ≡ s (s z) : ℕ as ??)

--- a/tests/equality-checker.m31.ref
+++ b/tests/equality-checker.m31.ref
@@ -1,0 +1,99 @@
+Processing module eq
+ML type eq.checker declared.
+Exception eq.Invalid_equality_rule is declared.
+external empty_checker : eq.checker = "Eqchk.empty_checker"
+external add_type_computation : eq.checker → derivation → ML.option
+  eq.checker = "Eqchk.add_type_computation"
+external add_term_computation : eq.checker → derivation → ML.option
+  eq.checker = "Eqchk.add_term_computation"
+external add : eq.checker → derivation → ML.option
+  eq.checker = "Eqchk.add"
+external normalize_type : eq.checker → judgement →
+  judgement * judgement = "Eqchk.normalize_type"
+external normalize_term : eq.checker → judgement →
+  judgement * judgement = "Eqchk.normalize_term"
+external add_extensionality : eq.checker → derivation → ML.option
+  eq.checker = "Eqchk.add_extensionality"
+external prove_eqtype_abstraction : eq.checker → boundary → ML.option
+  judgement = "Eqchk.prove_eq_type_abstraction"
+external prove_eqterm_abstraction : eq.checker → boundary → ML.option
+  judgement = "Eqchk.prove_eq_term_abstraction"
+val ch :> ref eq.checker = ref <checker>
+val add_rule :> derivation → mlunit = <function>
+Exception eq.Coerce_fail is declared.
+val equalize_type :> judgement → judgement → judgement = <function>
+val coerce_abstraction :> judgement → boundary → judgement = <function>
+val normalize :> judgement → judgement * judgement = <function>
+val prove :> boundary → ML.option judgement = <function>
+Rule unit is postulated.
+Rule tt is postulated.
+Rule unit_ext is postulated.
+Extensionality rule for unit: derive (x : unit) (y : unit) → x ≡ y :
+unit
+- : mlunit = ()
+Rule prod is postulated.
+Rule pair is postulated.
+Rule fst is postulated.
+Rule snd is postulated.
+Rule β_fst is postulated.
+Rule β_snd is postulated.
+Rule prod_ext is postulated.
+Term computation rule for fst (heads at [2]):
+  derive (A type) (B type) (x : A) (y : B) → fst A B (pair A B x y) ≡ x :
+  A
+
+- : mlunit = ()
+Term computation rule for snd (heads at [2]):
+  derive (A type) (B type) (x : A) (y : B) → snd A B (pair A B x y) ≡ y :
+  B
+
+- : mlunit = ()
+Extensionality rule for prod: derive (A type) (B type) (u : prod A B) (v :
+prod A B) (fst A B u ≡ fst A B v : A as ξ) (snd A B u ≡ snd A B v :
+B as ζ) → u ≡ v : prod A
+B
+- : mlunit = ()
+Rule U is postulated.
+Rule V is postulated.
+Rule p is postulated.
+Rule u is postulated.
+Rule v is postulated.
+- : judgement * judgement = ((⊢ fst U V (pair U V u v) ≡ u : U), (⊢ u))
+- : judgement * judgement = ((⊢ snd U V (pair U V u v) ≡ v : V), (⊢ v))
+- : ML.option judgement =
+  ML.Some (⊢ p ≡ pair U V (fst U V p) (snd U V p) : prod U V)
+Rule ℕ is postulated.
+Rule z is postulated.
+Rule s is postulated.
+Rule ℕ_ind is postulated.
+Rule ℕ_β_z is postulated.
+Rule ℕ_β_s is postulated.
+Term computation rule for ℕ_ind (heads at [3]):
+  derive ({_ : ℕ} C type) (base : C {z}) ({n : ℕ} {_ : C {n}} step : C {s
+  n}) (k : ℕ) → ℕ_ind ({x} C {x}) base ({c_n n} step {n} {c_n}) (s k)
+  ≡ step {k} {ℕ_ind ({x} C {x}) base ({c_n n} step {n} {c_n}) k} : C {s
+  k}
+
+- : mlunit = ()
+Term computation rule for ℕ_ind (heads at [3]):
+  derive ({_ : ℕ} C type) (base : C {z}) ({n : ℕ} {_ : C {n}} step : C {s
+  n}) → ℕ_ind ({x} C {x}) base ({c_n n} step {n} {c_n}) z ≡ base : C
+  {z}
+
+- : mlunit = ()
+val plus :> derivation = derive (n : ℕ) (m : ℕ) → ℕ_ind ({_} ℕ) n
+  ({c_n _} s c_n) m
+val foo :> judgement = ⊢ ℕ_ind ({_} ℕ) z ({c_n _} s c_n) (s z)
+- : judgement * judgement =
+  ((⊢ ℕ_ind ({_} ℕ) z ({c_n _} s c_n) (s z) ≡ s (ℕ_ind ({_} ℕ) z
+   ({c_n _} s c_n) z) : ℕ), (⊢ s (ℕ_ind ({_} ℕ) z ({c_n _} s c_n)
+   z)))
+- : judgement * judgement =
+  ((⊢ ℕ_ind ({_} ℕ) z ({_ c_n} s c_n) z ≡ z : ℕ), (⊢ z))
+- : judgement * judgement =
+  ((⊢ s (ℕ_ind ({_} ℕ) z ({_ c_n} s c_n) z) ≡ s (ℕ_ind ({_} ℕ) z
+   ({_ c_n} s c_n) z) : ℕ), (⊢ s (ℕ_ind ({_} ℕ) z ({_ c_n} s c_n)
+   z)))
+- : ML.option judgement =
+  ML.Some (⊢ ℕ_ind ({_} ℕ) (s z) ({c_n _} s c_n) (s z) ≡ s (s z) :
+    ℕ)


### PR DESCRIPTION
A few examples on how to use equality checker:
- unit type with extensionality rule
- simple products with computation rules for projections and extensionality rule. Eqchk can prove eta-rule.
- natural numbers with normalization of induction principle. 