### PR TITLE
Implement general boundaries in premises.

### DIFF
--- a/src/parser/desugar.ml
+++ b/src/parser/desugar.ml
@@ -1458,59 +1458,11 @@ and local_context :
 
 and premise ctx {Location.it=prem;at} =
   let locate x = Location.mark ~at x in
-  match prem with
-  | Sugared.PremiseAtBoundary (mvar, local_ctx, c) ->
-     let bdry, local_ctx = local_context ctx local_ctx (fun ctx -> comp ctx c) in
-     let mvar = (match mvar with Some mvar -> mvar | None -> Name.anonymous ()) in
-     let ctx = Ctx.add_bound mvar ctx in
-     ctx, locate (Desugared.Premise (mvar, local_ctx, bdry))
-
-
-  | Sugared.PremiseIsType (mvar, local_ctx) ->
-     let (), local_ctx = local_context ctx local_ctx (fun _ -> ()) in
-     let mvar = (match mvar with Some mvar -> mvar | None -> Name.anonymous ()) in
-     let ctx = Ctx.add_bound mvar ctx in
-     let bdry = locate Desugared.(MLBoundary BoundaryIsType) in
-     ctx, locate (Desugared.Premise (mvar, local_ctx, bdry))
-
-  | Sugared.PremiseIsTerm (mvar, local_ctx, c) ->
-     let c, local_ctx =
-       local_context
-         ctx local_ctx
-         (fun ctx -> comp ctx c)
-     in
-     let mvar = (match mvar with Some mvar -> mvar | None -> Name.anonymous ()) in
-     let ctx = Ctx.add_bound mvar ctx in
-     let bdry = Location.mark ~at:c.Location.at Desugared.(MLBoundary (BoundaryIsTerm c)) in
-     ctx, locate (Desugared.Premise (mvar, local_ctx, bdry))
-
-  | Sugared.PremiseEqType (mvar, local_ctx, (c1, c2)) ->
-     let (c1, c2), local_ctx =
-       local_context
-         ctx local_ctx
-         (fun ctx ->
-           comp ctx c1,
-           comp ctx c2)
-     in
-     let mvar = (match mvar with Some mvar -> mvar | None -> Name.anonymous ()) in
-     let ctx = Ctx.add_bound mvar ctx in
-     let bdry_at = Location.(union c1.at c2.at) in
-     let bdry = Location.mark ~at:bdry_at Desugared.(MLBoundary (BoundaryEqType (c1, c2))) in
-     ctx, locate (Desugared.Premise (mvar, local_ctx, bdry))
-
-  | Sugared.PremiseEqTerm (mvar, local_ctx, (c1, c2, c3)) ->
-     let (c1, c2, c3), local_ctx =
-       local_context ctx local_ctx
-       (fun ctx ->
-         comp ctx c1,
-         comp ctx c2,
-         comp ctx c3)
-     in
-     let mvar = (match mvar with Some mvar -> mvar | None -> Name.anonymous ()) in
-     let ctx = Ctx.add_bound mvar ctx in
-     let bdry_at = Location.(union c1.at (union c2.at c3.at)) in
-     let bdry = Location.mark ~at:bdry_at Desugared.(MLBoundary (BoundaryEqTerm (c1, c2, c3))) in
-     ctx, locate (Desugared.Premise (mvar, local_ctx, bdry))
+  let Sugared.Premise (mvar, local_ctx, c) = prem in
+  let bdry, local_ctx = local_context ctx local_ctx (fun ctx -> comp ctx c) in
+  let mvar = (match mvar with Some mvar -> mvar | None -> Name.anonymous ()) in
+  let ctx = Ctx.add_bound mvar ctx in
+  ctx, locate (Desugared.Premise (mvar, local_ctx, bdry))
 
 and premises :
   'a . Ctx.t -> Sugared.premise list -> (Ctx.t -> 'a) -> 'a * Desugared.premise list

--- a/src/parser/desugar.ml
+++ b/src/parser/desugar.ml
@@ -1544,49 +1544,14 @@ let rec toplevel' ctx {Location.it=cmd; at} =
 
   match cmd with
 
-  | Sugared.RuleIsType (rname, prems) ->
+  | Sugared.Rule (rname, prems, c) ->
      let arity = tt_arity prems in
-     let (), prems = premises ctx prems (fun _ -> ()) in
-     let pth, ctx = Ctx.add_tt_constructor ~at rname arity ctx in
-     let bdry = Desugared.BoundaryIsType in
-     (ctx, locate1 (Desugared.Rule (pth, prems, bdry)))
-
-  | Sugared.RuleIsTerm (rname, prems, c) ->
-     let arity = tt_arity prems in
-     let c, prems =
+     let bdry, prems =
        premises
          ctx prems
          (fun ctx -> comp ctx c)
      in
      let pth, ctx = Ctx.add_tt_constructor ~at rname arity ctx in
-     let bdry = Desugared.BoundaryIsTerm c in
-     (ctx, locate1 (Desugared.Rule (pth, prems, bdry)))
-
-  | Sugared.RuleEqType (rname, prems, (c1, c2)) ->
-     let arity = tt_arity prems in
-     let (c1, c2), prems =
-       premises
-         ctx prems
-         (fun ctx ->
-           comp ctx c1,
-           comp ctx c2)
-     in
-     let pth, ctx = Ctx.add_tt_constructor ~at rname arity ctx in
-     let bdry = Desugared.BoundaryEqType (c1, c2) in
-     (ctx, locate1 (Desugared.Rule (pth, prems, bdry)))
-
-  | Sugared.RuleEqTerm (rname, prems, (c1, c2, c3)) ->
-     let arity = tt_arity prems in
-     let (c1, c2, c3), prems =
-       premises
-         ctx prems
-         (fun ctx ->
-          comp ctx c1,
-          comp ctx c2,
-          comp ctx c3)
-     in
-     let pth, ctx = Ctx.add_tt_constructor ~at rname arity ctx in
-     let bdry = Desugared.BoundaryEqTerm (c1, c2, c3) in
      (ctx, locate1 (Desugared.Rule (pth, prems, bdry)))
 
   | Sugared.DeclOperation (op, (args, res)) ->
@@ -1746,7 +1711,7 @@ let rec load_requires ~basedir ~loading ctx cmds =
           let ctx, mdls = fold ~loading ctx cmds in
           ctx, mdls' @ mdls
 
-       | Sugared.(RuleIsType _ | RuleIsTerm _ | RuleEqType _ | RuleEqTerm _ | DefMLTypeAbstract _ |
+       | Sugared.(Rule _ | DefMLTypeAbstract _ |
                DefMLType _ | DefMLTypeRec _ | DeclOperation _ | DeclException _ | DeclExternal _ |
                TopLet _ | TopLetRec _ | TopWith _ | TopComputation _ |
                Include _ | Verbosity _ | Open _) ->

--- a/src/parser/desugar.ml
+++ b/src/parser/desugar.ml
@@ -1459,11 +1459,18 @@ and local_context :
 and premise ctx {Location.it=prem;at} =
   let locate x = Location.mark ~at x in
   match prem with
+  | Sugared.PremiseAtBoundary (mvar, local_ctx, c) ->
+     let bdry, local_ctx = local_context ctx local_ctx (fun ctx -> comp ctx c) in
+     let mvar = (match mvar with Some mvar -> mvar | None -> Name.anonymous ()) in
+     let ctx = Ctx.add_bound mvar ctx in
+     ctx, locate (Desugared.Premise (mvar, local_ctx, bdry))
+
+
   | Sugared.PremiseIsType (mvar, local_ctx) ->
      let (), local_ctx = local_context ctx local_ctx (fun _ -> ()) in
      let mvar = (match mvar with Some mvar -> mvar | None -> Name.anonymous ()) in
      let ctx = Ctx.add_bound mvar ctx in
-     let bdry = Desugared.BoundaryIsType in
+     let bdry = locate Desugared.(MLBoundary BoundaryIsType) in
      ctx, locate (Desugared.Premise (mvar, local_ctx, bdry))
 
   | Sugared.PremiseIsTerm (mvar, local_ctx, c) ->
@@ -1474,7 +1481,7 @@ and premise ctx {Location.it=prem;at} =
      in
      let mvar = (match mvar with Some mvar -> mvar | None -> Name.anonymous ()) in
      let ctx = Ctx.add_bound mvar ctx in
-     let bdry = Desugared.BoundaryIsTerm c in
+     let bdry = Location.mark ~at:c.Location.at Desugared.(MLBoundary (BoundaryIsTerm c)) in
      ctx, locate (Desugared.Premise (mvar, local_ctx, bdry))
 
   | Sugared.PremiseEqType (mvar, local_ctx, (c1, c2)) ->
@@ -1487,7 +1494,8 @@ and premise ctx {Location.it=prem;at} =
      in
      let mvar = (match mvar with Some mvar -> mvar | None -> Name.anonymous ()) in
      let ctx = Ctx.add_bound mvar ctx in
-     let bdry = Desugared.BoundaryEqType (c1, c2) in
+     let bdry_at = Location.(union c1.at c2.at) in
+     let bdry = Location.mark ~at:bdry_at Desugared.(MLBoundary (BoundaryEqType (c1, c2))) in
      ctx, locate (Desugared.Premise (mvar, local_ctx, bdry))
 
   | Sugared.PremiseEqTerm (mvar, local_ctx, (c1, c2, c3)) ->
@@ -1500,7 +1508,8 @@ and premise ctx {Location.it=prem;at} =
      in
      let mvar = (match mvar with Some mvar -> mvar | None -> Name.anonymous ()) in
      let ctx = Ctx.add_bound mvar ctx in
-     let bdry = Desugared.BoundaryEqTerm (c1, c2, c3) in
+     let bdry_at = Location.(union c1.at (union c2.at c3.at)) in
+     let bdry = Location.mark ~at:bdry_at Desugared.(MLBoundary (BoundaryEqTerm (c1, c2, c3))) in
      ctx, locate (Desugared.Premise (mvar, local_ctx, bdry))
 
 and premises :

--- a/src/parser/parser.mly
+++ b/src/parser/parser.mly
@@ -174,29 +174,27 @@ top_command_:
     { r }
 
 
+rule_boundary:
+  | bdry=premise_boundary
+    { bdry }
+
+  | COLON bdry=equality_premise_boundary
+    { bdry }
+
 rule_:
-  | c=tt_name ps=list(premise) TYPE
-    { Sugared.RuleIsType (c, ps) }
-
-  | c=tt_name ps=list(premise) COLON ty=term
-    { Sugared.RuleIsTerm (c, ps, ty) }
-
-  | c=tt_name ps=list(premise) COLON l=app_term EQEQ r=ty_term
-    { Sugared.RuleEqType (c, ps, (l, r)) }
-
-  | c=tt_name ps=list(premise) COLON l=app_term EQEQ r=app_term COLON ty=term
-    { Sugared.RuleEqTerm (c, ps, (l, r, ty)) }
+  | rl=tt_name ps=list(premise) bdry=rule_boundary
+    { Sugared.Rule (rl, ps, bdry) }
 
 premise: mark_location(premise_) { $1 }
 premise_:
-  | LPAREN lctx=local_context mv=opt_name(tt_name) bdry=boundary RPAREN
+  | LPAREN lctx=local_context mv=opt_name(tt_name) bdry=premise_boundary RPAREN
     { Sugared.Premise(mv, lctx, bdry) }
 
-  | LPAREN lctx=local_context bdry=eq_boundary mv=equality_premise_name RPAREN
+  | LPAREN lctx=local_context bdry=equality_premise_boundary mv=equality_premise_name RPAREN
     { Sugared.Premise (mv, lctx, bdry) }
 
-boundary: mark_location(boundary_) { $1 }
-boundary_:
+premise_boundary: mark_location(premise_boundary_) { $1 }
+premise_boundary_:
   | TYPE
     { Sugared.MLBoundaryIsType }
 
@@ -206,8 +204,8 @@ boundary_:
   | COLONQT c=term_
     { c }
 
-eq_boundary: mark_location(eq_boundary_) { $1 }
-eq_boundary_:
+equality_premise_boundary: mark_location(equality_premise_boundary_) { $1 }
+equality_premise_boundary_:
   | l=app_term EQEQ r=ty_term
     { Sugared.MLBoundaryEqType (l, r) }
 

--- a/src/parser/parser.mly
+++ b/src/parser/parser.mly
@@ -189,6 +189,9 @@ rule_:
 
 premise: mark_location(premise_) { $1 }
 premise_:
+  | LPAREN lctx=local_context mv=opt_name(tt_name) COLONQT c=term RPAREN
+    { Sugared.PremiseAtBoundary(mv, lctx, c) }
+
   | LPAREN lctx=local_context mv=opt_name(tt_name) TYPE RPAREN
     { Sugared.PremiseIsType (mv, lctx) }
 

--- a/src/parser/parser.mly
+++ b/src/parser/parser.mly
@@ -189,21 +189,30 @@ rule_:
 
 premise: mark_location(premise_) { $1 }
 premise_:
-  | LPAREN lctx=local_context mv=opt_name(tt_name) COLONQT c=term RPAREN
-    { Sugared.PremiseAtBoundary(mv, lctx, c) }
+  | LPAREN lctx=local_context mv=opt_name(tt_name) bdry=boundary RPAREN
+    { Sugared.Premise(mv, lctx, bdry) }
 
-  | LPAREN lctx=local_context mv=opt_name(tt_name) TYPE RPAREN
-    { Sugared.PremiseIsType (mv, lctx) }
+  | LPAREN lctx=local_context bdry=eq_boundary mv=equality_premise_name RPAREN
+    { Sugared.Premise (mv, lctx, bdry) }
 
-  | LPAREN lctx=local_context mv=opt_name(tt_name) COLON ty=term RPAREN
-    { Sugared.PremiseIsTerm (mv, lctx, ty) }
+boundary: mark_location(boundary_) { $1 }
+boundary_:
+  | TYPE
+    { Sugared.MLBoundaryIsType }
 
-  | LPAREN lctx=local_context l=app_term EQEQ r=ty_term mv=equality_premise_name RPAREN
-    { Sugared.PremiseEqType (mv, lctx, (l, r)) }
+  | COLON ty=term
+    { Sugared.MLBoundaryIsTerm ty }
 
-  | LPAREN lctx=local_context l=app_term EQEQ r=app_term COLON ty=term mv=equality_premise_name RPAREN
-    { Sugared.PremiseEqTerm (mv, lctx, (l, r, ty)) }
+  | COLONQT c=term_
+    { c }
 
+eq_boundary: mark_location(eq_boundary_) { $1 }
+eq_boundary_:
+  | l=app_term EQEQ r=ty_term
+    { Sugared.MLBoundaryEqType (l, r) }
+
+  | l=app_term EQEQ r=app_term COLON ty=term
+    { Sugared.MLBoundaryEqTerm (l, r, ty) }
 
 equality_premise_name:
   |

--- a/src/runtime/eval.ml
+++ b/src/runtime/eval.ml
@@ -638,8 +638,7 @@ and eval_boundary ~at = function
 and local_context lctx cmp =
   let rec fold = function
     | [] ->
-       cmp >>= fun v ->
-       return (Nucleus.abstract_not_abstract v)
+       cmp
     | (x, c) :: lctx ->
        comp_as_is_type c >>= fun t ->
        Runtime.add_free x t
@@ -650,8 +649,8 @@ and local_context lctx cmp =
   in
   fold lctx
 
-and premise {Location.it=Syntax.Premise(x, lctx, bdry); at} =
-  local_context lctx (eval_boundary ~at bdry) >>= fun bdry ->
+and premise {Location.it=Syntax.Premise(x, lctx, c); at} =
+  local_context lctx (comp_as_boundary_abstraction c) >>= fun bdry ->
   let mv, jdg = Nucleus.form_meta x bdry in
   let v = Runtime.Judgement jdg in
   return (mv, v)

--- a/src/runtime/eval.ml
+++ b/src/runtime/eval.ml
@@ -588,6 +588,10 @@ and comp_as_judgement_abstraction c =
 and comp_as_boundary_abstraction c =
   comp c >>= fun v -> return (Runtime.as_boundary_abstraction ~at:c.Location.at v)
 
+(** Run [c] and convert the result to a boundary. *)
+and comp_as_boundary ~at c =
+  comp c >>= fun v -> return (Runtime.as_boundary ~at:c.Location.at v)
+
 (** Run [c] and convert the result to a boundary abstraction. *)
 and comp_as_eq_type_abstraction c =
   comp c >>= fun v -> return (Runtime.as_eq_type_abstraction ~at:c.Location.at v)
@@ -743,7 +747,7 @@ let rec toplevel ~quiet ~print_annot {Location.it=c; at} =
 
   | Syntax.Rule (x, prems, bdry) ->
      Runtime.top_lookup_opens >>= fun opens ->
-     Runtime.top_handle ~at (premises prems (eval_boundary ~at bdry)) >>= fun (premises, head) ->
+     Runtime.top_handle ~at (premises prems (comp_as_boundary ~at bdry)) >>= fun (premises, head) ->
      let rule = Nucleus.form_rule premises head in
      (if not quiet then
         Format.printf "@[<hov 2>Rule %t is postulated.@]@." (Ident.print ~opens ~parentheses:false x));

--- a/src/runtime/runtime.ml
+++ b/src/runtime/runtime.ml
@@ -236,6 +236,7 @@ type error =
   | EqTermAbstractionExpected of value
   | BoundaryAbstractionExpected of value
   | JudgementAbstractionExpected of value
+  | BoundaryExpected of value
   | JudgementExpected of value
   | JudgementOrBoundaryExpected of value
   | EqualityCheckerExpected of value
@@ -494,6 +495,16 @@ let as_boundary_abstraction ~at v =
   | Boundary abstr -> abstr
   | Derivation _ | Judgement _ | External _ | Closure _ | Handler _ | Exc _ | Tag _ | Tuple _ | Ref _ | String _ ->
     error ~at (BoundaryAbstractionExpected v)
+
+let as_boundary ~at v =
+  match v with
+  | Boundary abstr ->
+     begin match Nucleus.as_not_abstract abstr with
+     | Some bdry -> bdry
+     | None -> error ~at (BoundaryExpected v)
+     end
+  | Derivation _ | Judgement _ | External _ | Closure _ | Handler _ | Exc _ | Tag _ | Tuple _ | Ref _ | String _ ->
+    error ~at (BoundaryExpected v)
 
 let as_closure ~at = function
   | Closure f -> f
@@ -905,6 +916,9 @@ let print_error ~penv err ppf =
 
   | EqTermAbstractionExpected v ->
      Format.fprintf ppf "expected a term abstraction equality but got %s" (name_of v)
+
+  | BoundaryExpected v ->
+     Format.fprintf ppf "expected a boundary but got %s" (name_of v)
 
   | JudgementExpected v ->
      Format.fprintf ppf "expected a judgement but got %s" (name_of v)

--- a/src/runtime/runtime.mli
+++ b/src/runtime/runtime.mli
@@ -103,6 +103,9 @@ val as_judgement_abstraction : at:Location.t -> value -> Nucleus.judgement_abstr
 (** Convert, or fail with [BoundaryAbstractionExpected] *)
 val as_boundary_abstraction : at:Location.t -> value -> Nucleus.boundary_abstraction
 
+(** Convert, or fail with [BoundaryExpected] *)
+val as_boundary : at:Location.t -> value -> Nucleus.boundary
+
 (** Convert, or fail with [ClosureExpected] *)
 val as_closure : at:Location.t -> value -> (value,value) closure
 
@@ -175,6 +178,7 @@ type error =
   | EqTermAbstractionExpected of value
   | BoundaryAbstractionExpected of value
   | JudgementAbstractionExpected of value
+  | BoundaryExpected of value
   | JudgementExpected of value
   | JudgementOrBoundaryExpected of value
   | EqualityCheckerExpected of value

--- a/src/syntax/desugared.mli
+++ b/src/syntax/desugared.mli
@@ -131,7 +131,7 @@ type ml_tydef =
 (** Desugared toplevel commands *)
 type toplevel = toplevel' located
 and toplevel' =
-  | Rule of Path.t * premise list * boundary
+  | Rule of Path.t * premise list * comp
   | DefMLTypeAbstract of Path.t * Name.t option list
   | DefMLType of (Path.t * (Name.t option list * ml_tydef)) list
   | DefMLTypeRec of (Path.t * (Name.t option list * ml_tydef)) list

--- a/src/syntax/desugared.mli
+++ b/src/syntax/desugared.mli
@@ -122,7 +122,7 @@ and match_op_case = pattern list * pattern option * comp
 and local_context = (Name.t * comp) list
 
 and premise = premise' located
-and premise' = Premise of Name.t * local_context * boundary
+and premise' = Premise of Name.t * local_context * comp
 
 type ml_tydef =
   | ML_Sum of (Name.t * ml_ty list) list

--- a/src/syntax/sugared.mli
+++ b/src/syntax/sugared.mli
@@ -141,10 +141,7 @@ type ml_tydef =
 (** Sugared toplevel commands *)
 type toplevel = toplevel' located
 and toplevel' =
-  | RuleIsType of Name.t * premise list
-  | RuleIsTerm of Name.t * premise list * comp
-  | RuleEqType of Name.t * premise list * (comp * comp)
-  | RuleEqTerm of Name.t * premise list * (comp * comp * comp)
+  | Rule of Name.t * premise list * comp
   | DefMLTypeAbstract of Name.t * Name.t option list
   | DefMLType of (Name.t * (Name.t option list * ml_tydef)) list
   | DefMLTypeRec of (Name.t * (Name.t option list * ml_tydef)) list

--- a/src/syntax/sugared.mli
+++ b/src/syntax/sugared.mli
@@ -132,12 +132,7 @@ and local_context = (Name.t * comp) list
 
 (** A premise to a rule *)
 and premise = premise' located
-and premise' =
-  | PremiseAtBoundary of Name.t option * local_context * comp
-  | PremiseIsType of Name.t option * local_context
-  | PremiseIsTerm of Name.t option * local_context * comp
-  | PremiseEqType of Name.t option * local_context * (comp * comp)
-  | PremiseEqTerm of Name.t option * local_context * (comp * comp * comp)
+and premise' = Premise of Name.t option * local_context * comp
 
 type ml_tydef =
   | ML_Sum of (Name.t * ml_ty list) list

--- a/src/syntax/sugared.mli
+++ b/src/syntax/sugared.mli
@@ -133,6 +133,7 @@ and local_context = (Name.t * comp) list
 (** A premise to a rule *)
 and premise = premise' located
 and premise' =
+  | PremiseAtBoundary of Name.t option * local_context * comp
   | PremiseIsType of Name.t option * local_context
   | PremiseIsTerm of Name.t option * local_context * comp
   | PremiseEqType of Name.t option * local_context * (comp * comp)

--- a/src/syntax/syntax.mli
+++ b/src/syntax/syntax.mli
@@ -112,7 +112,7 @@ and match_op_case = pattern list * pattern option * comp
 and local_context = (Name.t * comp) list
 
 and premise = premise' located
-and premise' = Premise of Name.t * local_context * boundary
+and premise' = Premise of Name.t * local_context * comp
 
 (** Type definitions are needed during runtime so that we can print them
     at the toplevel. *)

--- a/src/syntax/syntax.mli
+++ b/src/syntax/syntax.mli
@@ -123,7 +123,7 @@ type ml_tydef =
 (** Toplevel commands *)
 type toplevel = toplevel' located
 and toplevel' =
-  | Rule of tt_constructor * premise list * boundary
+  | Rule of tt_constructor * premise list * comp
   | DefMLTypeAbstract of Path.t
   | DefMLType of Path.t list (* we only need the names *)
   | DefMLTypeRec of Path.t list

--- a/src/typing/context.ml
+++ b/src/typing/context.ml
@@ -170,14 +170,14 @@ let empty = {
     ml_bound = [];
   }
 
-let lookup_bound (Path.Index (_, k)) {ml_bound;_} =
+let lookup_bound (Path.Index (x, k)) {ml_bound;_} =
   try
     let (ps, t) = List.nth ml_bound k in
     let pus = List.map (fun p -> (p, Mlty.fresh_type ())) ps in
     Mlty.instantiate pus t
   with
     Failure _ as exc ->
-     Format.printf "lookup_bound failed with %d@." k ;
+     Format.printf "lookup_bound failed with %t at index %d (%d available)@." (Name.print x) k (List.length ml_bound) ;
      raise exc
 
 let lookup_ml_value pth ctx =

--- a/src/typing/typecheck.ml
+++ b/src/typing/typecheck.ml
@@ -928,8 +928,8 @@ let add_ml_type (t, (params, def)) =
 let rec toplevel' ({Location.it=c; at} : Desugared.toplevel) =
   match c with
 
-  | Desugared.Rule (rname, prems, bdry) ->
-     premises prems (boundary bdry) >>= fun (ps, bdry) ->
+  | Desugared.Rule (rname, prems, c) ->
+     premises prems (check_comp c Mlty.Boundary) >>= fun (ps, bdry) ->
      let r = Ident.create rname in
      Tyenv.add_tt_constructor r >>= fun () ->
      return_located ~at (Syntax.Rule (r, ps, bdry))

--- a/src/typing/typecheck.ml
+++ b/src/typing/typecheck.ml
@@ -883,8 +883,8 @@ and local_context lctx m =
   fold [] lctx
 
 and premise {Location.it=prem; at} =
-  let Desugared.Premise (x, lctx, bdry) = prem in
-  local_context lctx (boundary bdry) >>= fun (lctx, bdry) ->
+  let Desugared.Premise (x, lctx, c) = prem in
+  local_context lctx (check_comp c Mlty.Boundary) >>= fun (lctx, bdry) ->
   let p = locate ~at (Syntax.Premise (x, lctx, bdry)) in
   return (x, p)
 

--- a/src/utils/location.ml
+++ b/src/utils/location.ml
@@ -46,6 +46,8 @@ let make start_lexpos end_lexpos =
 
 let mark ~at x = { it = x; at }
 
+let colocate {at; _} x = {it = x; at}
+
 let union l1 l2 =
   match l1, l2 with
   | Known {filename = fn1;

--- a/src/utils/location.mli
+++ b/src/utils/location.mli
@@ -36,6 +36,9 @@ val make : Lexing.position -> Lexing.position -> t
 (** Create a located thing. *)
 val mark : at:t -> 'a -> 'a located
 
+(** Copy the location from one thing to anoter. *)
+val colocate : 'a located -> 'a -> 'a located
+
 (** [union l1 l2] combines l1 and l2 to span from (min l1.beg l2.beg) to the
     end of (max l1.end l2.end). l1 and l2 have to come from the same file.
     If either l1 or l2 is Unknown, the other one is used. *)

--- a/tests/nucleus/premise_with_general_boundary.m31
+++ b/tests/nucleus/premise_with_general_boundary.m31
@@ -1,0 +1,9 @@
+rule prod (A type) (B type) type ;;
+
+rule Pi (X :? ?? type) ({_ : X} Y :? ?? type) type ;;
+
+Pi ;;
+
+rule Cow (A type) ({x : A} B type) (C :? (let X = A in ?? : prod (Pi A B) X)) type ;;
+
+Cow ;;

--- a/tests/nucleus/premise_with_general_boundary.m31.ref
+++ b/tests/nucleus/premise_with_general_boundary.m31.ref
@@ -1,0 +1,7 @@
+Rule prod is postulated.
+Rule Pi is postulated.
+- :> derivation = derive (X type) ({_ : X} Y type) → Pi X ({x₀} Y {x₀})
+  type
+Rule Cow is postulated.
+- :> derivation = derive (A type) ({_ : A} B type) (C : prod (Pi A ({x} B
+  {x})) A) → Cow A ({x} B {x}) C type

--- a/tests/nucleus/rules.m31
+++ b/tests/nucleus/rules.m31
@@ -1,7 +1,20 @@
-rule A type
-rule a : A
-rule B (X type) type
-rule P (U type) ({x : U} V type) type
-rule f (x : A) (y : B A) : A
-rule Ety (X type) (Y type) : B X ≡ B Y
-rule ETm (A type) (x : A) (y : A) (x ≡ y : A by ξ): y ≡ x : A
+rule A type ;;
+A ;;
+rule a : A ;;
+a ;;
+rule B (X type) type ;;
+B ;;
+rule P (U type) ({x : U} V type) type ;;
+P ;;
+rule f (x : A) (y : B A) : A ;;
+f ;;
+rule Ety (X type) (Y type) : B X ≡ B Y ;;
+Ety ;;
+rule ETm (A type) (x : A) (y : A) (x ≡ y : A by ξ): y ≡ x : A ;;
+ETm ;;
+rule C :? (let bdry = ?? type in bdry) ;;
+C ;;
+rule D (a : A) type ;;
+D ;;
+rule c (u : A) (v : B A) :? (let w = f u v in ?? : D w) ;;
+c ;;

--- a/tests/nucleus/rules.m31.ref
+++ b/tests/nucleus/rules.m31.ref
@@ -1,7 +1,21 @@
 Rule A is postulated.
+- :> judgement = ⊢ A type
 Rule a is postulated.
+- :> judgement = ⊢ a : A
 Rule B is postulated.
+- :> derivation = derive (X type) → B X type
 Rule P is postulated.
+- :> derivation = derive (U type) ({_ : U} V type) → P U ({x} V {x}) type
 Rule f is postulated.
+- :> derivation = derive (x : A) (y : B A) → f x y
 Rule Ety is postulated.
+- :> derivation = derive (X type) (Y type) → B X ≡ B Y
 Rule ETm is postulated.
+- :> derivation = derive (A type) (x : A) (y : A) (x ≡ y : A by ξ) → y
+  ≡ x : A
+Rule C is postulated.
+- :> judgement = ⊢ C type
+Rule D is postulated.
+- :> derivation = derive (a : A) → D a type
+Rule c is postulated.
+- :> derivation = derive (u : A) (v : B A) → c u v


### PR DESCRIPTION
We implement premises of the form `{x:A} ...{z:C} M :? c` where `c` computes an abribtrary
boundary. This is necessary in cases when the premise boundary needs to be computed, for example, using the equality checker with a local rule (that comes from a previous premise).