### PR TITLE
Fix topcomp printing

### DIFF
--- a/src/runtime/eval.ml
+++ b/src/runtime/eval.ml
@@ -824,7 +824,7 @@ let rec toplevel ~quiet ~print_annot {Location.it=c; at} =
      comp_value c >>= fun v ->
      Runtime.top_lookup_penv >>= fun penv ->
      if not quiet then
-       Format.printf "@[<hov 2>- :@ %t@ =@ %t@]@."
+       Format.printf "@[<hov 2>- :>@ %t@ =@ %t@]@."
            (print_annot () sch)
            (Runtime.print_value ~penv v) ;
      return ()

--- a/tests/equality-checker.m31.ref
+++ b/tests/equality-checker.m31.ref
@@ -32,7 +32,7 @@ Rule tt is postulated.
 Rule unit_ext is postulated.
 Extensionality rule for unit: derive (x : unit) (y : unit) → x ≡ y :
 unit
-- : mlunit = ()
+- :> mlunit = ()
 Rule prod is postulated.
 Rule pair is postulated.
 Rule fst is postulated.
@@ -44,25 +44,27 @@ Term computation rule for fst (heads at [2]):
   derive (A type) (B type) (x : A) (y : B) → fst A B (pair A B x y) ≡ x :
   A
 
-- : mlunit = ()
+- :> mlunit = ()
 Term computation rule for snd (heads at [2]):
   derive (A type) (B type) (x : A) (y : B) → snd A B (pair A B x y) ≡ y :
   B
 
-- : mlunit = ()
+- :> mlunit = ()
 Extensionality rule for prod: derive (A type) (B type) (u : prod A B) (v :
 prod A B) (fst A B u ≡ fst A B v : A by ξ) (snd A B u ≡ snd A B v :
 B by ζ) → u ≡ v : prod A
 B
-- : mlunit = ()
+- :> mlunit = ()
 Rule U is postulated.
 Rule V is postulated.
 Rule p is postulated.
 Rule u is postulated.
 Rule v is postulated.
-- : judgement * judgement = ((⊢ fst U V (pair U V u v) ≡ u : U), (⊢ u))
-- : judgement * judgement = ((⊢ snd U V (pair U V u v) ≡ v : V), (⊢ v))
-- : judgement = ⊢ p ≡ pair U V (fst U V p) (snd U V p) : prod U V
+- :> judgement * judgement =
+  ((⊢ fst U V (pair U V u v) ≡ u : U), (⊢ u))
+- :> judgement * judgement =
+  ((⊢ snd U V (pair U V u v) ≡ v : V), (⊢ v))
+- :> judgement = ⊢ p ≡ pair U V (fst U V p) (snd U V p) : prod U V
 Rule ℕ is postulated.
 Rule z is postulated.
 Rule s is postulated.
@@ -75,25 +77,25 @@ Term computation rule for ℕ_ind (heads at [3]):
   ≡ step {k} {ℕ_ind ({x} C {x}) base ({c_n n} step {n} {c_n}) k} : C {s
   k}
 
-- : mlunit = ()
+- :> mlunit = ()
 Term computation rule for ℕ_ind (heads at [3]):
   derive ({_ : ℕ} C type) (base : C {z}) ({n : ℕ} {_ : C {n}} step : C {s
   n}) → ℕ_ind ({x} C {x}) base ({c_n n} step {n} {c_n}) z ≡ base : C
   {z}
 
-- : mlunit = ()
+- :> mlunit = ()
 val plus :> derivation = derive (n : ℕ) (m : ℕ) → ℕ_ind ({_} ℕ) n
   ({c_n _} s c_n) m
 val foo :> judgement = ⊢ ℕ_ind ({_} ℕ) z ({c_n _} s c_n) (s z)
-- : judgement * judgement =
+- :> judgement * judgement =
   ((⊢ ℕ_ind ({_} ℕ) z ({c_n _} s c_n) (s z) ≡ s (ℕ_ind ({_} ℕ) z
    ({c_n _} s c_n) z) : ℕ), (⊢ s (ℕ_ind ({_} ℕ) z ({c_n _} s c_n)
    z)))
-- : judgement * judgement =
+- :> judgement * judgement =
   ((⊢ ℕ_ind ({_} ℕ) z ({_ c_n} s c_n) z ≡ z : ℕ), (⊢ z))
-- : judgement * judgement =
+- :> judgement * judgement =
   ((⊢ s (ℕ_ind ({_} ℕ) z ({_ c_n} s c_n) z) ≡ s (ℕ_ind ({_} ℕ) z
    ({_ c_n} s c_n) z) : ℕ), (⊢ s (ℕ_ind ({_} ℕ) z ({_ c_n} s c_n)
    z)))
-- : judgement = ⊢ ℕ_ind ({_} ℕ) (s z) ({c_n _} s c_n) (s z) ≡ s (s z)
-  : ℕ
+- :> judgement = ⊢ ℕ_ind ({_} ℕ) (s z) ({c_n _} s c_n) (s z) ≡ s (s
+  z) : ℕ

--- a/tests/equality/strong.m31.ref
+++ b/tests/equality/strong.m31.ref
@@ -39,47 +39,47 @@ Rule times_s is postulated.
 Term computation rule for plus (heads at [1]):
   derive (m : N) → plus m z ≡ m : N
 
-- : mlunit = ()
+- :> mlunit = ()
 Term computation rule for plus (heads at [1]):
   derive (m : N) (n : N) → plus m (s n) ≡ s (plus m n) : N
 
-- : mlunit = ()
+- :> mlunit = ()
 Term computation rule for times (heads at [1]):
   derive (m : N) → times m z ≡ z : N
 
-- : mlunit = ()
+- :> mlunit = ()
 Term computation rule for times (heads at [1]):
   derive (m : N) (n : N) → times m (s n) ≡ plus (times m n) m : N
 
-- : mlunit = ()
+- :> mlunit = ()
 val one :> judgement = ⊢ s z
 val two :> judgement = ⊢ s (s z)
 val three :> judgement = ⊢ s (s (s z))
 val four :> judgement = ⊢ s (s (s (s z)))
 val five :> judgement = ⊢ plus (s (s z)) (s (s (s z)))
 val six :> judgement = ⊢ plus (s (s (s z))) (s (s (s z)))
-- : judgement = ⊢ plus (s (s (s z))) (s (s (s z))) ≡ plus (s (s z)) (s (s
-  (s (s z)))) : N
-- : judgement * judgement =
+- :> judgement = ⊢ plus (s (s (s z))) (s (s (s z))) ≡ plus (s (s z)) (s
+  (s (s (s z)))) : N
+- :> judgement * judgement =
   ((⊢ plus (s z) (s z) ≡ s (plus (s z) z) : N), (⊢ s (plus (s z) z)))
-- : judgement * judgement =
+- :> judgement * judgement =
   ((⊢ plus (s (s (s z))) (s (s (s z))) ≡ s (plus (s (s (s z))) (s (s z)))
    : N), (⊢ s (plus (s (s (s z))) (s (s z)))))
-- : judgement * judgement =
+- :> judgement * judgement =
   ((⊢ plus (s (s (s z))) (s (s (s z))) ≡ s (s (s (s (s (s z))))) : N),
    (⊢ s (s (s (s (s (s z)))))))
-- : judgement * judgement =
+- :> judgement * judgement =
   ((⊢ plus (plus (s (s z)) (s (s (s z)))) (plus (s (s (s z))) (s (s (s
    z)))) ≡ s (plus (plus (s (s z)) (s (s (s z)))) (plus (s (s (s z))) (s (s
    z)))) : N), (⊢ s (plus (plus (s (s z)) (s (s (s z)))) (plus (s (s (s
    z))) (s (s z))))))
-- : judgement = ⊢ plus (plus (s (s z)) (s (s (s z)))) (plus (s (s (s z)))
+- :> judgement = ⊢ plus (plus (s (s z)) (s (s (s z)))) (plus (s (s (s z)))
   (s (s (s z)))) ≡ s (s (s (s (s (s (s (s (s (s (s z)))))))))) : N
-- : judgement * judgement =
+- :> judgement * judgement =
   ((⊢ plus (plus (s (s z)) (s (s (s z)))) (plus (s (s (s z))) (s (s (s
    z)))) ≡ s (s (s (s (s (s (s (s (s (s (s z)))))))))) : N), (⊢ s (s (s
    (s (s (s (s (s (s (s (s z))))))))))))
-- : judgement * judgement =
+- :> judgement * judgement =
   ((⊢ times (s (s z)) (times (plus (s (s (s z))) (s (s (s z)))) (plus (s (s
    (s z))) (s (s (s z))))) ≡ s (s (s (s (s (s (s (s (s (s (s (s (s (s (s (s
    (s (s (s (s (s (s (s (s (s (s (s (s (s (s (s (s (s (s (s (s (s (s (s (s (s
@@ -90,6 +90,6 @@ val six :> judgement = ⊢ plus (s (s (s z))) (s (s (s z)))
    (s (s (s (s (s (s (s (s (s (s (s (s (s (s (s (s (s (s (s (s (s (s (s (s (s
    (s (s (s (s (s (s (s (s (s (s (s (s (s (s (s (s (s (s (s (s (s (s (s (s (s
    z)))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))
-- : judgement = ⊢ times (plus (s (s z)) (s (s (s z)))) (plus (s (s (s z)))
+- :> judgement = ⊢ times (plus (s (s z)) (s (s (s z)))) (plus (s (s (s z)))
   (s (s (s z)))) ≡ plus (plus (s (s z)) (s (s (s z)))) (times (plus (s (s
   z)) (s (s (s z)))) (plus (s (s z)) (s (s (s z))))) : N

--- a/tests/modules/module_include.m31.ref
+++ b/tests/modules/module_include.m31.ref
@@ -1,8 +1,8 @@
 Processing module A
 val x :> ref mlstring = ref "A.x"
 Processing module B
-- : mlstring = "A.x"
-- : mlstring = "A.x"
-- : mlunit = ()
-- : mlstring = "B.x"
-- : mlstring = "B.x"
+- :> mlstring = "A.x"
+- :> mlstring = "A.x"
+- :> mlunit = ()
+- :> mlstring = "B.x"
+- :> mlstring = "B.x"

--- a/tests/modules/module_open_print.m31.ref
+++ b/tests/modules/module_open_print.m31.ref
@@ -1,7 +1,7 @@
 Processing module A
 Rule A.X is postulated.
 ML type A.cow declared.
-- : judgement = ⊢ A.X type
-- : A.cow = A.Cow
-- : judgement = ⊢ X type
-- : A.cow = Cow
+- :> judgement = ⊢ A.X type
+- :> A.cow = A.Cow
+- :> judgement = ⊢ X type
+- :> A.cow = Cow

--- a/tests/nucleus/abstraction_congruence.m31.ref
+++ b/tests/nucleus/abstraction_congruence.m31.ref
@@ -4,4 +4,4 @@ Rule T is postulated.
 Rule a is postulated.
 Rule b is postulated.
 Rule S is postulated.
-- : derivation = derive (a ≡ b : T by ζ) → S a a ≡ S b b
+- :> derivation = derive (a ≡ b : T by ζ) → S a a ≡ S b b

--- a/tests/nucleus/boundary.m31.ref
+++ b/tests/nucleus/boundary.m31.ref
@@ -2,16 +2,16 @@ Rule A is postulated.
 Rule B is postulated.
 Rule a is postulated.
 Rule b is postulated.
-- : boundary = ⊢ ⁇ type
-- : boundary = ⊢ {_ : A} {_ : A} ⁇ type
-- : boundary = ⊢ ⁇ : A
-- : boundary = ⊢ {_ : A} {_ : A} ⁇ : A
-- : boundary = ⊢ A ≡ B by ⁇
-- : boundary = ⊢ {_ : A} {_ : A} A ≡ B by ⁇
-- : boundary = ⊢ a ≡ b : A by ⁇
-- : boundary = ⊢ {x : A} a ≡ x : A by ⁇
+- :> boundary = ⊢ ⁇ type
+- :> boundary = ⊢ {_ : A} {_ : A} ⁇ type
+- :> boundary = ⊢ ⁇ : A
+- :> boundary = ⊢ {_ : A} {_ : A} ⁇ : A
+- :> boundary = ⊢ A ≡ B by ⁇
+- :> boundary = ⊢ {_ : A} {_ : A} A ≡ B by ⁇
+- :> boundary = ⊢ a ≡ b : A by ⁇
+- :> boundary = ⊢ {x : A} a ≡ x : A by ⁇
 Rule ξ is postulated.
-- : judgement = ⊢ a
+- :> judgement = ⊢ a
 Rule P is postulated.
 Rule ζ is postulated.
-- : judgement = ⊢ {z : A} P z ≡ P z
+- :> judgement = ⊢ {z : A} P z ≡ P z

--- a/tests/nucleus/congruence.m31.ref
+++ b/tests/nucleus/congruence.m31.ref
@@ -3,16 +3,16 @@ Rule B is postulated.
 Rule Π is postulated.
 Rule a is postulated.
 Rule b is postulated.
-- : judgement = ⊢ a ≡ a : A
+- :> judgement = ⊢ a ≡ a : A
 Rule isPropA is postulated.
-- : judgement = ⊢ B a a ≡ B a b
+- :> judgement = ⊢ B a a ≡ B a b
 val congrB :> judgement → judgement → judgement = <function>
-- : judgement = ⊢ Π A ({x} B x x) ≡ Π A ({_} B a a)
+- :> judgement = ⊢ Π A ({x} B x x) ≡ Π A ({_} B a a)
 Rule A' is postulated.
 Rule α is postulated.
 Rule α' is postulated.
 val isPropA' :> judgement → judgement → judgement = <function>
-- : judgement = ⊢ {x' : A'} {y' : A'} x' ≡ y' : A'
+- :> judgement = ⊢ {x' : A'} {y' : A'} x' ≡ y' : A'
 Rule B' is postulated.
 Rule β is postulated.
-- : judgement = ⊢ Π A ({x} B x x) ≡ Π A' ({y} B' y y)
+- :> judgement = ⊢ Π A ({x} B x x) ≡ Π A' ({y} B' y y)

--- a/tests/nucleus/congruence_derive.m31.ref
+++ b/tests/nucleus/congruence_derive.m31.ref
@@ -13,5 +13,5 @@ Rule Vec is postulated.
 Rule u is postulated.
 Rule j is postulated.
 Rule k is postulated.
-- : judgement = ⊢ u nat (plus j k) ≡ u nat (plus k j) : Vec nat (plus j
+- :> judgement = ⊢ u nat (plus j k) ≡ u nat (plus k j) : Vec nat (plus j
   k)

--- a/tests/nucleus/congruence_products.m31.ref
+++ b/tests/nucleus/congruence_products.m31.ref
@@ -8,7 +8,7 @@ Rule a is postulated.
 Rule B is postulated.
 Rule f is postulated.
 Rule g is postulated.
-- : judgement = ⊢ Π A ({x} B x) ≡ Π A ({x} B x)
-- : judgement = ⊢ app A ({x} B x) g a ≡ app A ({x} B x) g a : B a
-- : judgement = ⊢ λ A ({x} B x) ({x} f x) ≡ λ A ({x} B x) ({x} f x) :
+- :> judgement = ⊢ Π A ({x} B x) ≡ Π A ({x} B x)
+- :> judgement = ⊢ app A ({x} B x) g a ≡ app A ({x} B x) g a : B a
+- :> judgement = ⊢ λ A ({x} B x) ({x} f x) ≡ λ A ({x} B x) ({x} f x) :
   Π A ({x} B x)

--- a/tests/nucleus/convert.m31.ref
+++ b/tests/nucleus/convert.m31.ref
@@ -3,13 +3,13 @@ Rule B is postulated.
 Rule ξ is postulated.
 Rule a is postulated.
 Rule b is postulated.
-- : judgement = ⊢ a
-- : judgement = ⊢ B type
+- :> judgement = ⊢ a
+- :> judgement = ⊢ B type
 Rule P is postulated.
 Rule ζ is postulated.
-- : judgement = ⊢ P b ≡ P a
+- :> judgement = ⊢ P b ≡ P a
 Rule z is postulated.
 val e :> judgement = ⊢ {u : P z} u
-- : judgement * judgement * judgement * judgement =
+- :> judgement * judgement * judgement * judgement =
   ((u₀ : P z ⊢ u₀), (⊢ P z type), (u₀ : P z ⊢ u₀), (⊢ P a
    type))

--- a/tests/nucleus/convert_in_rule.m31.ref
+++ b/tests/nucleus/convert_in_rule.m31.ref
@@ -3,11 +3,11 @@ Rule B is postulated.
 Rule ξ is postulated.
 val d :> derivation = derive (x : A) → x
 Rule a is postulated.
-- : judgement * judgement = ((⊢ a), (⊢ B type))
+- :> judgement * judgement = ((⊢ a), (⊢ B type))
 Rule P is postulated.
 Rule e is postulated.
-- : judgement * judgement = ((⊢ e a), (⊢ B type))
+- :> judgement * judgement = ((⊢ e a), (⊢ B type))
 Rule b is postulated.
 Rule f is postulated.
-- : judgement * judgement = ((⊢ B type), (⊢ B type))
-- : judgement = ⊢ B type
+- :> judgement * judgement = ((⊢ B type), (⊢ B type))
+- :> judgement = ⊢ B type

--- a/tests/nucleus/derive.m31.ref
+++ b/tests/nucleus/derive.m31.ref
@@ -3,12 +3,12 @@ Rule a is postulated.
 Rule B is postulated.
 Rule s is postulated.
 val d :> derivation = derive (x : A) → B x x type
-- : judgement = ⊢ B a a type
-- : judgement = ⊢ {z : A} B z z type
+- :> judgement = ⊢ B a a type
+- :> judgement = ⊢ {z : A} B z z type
 val d' :> derivation = derive (x : A) → B a x type
-- : judgement = ⊢ B a a type
+- :> judgement = ⊢ B a a type
 Rule refl is postulated.
 val e :> derivation = derive (x : A) → s x ≡ s x : B x x
-- : judgement = ⊢ {a₀ : A} s a₀ ≡ s a₀ : B a₀ a₀
+- :> judgement = ⊢ {a₀ : A} s a₀ ≡ s a₀ : B a₀ a₀
 val f :> derivation = derive (a : A) (b : A) → B a b type
-- : judgement = ⊢ {u : A} {v : A} B u v type
+- :> judgement = ⊢ {u : A} {v : A} B u v type

--- a/tests/nucleus/order_of_arguments.m31.ref
+++ b/tests/nucleus/order_of_arguments.m31.ref
@@ -5,6 +5,6 @@ Rule b is postulated.
 Rule P is postulated.
 Rule p is postulated.
 Rule Q is postulated.
-- : judgement = ⊢ P a b type
-- : judgement = ⊢ p
-- : judgement = ⊢ Q p a b type
+- :> judgement = ⊢ P a b type
+- :> judgement = ⊢ p
+- :> judgement = ⊢ Q p a b type

--- a/tests/nucleus/rule_as_derivation.m31.ref
+++ b/tests/nucleus/rule_as_derivation.m31.ref
@@ -1,16 +1,16 @@
 Rule bull is postulated.
-- : judgement = ⊢ bull type
+- :> judgement = ⊢ bull type
 Rule tail is postulated.
-- : judgement = ⊢ tail
+- :> judgement = ⊢ tail
 Rule eq is postulated.
-- : judgement = ⊢ tail ≡ tail : bull
+- :> judgement = ⊢ tail ≡ tail : bull
 Rule Id is postulated.
-- : derivation = derive (A type) (a : A) (b : A) → Id A a b type
+- :> derivation = derive (A type) (a : A) (b : A) → Id A a b type
 Rule Pi is postulated.
-- : derivation = derive (A type) ({_ : A} B type) → Pi A ({x} B {x}) type
+- :> derivation = derive (A type) ({_ : A} B type) → Pi A ({x} B {x}) type
 Rule cow is postulated.
-- : derivation = derive (A type) (a : A) ({x : A} a ≡ x : A by ξ) → cow
+- :> derivation = derive (A type) (a : A) ({x : A} a ≡ x : A by ξ) → cow
   A a ({x} a ≡ x : A) type
 Rule reflect is postulated.
-- : derivation = derive (A type) (a : A) (b : A) (p : Id A a b) → a ≡ b :
-  A
+- :> derivation = derive (A type) (a : A) (b : A) (p : Id A a b) → a ≡ b
+  : A

--- a/tests/runtime/abstract_atoms.m31.ref
+++ b/tests/runtime/abstract_atoms.m31.ref
@@ -1,6 +1,6 @@
 Rule A is postulated.
-- : judgement = ⊢ {x : A} x
-- : boundary = ⊢ {_ : A} ⁇ : A
+- :> judgement = ⊢ {x : A} x
+- :> boundary = ⊢ {_ : A} ⁇ : A
 val abstr_jdg :> judgement = ⊢ {z : A} z
 val a :> judgement = z₀ : A ⊢ z₀
 val abstr1 :> judgement = ⊢ {z : A} z

--- a/tests/runtime/compare.m31.ref
+++ b/tests/runtime/compare.m31.ref
@@ -1,11 +1,11 @@
 Processing module C
 external compare : mlforall α, α → α → ML.order = "compare"
-- : ML.order = ML.less
-- : ML.order = ML.less
-- : ML.order = ML.greater
-- : ML.order = ML.less
-- : ML.order = ML.greater
-- : ML.order = ML.greater
-- : mlstring = "a"
-- : mlstring = "b"
-- : mlstring = "c"
+- :> ML.order = ML.less
+- :> ML.order = ML.less
+- :> ML.order = ML.greater
+- :> ML.order = ML.less
+- :> ML.order = ML.greater
+- :> ML.order = ML.greater
+- :> mlstring = "a"
+- :> mlstring = "b"
+- :> mlstring = "c"

--- a/tests/runtime/derivation.m31.ref
+++ b/tests/runtime/derivation.m31.ref
@@ -6,9 +6,9 @@ Rule a is postulated.
 Rule B is postulated.
 Rule s is postulated.
 val d :> derivation = derive (x : A) (y : A) → s x x y
-- : judgement = ⊢ s a a a
+- :> judgement = ⊢ s a a a
 val e :> derivation = derive ({_ : A} {_ : A} T type) (a : A) → T {a} {a}
   type
-- : judgement → judgement → judgement = <function>
-- : judgement = ⊢ B a a a type
-- : judgement = ⊢ B a a a type
+- :> judgement → judgement → judgement = <function>
+- :> judgement = ⊢ B a a a type
+- :> judgement = ⊢ B a a a type

--- a/tests/runtime/equation_by.m31.ref
+++ b/tests/runtime/equation_by.m31.ref
@@ -1,6 +1,6 @@
 Rule A is postulated.
 Rule a is postulated.
-- : judgement = ⊢ A ≡ A
-- : judgement = ⊢ a ≡ a : A
-- : derivation = derive ({_ : A} f : A) (x : A) (y : A) (x ≡ y : A by ξ)
+- :> judgement = ⊢ A ≡ A
+- :> judgement = ⊢ a ≡ a : A
+- :> derivation = derive ({_ : A} f : A) (x : A) (y : A) (x ≡ y : A by ξ)
   → f {x} ≡ f {y} : A

--- a/tests/runtime/exception.m31.ref
+++ b/tests/runtime/exception.m31.ref
@@ -2,10 +2,10 @@ Exception Cow is declared.
 Exception Horn is declared.
 Exception Tail is declared.
 val f :> exn → exn = <function>
-- : exn = Cow "horn"
-- : exn = Cow "horn"
-- : exn = Cow "tail"
-- : mlstring * mlstring = ("foo", "bar")
-- : mlstring * mlstring = ("horn", "")
-- : mlstring * mlstring = ("tail", "")
-- : mlstring = "horn"
+- :> exn = Cow "horn"
+- :> exn = Cow "horn"
+- :> exn = Cow "tail"
+- :> mlstring * mlstring = ("foo", "bar")
+- :> mlstring * mlstring = ("horn", "")
+- :> mlstring * mlstring = ("tail", "")
+- :> mlstring = "horn"

--- a/tests/runtime/handler.m31.ref
+++ b/tests/runtime/handler.m31.ref
@@ -2,5 +2,5 @@ Operation auto is declared.
 Rule A is postulated.
 Rule a is postulated.
 Rule B is postulated.
-- : judgement = ⊢ a
-- : judgement = ⊢ B type
+- :> judgement = ⊢ a
+- :> judgement = ⊢ B type

--- a/tests/runtime/handler_exception.m31.ref
+++ b/tests/runtime/handler_exception.m31.ref
@@ -1,3 +1,3 @@
 Exception Cow is declared.
 Operation moo is declared.
-- : mlstring * mlstring = ("correct", "moo")
+- :> mlstring * mlstring = ("correct", "moo")

--- a/tests/runtime/patterns.m31.ref
+++ b/tests/runtime/patterns.m31.ref
@@ -1,50 +1,50 @@
-- : mlstring = "bar"
-- : mlstring = "foo"
-- : mlstring * mlstring * mlstring = ("baz", "foo", "bar")
-- : mlstring = "right"
-- : mlstring * mlstring * mlstring = ("baz", "foo", "bar")
-- : list mlstring * mlstring * mlstring * list mlstring * mlstring =
+- :> mlstring = "bar"
+- :> mlstring = "foo"
+- :> mlstring * mlstring * mlstring = ("baz", "foo", "bar")
+- :> mlstring = "right"
+- :> mlstring * mlstring * mlstring = ("baz", "foo", "bar")
+- :> list mlstring * mlstring * mlstring * list mlstring * mlstring =
   ("foo" :: "bar" :: [], "baz", "foo", "bar" :: [], "baz")
-- : mlstring = "foo"
+- :> mlstring = "foo"
 Rule A is postulated.
 Rule a is postulated.
 Rule P is postulated.
 val test_judgement :> judgement → list judgement * mlstring = <function>
-- : list judgement * mlstring = ((⊢ a) :: (⊢ A type) :: [], "isterm")
-- : list judgement * mlstring = ((⊢ A type) :: [], "istype")
-- : list judgement * mlstring = ((⊢ P a type) :: [], "istype")
+- :> list judgement * mlstring = ((⊢ a) :: (⊢ A type) :: [], "isterm")
+- :> list judgement * mlstring = ((⊢ A type) :: [], "istype")
+- :> list judgement * mlstring = ((⊢ P a type) :: [], "istype")
 Rule B is postulated.
 Rule ξ is postulated.
-- : list judgement * mlstring =
+- :> list judgement * mlstring =
   ((⊢ A type) :: (⊢ B type) :: [], "eqtype")
 Rule b is postulated.
 Rule ζ is postulated.
-- : list judgement * mlstring =
+- :> list judgement * mlstring =
   ((⊢ a) :: (⊢ b) :: (⊢ A type) :: [], "eqterm")
-- : list judgement * mlstring =
+- :> list judgement * mlstring =
   ((⊢ a) :: (⊢ b) :: (⊢ B type) :: [], "eqterm")
-- : list judgement * mlstring = ((⊢ a) :: (⊢ B type) :: [], "isterm")
-- : list judgement * mlstring =
+- :> list judgement * mlstring = ((⊢ a) :: (⊢ B type) :: [], "isterm")
+- :> list judgement * mlstring =
   ((z₀ : A ⊢ z₀) :: (⊢ A type) :: (z₀ : A ⊢ P z₀ type) :: [],
    "abstraction")
 val test_boundary :> boundary → list judgement * list boundary * mlstring =
   <function>
-- : list judgement * list boundary * mlstring = ([], [], "istype boundary")
-- : list judgement * list boundary * mlstring =
+- :> list judgement * list boundary * mlstring = ([], [], "istype boundary")
+- :> list judgement * list boundary * mlstring =
   ((⊢ A type) :: [], [], "isterm boundary")
-- : list judgement * list boundary * mlstring =
+- :> list judgement * list boundary * mlstring =
   ((⊢ P a type) :: [], [], "isterm boundary")
-- : list judgement * list boundary * mlstring =
+- :> list judgement * list boundary * mlstring =
   ((⊢ A type) :: (⊢ P a type) :: [], (⊢ A ≡ P a by ⁇) :: [],
    "eqtype boundary")
-- : list judgement * list boundary * mlstring =
+- :> list judgement * list boundary * mlstring =
   ((⊢ a) :: (⊢ b) :: (⊢ A type) :: [], [], "eqterm boundary")
-- : list judgement * list boundary * mlstring =
+- :> list judgement * list boundary * mlstring =
   ((⊢ a) :: (⊢ b) :: (⊢ B type) :: [], [], "eqterm boundary")
-- : list judgement * list boundary * mlstring =
+- :> list judgement * list boundary * mlstring =
   ((z₁ : A ⊢ z₁) :: (⊢ A type) :: [], (z₁ : A ⊢ ⁇ : P z₁) ::
    [], "abstraction boundary")
 Rule θ is postulated.
-- : list judgement * list boundary * mlstring =
+- :> list judgement * list boundary * mlstring =
   ((z₂ : B ⊢ z₂) :: (⊢ B type) :: [], (z₂ : B ⊢ ⁇ : P z₂) ::
    [], "abstraction boundary")

--- a/tests/runtime/top_handler.m31.ref
+++ b/tests/runtime/top_handler.m31.ref
@@ -6,8 +6,8 @@ Rule b is postulated.
 Rule prod is postulated.
 Rule pair is postulated.
 Exception Auto_cannot_infer is declared.
-- : judgement = ⊢ a
-- : judgement = ⊢ pair A B a b
-- : judgement = ⊢ pair (prod A B) A (pair A B a b) a
+- :> judgement = ⊢ a
+- :> judgement = ⊢ pair A B a b
+- :> judgement = ⊢ pair (prod A B) A (pair A B a b) a
 File "./runtime/top_handler.m31", line 25, characters 1-4:
 Runtime error: uncaught exception Auto_cannot_infer

--- a/tests/runtime/when_guard.m31.ref
+++ b/tests/runtime/when_guard.m31.ref
@@ -1,3 +1,3 @@
-- : mlstring = "a"
-- : mlstring = "yes"
-- : mlstring = "no"
+- :> mlstring = "a"
+- :> mlstring = "yes"
+- :> mlstring = "no"

--- a/tests/syntax/subscripts.m31.ref
+++ b/tests/syntax/subscripts.m31.ref
@@ -1,27 +1,27 @@
 Rule A is postulated.
 Rule f is postulated.
-- : judgement = ⊢ {a₀ : A} {a : A} f a₀ a
+- :> judgement = ⊢ {a₀ : A} {a : A} f a₀ a
 Rule a is postulated.
-- : judgement = ⊢ {a₀ : A} {a₁ : A} f a₀ a₁
+- :> judgement = ⊢ {a₀ : A} {a₁ : A} f a₀ a₁
 Rule a₁ is postulated.
-- : judgement = ⊢ {a₀ : A} {a₂ : A} f a₀ a₂
+- :> judgement = ⊢ {a₀ : A} {a₂ : A} f a₀ a₂
 Rule a₂ is postulated.
 Rule a₃ is postulated.
-- : judgement = ⊢ {a₀ : A} {a₄ : A} f a₀ a₄
-- : judgement = ⊢ {a₀ : A} {a₄ : A} {a₅ : A} f (f a₀ a₄) a₅
-- : judgement = ⊢ {a₀ : A} {a4 : A} {a₄ : A} f (f a₀ a4) a₄
+- :> judgement = ⊢ {a₀ : A} {a₄ : A} f a₀ a₄
+- :> judgement = ⊢ {a₀ : A} {a₄ : A} {a₅ : A} f (f a₀ a₄) a₅
+- :> judgement = ⊢ {a₀ : A} {a4 : A} {a₄ : A} f (f a₀ a4) a₄
 Rule a₄ is postulated.
 Rule a₅ is postulated.
 Rule a₆ is postulated.
 Rule a₇ is postulated.
 Rule a₈ is postulated.
 Rule a₉ is postulated.
-- : judgement = ⊢ {a₀ : A} {a₁₀ : A} f a₀ a₁₀
+- :> judgement = ⊢ {a₀ : A} {a₁₀ : A} f a₀ a₁₀
 Rule a₁₀ is postulated.
-- : judgement = ⊢ {a₀ : A} {a₁₁ : A} f a₀ a₁₁
+- :> judgement = ⊢ {a₀ : A} {a₁₁ : A} f a₀ a₁₁
 Rule a₁1 is postulated.
-- : judgement = ⊢ {a₀ : A} {a₁₁ : A} f (f a₁1 a₀) a₁₁
-- : judgement = ⊢ {a₀ : A} {a₁₁ : A} f (f a₁1 a₀) a₁₁
+- :> judgement = ⊢ {a₀ : A} {a₁₁ : A} f (f a₁1 a₀) a₁₁
+- :> judgement = ⊢ {a₀ : A} {a₁₁ : A} f (f a₁1 a₀) a₁₁
 Rule a₁₁ is postulated.
-- : judgement = ⊢ {a₀ : A} {a₁₂ : A} f (f a₁1 a₀) a₁₂
-- : judgement = ⊢ {a₀ : A} {a₁₂ : A} f (f a₁₂ a₀) a₁₂
+- :> judgement = ⊢ {a₀ : A} {a₁₂ : A} f (f a₁1 a₀) a₁₂
+- :> judgement = ⊢ {a₀ : A} {a₁₂ : A} f (f a₁₂ a₀) a₁₂

--- a/tests/types/abstract_type.m31.ref
+++ b/tests/types/abstract_type.m31.ref
@@ -1,4 +1,4 @@
 ML type cow declared.
 ML type pretty declared.
 val f :> pretty cow → pretty cow = <function>
-- : list (pretty cow → pretty cow) = <function> :: <function> :: []
+- :> list (pretty cow → pretty cow) = <function> :: <function> :: []


### PR DESCRIPTION
Print a top comp as `- :> [type] = [value]`, like a toplet instead of using `- : [type] = [value]`.

