### PR TITLE
Nullary derivations and rule applications.

### DIFF
--- a/src/parser/desugar.ml
+++ b/src/parser/desugar.ml
@@ -1050,6 +1050,11 @@ let rec comp ctx {Location.it=c';at} =
      let c, prems = premises ctx prems (fun ctx -> comp ctx c) in
      locate (Desugared.Derive (prems, c))
 
+  | Sugared.RuleApply (c, cs) ->
+     let c = comp ctx c in
+     let cs = List.map (comp ctx) cs in
+     locate (Desugared.RuleApply (c, cs))
+
   | Sugared.Spine (e, cs) ->
      spine ~at ctx e cs
 
@@ -1289,7 +1294,8 @@ and spine ~at ctx ({Location.it=c'; at=c_at} as c) cs =
   let split_at constr arity lst =
     let rec split acc m lst =
       if m = 0 then
-        List.rev acc, lst
+        List.rev acc,
+        (match lst with [] -> None | _::_ -> Some lst)
       else
         match lst with
         | [] -> error ~at (ArityMismatch (constr, List.length acc, arity))
@@ -1304,10 +1310,10 @@ and spine ~at ctx ({Location.it=c'; at=c_at} as c) cs =
      begin match Ctx.get_name ~at x ctx with
 
      | Bound i ->
-          Location.mark ~at:c_at (Desugared.Bound i), cs
+          Location.mark ~at:c_at (Desugared.Bound i), Some cs
 
      | Value pth ->
-          Location.mark ~at:c_at (Desugared.Value pth), cs
+          Location.mark ~at:c_at (Desugared.Value pth), Some cs
 
      | TTConstructor (pth, arity) ->
           check_tt_arity ~at x (List.length cs) arity ;
@@ -1326,18 +1332,18 @@ and spine ~at ctx ({Location.it=c'; at=c_at} as c) cs =
 
      | Exception (pth, arity) ->
         begin match arity, cs with
-        | Nullary, [] -> ml_exception ~at ctx pth None, []
-        | Unary, [c] -> ml_exception ~at ctx pth (Some c), []
+        | Nullary, [] -> ml_exception ~at ctx pth None, None
+        | Unary, [c] -> ml_exception ~at ctx pth (Some c), None
         | Nullary, _::_ -> error ~at (ArityMismatch (x, List.length cs, 0))
         | Unary, ([] | _::_::_) -> error ~at (ArityMismatch (x, List.length cs, 1))
         end
      end
 
-    | _ -> comp ctx c, cs
+    | _ -> comp ctx c, Some cs
   in
   match cs with
-  | [] -> head
-  | _::_ ->
+  | None -> head
+  | Some cs ->
      let cs = List.map (comp ctx) cs in
      Location.mark ~at (Desugared.Spine (head, cs))
 

--- a/src/parser/parser.mly
+++ b/src/parser/parser.mly
@@ -235,7 +235,7 @@ term_:
   | FUN xs=ml_arg+ ARROW e=term
     { Sugared.Function (xs, e) }
 
-  | DERIVE ps=nonempty_list(premise) ARROW e=term
+  | DERIVE ps=list(premise) ARROW e=term
     { Sugared.Derive (ps, e) }
 
   | WITH h=term TRY c=term
@@ -319,6 +319,9 @@ app_term_:
 
   | OCCURS c1=substitution_term c2=substitution_term
     { Sugared.Occurs (c1, c2) }
+
+  | MLJUDGEMENT e=substitution_term es=list(substitution_term)
+    { Sugared.RuleApply (e, es) }
 
   | e=substitution_term es=nonempty_list(substitution_term)
     { Sugared.Spine (e, es) }

--- a/src/syntax/desugared.mli
+++ b/src/syntax/desugared.mli
@@ -78,6 +78,7 @@ and comp' =
   | EqTermAscribe of comp * comp * comp * comp
   | AsDerivation of Path.t
   | TTConstructor of Path.t * comp list
+  | RuleApply of comp * comp list
   | Spine of comp * comp list
   | Abstract of Name.t * comp option * comp
   | AbstractAtom of comp * comp

--- a/src/syntax/sugared.mli
+++ b/src/syntax/sugared.mli
@@ -92,6 +92,7 @@ and comp' =
   | AbstractAtom of comp * comp
   | Substitute of comp * comp list
   | Derive of premise list * comp
+  | RuleApply of comp * comp list
   | Spine of comp * comp list
   | String of string
   | Congruence of comp * comp * comp list


### PR DESCRIPTION
We may write `derive -> j` for a nullary rule with conclusion `j`
and `judgement r` for the conclusion of a nullary rule r`.

More generally, `judgement r e_0 ... e_(n-1)` is an alternative
notation for the application of rule r to (possibly zero) arguments
`e0 ... e_(n-1)`.