### PR TITLE
printing types of terms in derivations

### DIFF
--- a/src/nucleus/nucleus.ml
+++ b/src/nucleus/nucleus.ml
@@ -20,6 +20,7 @@ let type_of_term = Sanity.type_of_term
 let type_of_term_abstraction = Sanity.type_of_term_abstraction
 let type_at_abstraction = Sanity.type_at_abstraction
 let abstracted_judgement_with_boundary = Sanity.abstracted_judgement_with_boundary
+let derivation_with_boundary = Sanity.derivation_with_boundary
 let type_of_atom = Sanity.type_of_atom
 let natural_type_eq = Sanity.natural_type_eq
 
@@ -198,6 +199,7 @@ let print_judgement_abstraction = Nucleus_print.judgement_abstraction
 let print_boundary_abstraction = Nucleus_print.boundary_abstraction
 let print_judgement_with_boundary_abstraction = Nucleus_print.judgement_with_boundary_abstraction
 let print_derivation = Nucleus_print.derivation
+let print_derivation_with_boundary = Nucleus_print.derivation_with_boundary
 let print_error = Nucleus_print.error
 
 let name_of_judgement = Nucleus_print.name_of_judgement

--- a/src/nucleus/nucleus.mli
+++ b/src/nucleus/nucleus.mli
@@ -329,6 +329,10 @@ val check_judgement_boundary_abstraction : signature -> judgement_abstraction ->
 (** A judgement with its boundary, under the same abstraction *)
 val abstracted_judgement_with_boundary : signature -> judgement abstraction -> (judgement * boundary) abstraction
 
+(** A derivation whose conclusion is a pair of judgement and its boundary *)
+val derivation_with_boundary : signature -> derivation -> (judgement * boundary) rule
+
+
 
 (** Typeof for atoms *)
 val type_of_atom : is_atom -> is_type
@@ -489,6 +493,9 @@ val print_judgement_with_boundary_abstraction :
 
 val print_derivation :
   ?max_level:Level.t -> penv:print_environment -> derivation -> Format.formatter -> unit
+
+val print_derivation_with_boundary :
+  ?max_level:Level.t -> penv:print_environment -> (judgement * boundary) rule -> Format.formatter -> unit
 
 
 

--- a/src/nucleus/nucleus_print.ml
+++ b/src/nucleus/nucleus_print.ml
@@ -307,20 +307,6 @@ let judgement_abstraction ?max_level ~penv abstr ppf =
     (Print.char_vdash ())
     (abstraction Occurs_bound.judgement thesis_judgement ~max_level:Level.vdash_right ~penv abstr)
 
-let premise ~penv {meta_nonce=n; meta_boundary=prem} ppf =
-  boundary_abstraction' ~penv:(forbid (Nonce.name n) penv) ~print_head:(Name.print ~parentheses:true (Nonce.name n)) prem ppf
-
-let derivation ?max_level ~penv drv ppf =
-  let rec fold ~penv drv ppf =
-    match drv with
-    | Conclusion jdg -> Print.print ppf "%s@ %t" (Print.char_arrow ()) (thesis_judgement ~penv jdg)
-    | Premise (mv, drv) ->
-       Print.print ppf "(%t)@ %t"
-                   (premise ~penv mv)
-                   (fold ~penv:(debruijn_meta mv penv) drv)
-  in
-  Print.print ppf ?max_level ~at_level:Level.derive "derive@ %t" (fold ~penv drv)
-
 let thesis_judgement_with_boundary ?max_level ~penv (jdg, bdry) ppf =
   match bdry with
   | (BoundaryIsType _ | BoundaryEqType _ | BoundaryEqTerm _) ->
@@ -339,6 +325,31 @@ let judgement_with_boundary_abstraction ?max_level ~penv abstr ppf =
     (print_assumptions ~max_level:Level.vdash_left ~penv asmp)
     (Print.char_vdash ())
     (abstraction Occurs_bound.judgement_with_boundary thesis_judgement_with_boundary ~max_level:Level.vdash_right ~penv abstr)
+
+let premise ~penv {meta_nonce=n; meta_boundary=prem} ppf =
+  boundary_abstraction' ~penv:(forbid (Nonce.name n) penv) ~print_head:(Name.print ~parentheses:true (Nonce.name n)) prem ppf
+
+let derivation ?max_level ~penv drv ppf =
+  let rec fold ~penv drv ppf =
+    match drv with
+    | Conclusion jdg -> Print.print ppf "%s@ %t" (Print.char_arrow ()) (thesis_judgement ~penv jdg)
+    | Premise (mv, drv) ->
+       Print.print ppf "(%t)@ %t"
+                   (premise ~penv mv)
+                   (fold ~penv:(debruijn_meta mv penv) drv)
+  in
+  Print.print ppf ?max_level ~at_level:Level.derive "derive@ %t" (fold ~penv drv)
+
+let derivation_with_boundary ?max_level ~penv drv ppf =
+  let rec fold ~penv drv ppf =
+    match drv with
+    | Conclusion jdg_bdry -> Print.print ppf "%s@ %t" (Print.char_arrow ()) (thesis_judgement_with_boundary ~penv jdg_bdry)
+    | Premise (mv, drv) ->
+       Print.print ppf "(%t)@ %t"
+                   (premise ~penv mv)
+                   (fold ~penv:(debruijn_meta mv penv) drv)
+  in
+  Print.print ppf ?max_level ~at_level:Level.derive "derive@ %t" (fold ~penv drv)
 
 (** Printing of error messages *)
 (* TODO: Some of these are probably internal while others count as runtime errors. We

--- a/src/runtime/runtime.ml
+++ b/src/runtime/runtime.ml
@@ -701,7 +701,9 @@ let rec print_value ?max_level ~penv v ppf =
 
   | Boundary bdry -> Nucleus.print_boundary_abstraction ~penv:(mk_nucleus_penv penv) ?max_level bdry ppf
 
-  | Derivation drv -> Nucleus.print_derivation ~penv:(mk_nucleus_penv penv) ?max_level drv ppf
+  | Derivation drv -> 
+    let drv = Nucleus.derivation_with_boundary penv.signature drv in
+    Nucleus.print_derivation_with_boundary ~penv:(mk_nucleus_penv penv) ?max_level drv ppf
 
   | External v -> print_external ?max_level ~penv v ppf
 

--- a/tests/equality-checker.m31.ref
+++ b/tests/equality-checker.m31.ref
@@ -85,7 +85,7 @@ Term computation rule for ℕ_ind (heads at [3]):
 
 - :> mlunit = ()
 val plus :> derivation = derive (n : ℕ) (m : ℕ) → ℕ_ind ({_} ℕ) n
-  ({c_n _} s c_n) m
+  ({c_n _} s c_n) m : ℕ
 val foo :> judgement = ⊢ ℕ_ind ({_} ℕ) z ({c_n _} s c_n) (s z) : ℕ
 - :> judgement * judgement =
   ((⊢ ℕ_ind ({_} ℕ) z ({c_n _} s c_n) (s z) ≡ s (ℕ_ind ({_} ℕ) z

--- a/tests/nucleus/convert_in_rule.m31.ref
+++ b/tests/nucleus/convert_in_rule.m31.ref
@@ -1,7 +1,7 @@
 Rule A is postulated.
 Rule B is postulated.
 Rule ξ is postulated.
-val d :> derivation = derive (x : A) → x
+val d :> derivation = derive (x : A) → x : B
 Rule a is postulated.
 - :> judgement * judgement = ((⊢ a : B), (⊢ B type))
 Rule P is postulated.

--- a/tests/nucleus/rules.m31.ref
+++ b/tests/nucleus/rules.m31.ref
@@ -7,7 +7,7 @@ Rule B is postulated.
 Rule P is postulated.
 - :> derivation = derive (U type) ({_ : U} V type) → P U ({x} V {x}) type
 Rule f is postulated.
-- :> derivation = derive (x : A) (y : B A) → f x y
+- :> derivation = derive (x : A) (y : B A) → f x y : A
 Rule Ety is postulated.
 - :> derivation = derive (X type) (Y type) → B X ≡ B Y
 Rule ETm is postulated.
@@ -18,4 +18,4 @@ Rule C is postulated.
 Rule D is postulated.
 - :> derivation = derive (a : A) → D a type
 Rule c is postulated.
-- :> derivation = derive (u : A) (v : B A) → c u v
+- :> derivation = derive (u : A) (v : B A) → c u v : D (f u v)

--- a/tests/runtime/derivation.m31.ref
+++ b/tests/runtime/derivation.m31.ref
@@ -5,7 +5,7 @@ Rule A is postulated.
 Rule a is postulated.
 Rule B is postulated.
 Rule s is postulated.
-val d :> derivation = derive (x : A) (y : A) → s x x y
+val d :> derivation = derive (x : A) (y : A) → s x x y : B x x y
 - :> judgement = ⊢ s a a a : B a a a
 val e :> derivation = derive ({_ : A} {_ : A} T type) (a : A) → T {a} {a}
   type


### PR DESCRIPTION
When printing the derivations we can now see the type of the conclusion as well (relevant only if the conclusion is a term judgement).
For example 
```
# rule A type;;
Rule A is postulated.
# rule a : A ;;
Rule a is postulated.
# derive -> a ;;
- :> derivation = derive → a : A
```