### PR TITLE
Have congruence rules handle atoms as well.

### DIFF
--- a/src/nucleus/congruence.ml
+++ b/src/nucleus/congruence.ml
@@ -176,11 +176,18 @@ let form_judgement sgn jdg1 jdg2 =
           abstr
           args1 args2
 
-       | TermMeta _, TermConstructor _
-       | TermConstructor _, TermMeta _
-       | TermAtom _, _
-       | _, TermAtom _ ->
-           Error.raise InvalidCongruence
+
+       | TermAtom x as e1, TermAtom y ->
+          if Nonce.equal x.atom_nonce y.atom_nonce then
+            let eq = Form.reflexivity_term sgn e1 in
+            RapDone (JudgementEqTerm eq)
+          else
+            Error.raise InvalidCongruence
+
+       | TermMeta _, (TermConstructor _ | TermAtom _)
+       | TermConstructor _, (TermMeta _ | TermAtom _)
+       | TermAtom _, (TermMeta _ | TermConstructor _) ->
+          Error.raise InvalidCongruence
 
        | TermMeta (MetaBound _, _), _ | _, TermMeta (MetaBound _, _)
        | TermBoundVar _, _ | _, TermBoundVar _ -> assert false
@@ -287,10 +294,16 @@ let form_is_term sgn e1 e2 =
                  abstr
                  args1 args2)
 
-    | TermMeta _, TermConstructor _
-      | TermConstructor _, TermMeta _
-      | TermAtom _, _
-      | _, TermAtom _ ->
+    | TermAtom x as e1, TermAtom y ->
+       if Nonce.equal x.atom_nonce y.atom_nonce then
+         let eq = Form.reflexivity_term sgn e1 in
+         Some (RapDone eq)
+       else
+         None
+
+    | TermMeta _, (TermConstructor _ | TermAtom _)
+    | TermConstructor _, (TermMeta _ | TermAtom _)
+    | TermAtom _, (TermMeta _ | TermConstructor _) ->
        None
 
     | TermMeta (MetaBound _, _), _ | _, TermMeta (MetaBound _, _)

--- a/theories/dependent_product.m31
+++ b/theories/dependent_product.m31
@@ -8,14 +8,11 @@ rule app (A type) ({x : A} B type) (s : Π A B) (a : A)
   : B{a}
 
 rule Π_β (A type) ({x : A} B type) ({x : A} s : B{x}) (a : A)
-  : app A B (λ A B s) a == s{a} : B{a} ;;
+  : app A B (λ A B s) a ≡ s{a} : B{a} ;;
 
 eq.add_rule Π_β;;
 
-rule Π_η (A type) ({x : A} B type) (s : Π A B)
-  : s == λ A B ({x:A} app A B s x) : Π A B
-
-rule Π_ext (A type) ({x : A} B type) 
+rule Π_ext (A type) ({x : A} B type)
            (f : Π A B) (g : Π A B)
            ({x : A} app A B f x ≡ app A B g x : B{x})
            :

--- a/theories/dependent_sum.m31
+++ b/theories/dependent_sum.m31
@@ -27,10 +27,11 @@ rule Σ_β₂ (A type) ({x : A} B type) (a : A) (b : B{a})
 eq.add_rule Σ_β₂
 ;;
 
-rule Σ_ext (A type) ({x : A} B type) (s : Σ A B) (v : Σ A B)
-           (π₁ A B s ≡ π₁ A B v : A by ξ)
-           (convert (π₂ A B s) (congruence B{π₁ A B s} B{π₁ A B v} ξ) ≡ π₂ A B v : B{π₁ A B v})
-  : s ≡ v : Σ A B
+rule Σ_ext
+  (A type) ({x : A} B type) (s : Σ A B) (t : Σ A B)
+  (π₁ A B s ≡ π₁ A B t : A by ξ)
+  (convert (π₂ A B s) (congruence B{π₁ A B s} B{π₁ A B t} ξ) ≡ π₂ A B t : B{π₁ A B t})
+  : s ≡ t : Σ A B
 ;;
 
 eq.add_rule Σ_ext

--- a/theories/dependent_sum.m31
+++ b/theories/dependent_sum.m31
@@ -1,8 +1,6 @@
-require eq_subst
-require eq
+require eq ;;
 
-rule Σ (A type) ({x : A} B type)
-  type
+rule Σ (A type) ({x : A} B type) type
 
 rule pair (A type) ({x : A} B type) (a : A) (b : B{a})
   : Σ A B
@@ -23,8 +21,8 @@ rule Σ_β₁ (A type) ({x : A} B type) (a : A) (b : B{a})
 eq.add_rule Σ_β₁
 ;;
 
-rule Σ_β₂ (A type) ({x : A} B type) (a : A) (b : B{a}) 
-  : π₂ A B (pair A B a b) ≡ b : B{a} ;; 
+rule Σ_β₂ (A type) ({x : A} B type) (a : A) (b : B{a})
+  : π₂ A B (pair A B a b) ≡ b : B{a} ;;
 
 eq.add_rule Σ_β₂
 ;;

--- a/theories/empty.m31
+++ b/theories/empty.m31
@@ -1,2 +1,6 @@
-rule Empty type
-rule Empty_ind ({x : Empty} C type) (a : Empty) : C {a}
+rule empty type
+;;
+
+rule empty_ind
+  ({x : empty} C type) (a : empty)
+  : C{a}

--- a/theories/eq_subst.m31
+++ b/theories/eq_subst.m31
@@ -1,8 +1,9 @@
-rule eq_subst
-        (A type)
-        ({x : A} C type)
-        (s : A)
-        (t : A)
-        (s == t : A)
-  :
-  C{s} == C{t}
+let eq_subst =
+  derive
+    (A type)
+    ({x : A} C type)
+    (s : A)
+    (t : A)
+    (s ≡ t : A by ξ)
+  →
+  C{s} ≡ C{t} by congruence C{s} C{t} ξ

--- a/theories/equality_reflection.m31
+++ b/theories/equality_reflection.m31
@@ -1,3 +1,6 @@
-require identity_type
+require identity_type ;;
+open identity_type ;;
 
-rule equality_reflection (A type) (a : A) (b : A) (_ : identity_type.Id A a b) : a == b : A
+rule equality_reflection
+  (A type) (a : A) (b : A) (_ : Id A a b)
+  : a == b : A

--- a/theories/identity_type.m31
+++ b/theories/identity_type.m31
@@ -1,45 +1,28 @@
-require eq;;
+require eq ;;
 
 rule Id (A type) (a : A) (b : A) type
+;;
 
-rule Id_refl (A type) (a : A) : Id A a a
+rule refl (A type) (a : A) : Id A a a
+;;
 
-rule Id_ind
+rule J
   (A type)
   ({x y : A} {p : Id A x y} C type)
-  ({x : A} c : C{x, x, (Id_refl A x)})
+  ({x : A} c : C{x, x, refl A x})
   (a : A)
   (b : A)
   (p : Id A a b)
   : C{a, b, p}
+;;
 
-rule Id_β
+rule J_β
   (A type)
   ({x y : A} {p : Id A x y} C type)
-  ({x : A} c : C{x, x, Id_refl A x})
+  ({x : A} c : C{x, x, refl A x})
   (a : A)
-  : Id_ind A C c a a (Id_refl A a) ≡ c{a} : C{a, a, Id_refl A a};;
+  : J A C c a a (refl A a) ≡ c{a} : C{a, a, refl A a}
+;;
 
-eq.add_rule Id_β;;
-
-require judgemental_equality
-let sym = judgemental_equality.sym_eq_type
-
-rule Id_congr
-  (A type)
-  (A' type)
-  (a : A) (b : A)
-  (a' : A') (b' : A')
-  (A ≡ A' by ξ)
-  (a ≡ (convert a' (sym ξ)) : A)
-  (b ≡ (convert b' (sym ξ)) : A)
-  : Id A a b ≡ Id A' a' b'
-
-rule Id_refl_congr
-  (A type) (A' type)
-  (a : A) (a' : A')
-  (A ≡ A' by ξ)
-  (a ≡ (convert a' (sym ξ)) : A by ζ)
-  : Id_refl A a ≡
-         (convert (Id_refl A' a') (sym (Id_congr A A' a a a' a' ξ ζ ζ)))
-    : Id A a a
+eq.add_rule J_β
+;;

--- a/theories/identity_type.m31
+++ b/theories/identity_type.m31
@@ -12,8 +12,8 @@ rule J
   ({x : A} c : C{x, x, refl A x})
   (a : A)
   (b : A)
-  (p : Id A a b)
-  : C{a, b, p}
+  (q : Id A a b)
+  : C{a, b, q}
 ;;
 
 rule J_β

--- a/theories/judgemental_equality_term.m31
+++ b/theories/judgemental_equality_term.m31
@@ -1,4 +1,5 @@
-rule eq_term_refl (A type) (a : A) : a ≡ a : A
+let eq_term_refl = derive (A type) (a : A) → a ≡ a : A by congruence a a
+;;
 
 rule eq_term_sym (A type) (a : A) (b : A) (a ≡ b : A) : b ≡ a : A
 

--- a/theories/judgemental_equality_type.m31
+++ b/theories/judgemental_equality_type.m31
@@ -1,5 +1,8 @@
-rule eq_type_refl (A type) : A ≡ A
+let eq_type_refl = derive (A type) → A ≡ A by congruence A A
+;;
 
 rule eq_type_sym (A type) (B type) (A ≡ B) : B ≡ A
+;;
 
 rule eq_type_trans (A type) (B type) (C type) (A ≡ B) (B ≡ C) : A ≡ C
+;;

--- a/theories/nat.m31
+++ b/theories/nat.m31
@@ -1,31 +1,39 @@
-require eq;;
+require eq ;;
 
-rule Nat type
+rule ℕ type
+;;
 
-rule z : Nat
+rule z : ℕ
+;;
 
-rule s (n : Nat) : Nat
+rule s (n : ℕ) : ℕ
+;;
 
-rule Nat_ind
-  ({x : Nat} C type)
-  (base : C{z})
-  ({n : Nat} {c_n : C{n}} step : C{s n})
-  (k : Nat)
-  : C{k}
+rule ℕ_ind
+  ({_ : ℕ} C type)
+  (x : C{z})
+  ({n : ℕ} {u : C{n}} f : C{s n})
+  (n : ℕ)
+  : C{n}
+;;
 
-rule Nat_β_z
-  ({x : Nat} C type)
-  (base : C{z})
-  ({n : Nat} {c_n : C{n}} step : C{s n})
-  : Nat_ind C base step z == base : C{z};;
+rule ℕ_β_z
+  ({_ : ℕ} C type)
+  (x : C{z})
+  ({n : ℕ} {u : C{n}} f : C{s n})
+  : ℕ_ind C x f z == x : C{z}
+;;
 
-eq.add_rule Nat_β_z;;
+eq.add_rule ℕ_β_z
+;;
 
-rule Nat_β_s
-  ({x : Nat} C type)
-  (base : C{z})
-  ({n : Nat} {c_n : C{n}} step : C{s n})
-  (k : Nat)
-  : Nat_ind C base step (s k) == step { k, Nat_ind C base step k } : C { s k };;
+rule ℕ_β_s
+  ({_ : ℕ} C type)
+  (x : C{z})
+  ({n : ℕ} {u : C{n}} f : C{s n})
+  (n : ℕ)
+  : ℕ_ind C x f (s n) == f{n, ℕ_ind C x f n} : C{s n}
+;;
 
-eq.add_rule Nat_β_s;;
+eq.add_rule ℕ_β_s
+;;

--- a/theories/unit.m31
+++ b/theories/unit.m31
@@ -1,19 +1,26 @@
-require eq;;
-rule Unit type
+require eq ;;
 
-rule unit : Unit
+rule unit type
+;;
 
-rule unit_ind ({x : Unit} C type) (c : C{unit}) (a : Unit)
-  : C {a}
+rule tt : unit
+;;
 
-rule unit_β ({x : Unit} C type) (c : C{unit})
-  : unit_ind C c unit ≡ c : C{unit};;
+rule unit_ind
+  ({x : unit} C type) (c : C{tt}) (a : unit)
+  : C{a}
+;;
 
-eq.add_rule unit_β;;
+rule unit_β
+  ({x : unit} C type) (c : C{tt})
+  : unit_ind C c tt ≡ c : C{tt}
+;;
 
-rule unit_η (s : Unit)
-  : s ≡ unit : Unit
+eq.add_rule unit_β ;;
 
-rule unit_ext (s : Unit) (t : Unit) : s ≡ t : Unit;;
+rule unit_ext
+  (s : unit) (t : unit)
+  : s ≡ t : unit
+;;
 
 eq.add_rule unit_ext;;


### PR DESCRIPTION
The rationale is: it can handle constants, so perhaps it should also handle atoms. The user will be less surprised that `congruence x x` doesn't fail on atoms.