### PR TITLE
Add AML support for creating meta variables.

### DIFF
--- a/src/parser/desugar.ml
+++ b/src/parser/desugar.ml
@@ -994,6 +994,9 @@ let rec comp ctx {Location.it=c';at} =
      let c = comp ctx c in
      locate (Desugared.Fresh (xopt, c))
 
+  | Sugared.Meta xopt ->
+     locate (Desugared.Meta xopt)
+
    | Sugared.AbstractAtom (c1,c2) ->
      let c1 = comp ctx c1
      and c2 = comp ctx c2 in

--- a/src/parser/lexer.ml
+++ b/src/parser/lexer.ml
@@ -27,6 +27,7 @@ let reserved = [
   ("judgment", MLJUDGEMENT) ; (* for Egbert Rijke and other Americans *)
   ("let", LET) ;
   ("match", MATCH) ;
+  ("meta", META) ;
   ("mlforall", MLFORALL) ;
   ("mlstring", MLSTRING) ;
   ("mltype", MLTYPE) ;

--- a/src/parser/parser.mly
+++ b/src/parser/parser.mly
@@ -54,7 +54,7 @@
 %token FUN
 
 (* TT commands *)
-%token FRESH CONVERT CONGRUENCE CONTEXT OCCURS DERIVE ABSTRACT
+%token FRESH META CONVERT CONGRUENCE CONTEXT OCCURS DERIVE ABSTRACT
 
 (* Toplevel directives *)
 %token VERBOSITY
@@ -321,6 +321,9 @@ app_term_:
   | OCCURS c1=substitution_term c2=substitution_term
     { Sugared.Occurs (c1, c2) }
 
+  | META x=opt_name(ml_name)
+    { Sugared.Meta x }
+
   | MLJUDGEMENT e=substitution_term es=list(substitution_term)
     { Sugared.RuleApply (e, es) }
 
@@ -538,7 +541,7 @@ ml_arg_:
 
   | pt=let_pattern_
     { pt }
-    
+
 
 let_annotation:
   |

--- a/src/runtime/runtime.ml
+++ b/src/runtime/runtime.ml
@@ -218,6 +218,7 @@ type error =
   | TermEqualityFail of Nucleus.is_term * Nucleus.is_term
   | TypeEqualityFail of Nucleus.is_type * Nucleus.is_type
   | UnannotatedAbstract of Name.t
+  | MetaWithoutBoundary of Name.t option
   | MatchFail of value
   | InvalidComparison
   | InvalidEqualTerm of Nucleus.is_term * Nucleus.is_term
@@ -844,6 +845,13 @@ let print_error ~penv err ppf =
 
   | UnannotatedAbstract x ->
      Format.fprintf ppf "cannot infer the type of@ %t@ in abstraction" (Name.print x)
+
+  | MetaWithoutBoundary (Some x) ->
+     Format.fprintf ppf "meta-variable %t appears without a boundary"
+                    (Name.print x)
+
+  | MetaWithoutBoundary None ->
+     Format.fprintf ppf "this meta-variable appears without a boundary"
 
   | MatchFail v ->
      Format.fprintf ppf "no matching pattern found for value@ %t"

--- a/src/runtime/runtime.mli
+++ b/src/runtime/runtime.mli
@@ -157,6 +157,7 @@ type error =
   | TermEqualityFail of Nucleus.is_term * Nucleus.is_term
   | TypeEqualityFail of Nucleus.is_type * Nucleus.is_type
   | UnannotatedAbstract of Name.t
+  | MetaWithoutBoundary of Name.t option
   | MatchFail of value
   | InvalidComparison
   | InvalidEqualTerm of Nucleus.is_term * Nucleus.is_term

--- a/src/syntax/desugared.mli
+++ b/src/syntax/desugared.mli
@@ -71,6 +71,7 @@ and comp' =
   | Ref of comp
   | Sequence of comp * comp
   | Fresh of Name.t option * comp
+  | Meta of Name.t option
   | Match of comp * match_case list
   | BoundaryAscribe of comp * comp
   | TypeAscribe of comp * comp

--- a/src/syntax/sugared.mli
+++ b/src/syntax/sugared.mli
@@ -81,6 +81,7 @@ and comp' =
   | Ref of comp
   | Sequence of comp * comp
   | Fresh of Name.t option * comp
+  | Meta of Name.t option
   | BoundaryAscribe of comp * comp
   | TypeAscribe of comp * comp
   | EqTypeAscribe of comp * comp * comp

--- a/src/syntax/syntax.mli
+++ b/src/syntax/syntax.mli
@@ -59,6 +59,7 @@ and comp' =
   | Sequence of comp * comp
   | Raise of comp
   | Fresh of Name.t option * comp
+  | Meta of Name.t option
   | Match of comp * match_case list
   | BoundaryAscribe of comp * comp
   | AsDerivation of tt_constructor

--- a/src/typing/typecheck.ml
+++ b/src/typing/typecheck.ml
@@ -38,6 +38,7 @@ let rec generalizable c =
     | Update _
     | Ref _
     | Fresh _
+    | Meta _
     | AbstractAtom _
     | Match _
     | BoundaryAscribe _
@@ -430,6 +431,9 @@ let rec infer_comp ({Location.it=c; at} : Desugared.comp) : (Syntax.comp * Mlty.
   | Desugared.Fresh (xopt, c) ->
      check_comp c Mlty.Judgement >>= fun c ->
      return (locate ~at (Syntax.Fresh (xopt, c)), Mlty.Judgement)
+
+  | Desugared.Meta xopt ->
+     return (locate ~at (Syntax.Meta xopt), Mlty.Judgement)
 
    | Desugared.AbstractAtom (c1, c2) ->
       check_comp c1 Mlty.Judgement >>= fun c1 ->


### PR DESCRIPTION
The syntax is `meta x` or `meta _`.

In checking-mode *only* `meta x` creates a fresh meta-variable whose name is derived from
`x` and whose boundary is the checking boundary.

Future extensions can add additional support. Right now, once a meta-variable is created,
it can never be removed.