### PR TITLE
Eqchk abstracted constructors

### DIFF
--- a/src/equality/eqchk.ml
+++ b/src/equality/eqchk.ml
@@ -118,7 +118,7 @@ and prove_eq_term ~ext chk sgn bdry =
 and check_normal_type chk sgn (Normal ty1) (Normal ty2) =
   match Nucleus.congruence_is_type sgn ty1 ty2 with
 
-  | None -> raise Equality_fail
+  | None -> raise (Equality_fail ("cannot find a congruence rule for given types") )
 
   | Some rap ->
      let sym = head_symbol_type (Nucleus.expose_is_type ty1) in
@@ -129,7 +129,7 @@ and check_normal_type chk sgn (Normal ty1) (Normal ty2) =
 and check_normal_term chk sgn (Normal e1) (Normal e2) =
   match Nucleus.congruence_is_term sgn e1 e2 with
 
-  | None -> raise Equality_fail
+  | None -> raise (Equality_fail "cannot find a congruence rule for given terms")
 
   | Some rap ->
      let sym = head_symbol_term (Nucleus.expose_is_term e1) in
@@ -170,7 +170,7 @@ and prove_boundary_abstraction ~ext chk sgn bdry =
      Nucleus.abstract_judgement atm eq_abstr
 
   | Nucleus.(Stump_NotAbstract (BoundaryIsTerm _ | BoundaryIsType _)) ->
-     assert false
+     raise (Fatal_error "cannot prove an object boundary")
 
   in
   prove bdry
@@ -202,7 +202,7 @@ let add ~quiet ~penv chk drv =
       chk
 
   with
-    | Invalid_rule ->
+    | Invalid_rule _ ->
       try
         begin match add_type_computation' chk drv with
 
@@ -218,7 +218,7 @@ let add ~quiet ~penv chk drv =
         end
 
      with
-      | Invalid_rule ->
+      | Invalid_rule _ ->
           begin match add_term_computation' chk drv with
             | (sym, ((patt, _), _), chk) ->
               let heads = heads_term patt in

--- a/src/equality/eqchk.ml
+++ b/src/equality/eqchk.ml
@@ -83,8 +83,8 @@ and prove_eq_term_abstraction chk sgn abstr =
   fold abstr
 
 and prove_eq_type chk sgn (ty1, ty2) =
-  let ty1_eq_ty1', ty1' = Eqchk_normalizer.normalize_type ~strong:false sgn chk.normalizer ty1
-  and ty2_eq_ty2', ty2' = Eqchk_normalizer.normalize_type ~strong:false sgn chk.normalizer ty2 in
+  let ty1_eq_ty1', ty1' = Eqchk_normalizer.normalize_type ~strong:true sgn chk.normalizer ty1
+  and ty2_eq_ty2', ty2' = Eqchk_normalizer.normalize_type ~strong:true sgn chk.normalizer ty2 in
   let ty1'_eq_ty2' = check_normal_type chk sgn ty1' ty2' in
   Nucleus.transitivity_type
     (Nucleus.transitivity_type ty1_eq_ty1' ty1'_eq_ty2')
@@ -92,11 +92,10 @@ and prove_eq_type chk sgn (ty1, ty2) =
 
 
 and prove_eq_term ~ext chk sgn bdry =
-
   let normalization_phase bdry =
      let (e1, e2, t) = Nucleus.invert_eq_term_boundary bdry in
-     let e1_eq_e1', e1' = Eqchk_normalizer.normalize_term ~strong:false sgn chk.normalizer e1
-     and e2_eq_e2', e2' = Eqchk_normalizer.normalize_term ~strong:false sgn chk.normalizer e2 in
+     let e1_eq_e1', e1' = Eqchk_normalizer.normalize_term ~strong:true sgn chk.normalizer e1
+     and e2_eq_e2', e2' = Eqchk_normalizer.normalize_term ~strong:true sgn chk.normalizer e2 in
      let e1'_eq_e2' = check_normal_term chk sgn e1' e2' in
      Nucleus.transitivity_term
        (Nucleus.transitivity_term e1_eq_e1' e1'_eq_e2')
@@ -107,7 +106,7 @@ and prove_eq_term ~ext chk sgn bdry =
     normalization_phase bdry
   else
     match Eqchk_extensionality.find chk.ext_rules sgn bdry with
-    
+
     | Some rap ->
        (* reduce the problem to an application of an extensionality rule *)
        resolve_rap chk sgn IntSet.empty rap

--- a/src/equality/eqchk.mli
+++ b/src/equality/eqchk.mli
@@ -5,13 +5,13 @@ type checker
 val empty_checker : checker
 
 (** Add a type computation rule (also known as β-rule. XXX what about exceptions? *)
-val add_type_computation : checker -> Nucleus.derivation -> checker option
+val add_type_computation : checker -> Nucleus.derivation -> checker
 
 (** Add a term computation rule (also known as β-rule *)
-val add_term_computation : checker -> Nucleus.derivation -> checker option
+val add_term_computation : checker -> Nucleus.derivation -> checker
 
 (** Add an extensionality rule *)
-val add_extensionality : checker -> Nucleus.derivation -> checker option
+val add_extensionality : checker -> Nucleus.derivation -> checker
 
 (** Set the heads of a type symbol *)
 val set_type_heads : checker -> Ident.t -> int list -> checker
@@ -21,15 +21,15 @@ val set_term_heads : checker -> Ident.t -> int list -> checker
 
 (** The user-friendly interface, which figures out which kind of rule we are
    adding, and it guesses the heads. *)
-val add : quiet:bool -> penv:Nucleus.print_environment -> checker -> Nucleus.derivation -> checker option
+val add : quiet:bool -> penv:Nucleus.print_environment -> checker -> Nucleus.derivation -> checker
 
 (** Prove an abstracted type equality *)
 val prove_eq_type_abstraction :
-  checker -> Nucleus.signature -> Nucleus.eq_type_boundary Nucleus.abstraction -> Nucleus.eq_type_abstraction option
+  checker -> Nucleus.signature -> Nucleus.eq_type_boundary Nucleus.abstraction -> Nucleus.eq_type_abstraction
 
 (** Prove an abstracted term equality *)
 val prove_eq_term_abstraction :
-  checker -> Nucleus.signature -> Nucleus.eq_term_boundary Nucleus.abstraction -> Nucleus.eq_term_abstraction option
+  checker -> Nucleus.signature -> Nucleus.eq_term_boundary Nucleus.abstraction -> Nucleus.eq_term_abstraction
 
 (** Normalize a type *)
 val normalize_type :

--- a/src/equality/eqchk_extensionality.ml
+++ b/src/equality/eqchk_extensionality.ml
@@ -41,12 +41,9 @@ let make_equation drv =
        and t2' = Shift_meta.is_type (n_eq+1) (extract_type bdry2opt) in
        (* check that types are equal *)
        if not (Alpha_equal.is_type t1' t) || not (Alpha_equal.is_type t2' t) then raise Invalid_rule ;
-       begin match Eqchk_pattern.make_is_type (n_ob-2) t1 with
-       | Some patt ->
-          let s = head_symbol_type t1 in
-          (s, patt)
-       | None -> raise Invalid_rule
-       end
+       let patt = Eqchk_pattern.make_is_type (n_ob-2) t1 in
+       let s = head_symbol_type t1 in
+       (s, patt)
 
     | Nucleus_types.(Premise ({meta_boundary=bdry;_}, drv)) ->
        if is_object_premise bdry then

--- a/src/equality/eqchk_extensionality.ml
+++ b/src/equality/eqchk_extensionality.ml
@@ -43,8 +43,8 @@ let make_equation drv =
        end ;
        begin
        try (* check RHS *)
-         check_meta n_eq e2 
-       with 
+         check_meta n_eq e2
+       with
          Invalid_rule _ -> raise (Invalid_rule "RHS of equation is not a correct metavariable")
        end ;
        let t1 = extract_type bdry1opt in

--- a/src/equality/eqchk_normalizer.ml
+++ b/src/equality/eqchk_normalizer.ml
@@ -148,8 +148,6 @@ let rec apply_type_beta betas sgn t =
 (** Find a term computation rule and apply it to [e]. *)
 and apply_term_beta betas sgn e =
   let s = head_symbol_term (Nucleus.expose_is_term e) in
-  let penv = Nucleus.({forbidden = Name.set_empty; debruijn_var = []; debruijn_meta = []; opens = Path.set_empty}) in
-  Format.printf "%t@." (Eqchk_common.print_symbol ~penv:penv s) ;
   match SymbolMap.find_opt s betas with
 
   | None -> None

--- a/src/equality/eqchk_normalizer.ml
+++ b/src/equality/eqchk_normalizer.ml
@@ -3,7 +3,7 @@
 open Eqchk_common
 
 (** Extract an optional value, or declare an equality failure *)
-let deopt x msg = 
+let deopt x msg =
   match x with
   | None -> raise (Normalization_fail msg)
   | Some x -> x
@@ -148,6 +148,8 @@ let rec apply_type_beta betas sgn t =
 (** Find a term computation rule and apply it to [e]. *)
 and apply_term_beta betas sgn e =
   let s = head_symbol_term (Nucleus.expose_is_term e) in
+  let penv = Nucleus.({forbidden = Name.set_empty; debruijn_var = []; debruijn_meta = []; opens = Path.set_empty}) in
+  Format.printf "%t@." (Eqchk_common.print_symbol ~penv:penv s) ;
   match SymbolMap.find_opt s betas with
 
   | None -> None
@@ -231,7 +233,7 @@ and normalize_heads_type ~strong sgn nrm ty0 =
      and es_eq_es' = List.map (fun eq -> Nucleus.(abstract_not_abstract (JudgementEqTerm eq))) es_eq_es' in
      let ty1 =
        let jdg1 = deopt (rap_fully_apply (Nucleus.form_meta_rap sgn mv) es') "cannot apply arguments to type metavariable" in
-       deopt (Nucleus.as_is_type jdg1) "application of the type matavariable did not result in type judgement" 
+       deopt (Nucleus.as_is_type jdg1) "application of the type matavariable did not result in type judgement"
      in
      let ty0_eq_ty1 =
        let rap = deopt (Nucleus.congruence_is_type sgn ty0 ty1)  "unable to construct a type congruence rule" in

--- a/src/equality/eqchk_normalizer.ml
+++ b/src/equality/eqchk_normalizer.ml
@@ -38,14 +38,9 @@ let make_type_computation drv =
 
     | Nucleus_types.(Conclusion eq)  ->
        let (Nucleus_types.EqType (_asmp, t1, _t2)) = Nucleus.expose_eq_type eq in
-       begin match Eqchk_pattern.make_is_type k t1 with
-
-       | Some patt ->
-          let s = head_symbol_type t1 in
-          (s, patt)
-
-       | None -> raise Invalid_rule
-       end
+       let patt =  Eqchk_pattern.make_is_type k t1 in
+       let s = head_symbol_type t1 in
+       (s, patt)
 
     | Nucleus_types.(Premise ({meta_boundary=bdry;_}, drv)) ->
        if is_object_premise bdry then
@@ -67,14 +62,9 @@ let make_term_computation drv =
 
     | Nucleus_types.(Conclusion eq) ->
        let (Nucleus_types.EqTerm (_asmp, e1, _e2, _t)) = Nucleus.expose_eq_term eq in
-       begin match Eqchk_pattern.make_is_term k e1 with
-
-       | Some patt ->
-          let s = head_symbol_term e1 in
-          (s, patt)
-
-       | None -> raise Invalid_rule
-       end
+       let patt = Eqchk_pattern.make_is_term k e1 in
+       let s = head_symbol_term e1 in
+       (s, patt)
 
     | Nucleus_types.(Premise ({meta_boundary=bdry;_}, drv)) ->
        if is_object_premise bdry then

--- a/src/equality/eqchk_pattern.ml
+++ b/src/equality/eqchk_pattern.ml
@@ -386,24 +386,18 @@ let is_range s k =
    the bound meta-variables [0, ..., k-1]. Return the pair [(p, k)] to be used as part of
    a beta or extensionality rule. *)
 let make_is_type k t =
-  try
-    let metas, patt = form_is_type Bound_set.empty t in
-    if is_range metas k then
-      Some (patt, k)
-    else
-      None
-  with
-  | Form_fail -> None
+   let metas, patt = form_is_type Bound_set.empty t in
+   if is_range metas k then
+     (patt, k)
+   else
+     raise Form_fail
 
 (** Construct a pattern [p] from term [e], and verify that the pattern captures exactly
    the bound meta-variables [0, ..., k-1]. Return the pair [(p, k)] to be used as part of
    a beta or extensionality rule. *)
 let make_is_term k e =
-  try
-    let metas, patt = form_is_term Bound_set.empty e in
-    if is_range metas k then
-      Some (patt, k)
-    else
-      None
-  with
-  | Form_fail -> None
+   let metas, patt = form_is_term Bound_set.empty e in
+   if is_range metas k then
+     (patt, k)
+   else
+     raise Form_fail

--- a/src/equality/eqchk_pattern.ml
+++ b/src/equality/eqchk_pattern.ml
@@ -205,7 +205,7 @@ let match_is_term sgn e (r, k) =
 exception Form_fail of string
 
 (** Is the given judgement abstraction an eta-expanded meta-variable? *)
-let extract_meta metas abstr =
+let rec extract_meta metas abstr =
   let rec fold k = function
 
     | Nucleus_types.Arg_Abstract (_, abstr) -> fold (k+1) abstr
@@ -236,10 +236,10 @@ let extract_meta metas abstr =
              else
                let metas = Bound_set.add m metas in
                metas, Patt.ArgumentIsTerm (Patt.TermAddMeta m)
+          | Nucleus_types.TermConvert (e, _, _) -> extract_meta metas (Nucleus_types.(Arg_NotAbstract (JudgementIsTerm e)))
 
           | Nucleus_types.(TermMeta (MetaFree _, _) | TermBoundVar _ | TermAtom _ |
-                           TermConstructor _ | TermConvert _) ->
-             (** XXX should go through TermConvert here *)
+                           TermConstructor _) ->
              raise (Form_fail "Given abstraction is not an eta-expanded metavariable")
 
           end

--- a/src/equality/eqchk_pattern.ml
+++ b/src/equality/eqchk_pattern.ml
@@ -140,7 +140,13 @@ and collect_normal_is_term sgn metas e = function
      in
      fold e
 
-  | Patt.TermBound _ -> failwith "todo"
+  | Patt.TermBound v ->
+    begin match Nucleus.expose_is_term e with
+    | Nucleus_types.TermBoundVar j ->
+      if v == j then metas else raise Match_fail
+    | Nucleus_types.(TermAtom _ | TermMeta _ | TermConstructor _| TermConvert _) ->
+      raise Match_fail
+    end
 
 and collect_is_terms sgn metas es es' =
   match es, es' with

--- a/src/equality/eqchk_pattern.ml
+++ b/src/equality/eqchk_pattern.ml
@@ -192,9 +192,16 @@ and collect_argument sgn metas bounds jdg arg_abstr =
       let bounds = add_bound atm bounds in
       fold jdg abstr bounds
 
-    | Nucleus.Stump_NotAbstract _, Patt.Arg_Abstract _
-    | Nucleus.Stump_Abstract _, Patt.Arg_NotAbstract _ ->
-      raise Match_fail
+    | Nucleus.Stump_Abstract _, Patt.Arg_NotAbstract patt_jdg ->
+      (* Is the judgement eta-expanded metavariable? *)
+      begin
+        match patt_jdg with
+
+        | Patt.ArgumentIsType r -> collect_is_type sgn metas bounds jdg r
+
+        | Patt.ArgumentIsTerm r -> collect_is_term sgn metas bounds jdg r
+      end
+
 
     | Nucleus.Stump_NotAbstract jdg , Patt.Arg_NotAbstract patt_jdg ->
       begin
@@ -204,6 +211,9 @@ and collect_argument sgn metas bounds jdg arg_abstr =
 
         | Patt.ArgumentIsTerm r -> collect_is_term sgn metas bounds (Nucleus.abstract_not_abstract jdg) r
       end
+
+      | Nucleus.Stump_NotAbstract _, Patt.Arg_Abstract _ ->
+        raise Match_fail
   in
   fold jdg arg_abstr bounds
 

--- a/src/nucleus/nucleus.ml
+++ b/src/nucleus/nucleus.ml
@@ -14,6 +14,7 @@ let expose_eq_type eq = eq
 let expose_eq_term eq = eq
 let expose_judgement jdg = jdg
 let expose_rule rl = rl
+let expose_judgement_abstraction abstr = abstr
 
 (** Exports from [Sanity] *)
 let type_of_term = Sanity.type_of_term

--- a/src/nucleus/nucleus.mli
+++ b/src/nucleus/nucleus.mli
@@ -133,6 +133,7 @@ val expose_eq_type : eq_type -> Nucleus_types.eq_type
 val expose_eq_term : eq_term -> Nucleus_types.eq_term
 val expose_judgement : judgement -> Nucleus_types.judgement
 val expose_rule : 'a rule -> 'a Nucleus_types.rule
+val expose_judgement_abstraction : judgement_abstraction -> Nucleus_types.judgement_abstraction
 
 (** When we apply a rule application to one more argument two things may happen.
    Either we are done and we get a result, or more arguments are needed, in

--- a/src/parser/builtin.ml
+++ b/src/parser/builtin.ml
@@ -42,6 +42,12 @@ let builtin_ops =
   [unloc decl_equal_type;
    unloc decl_coerce]
 
+let builtin_excs =
+  let un_ml_string = unloc (Sugared.ML_String) in
+  let decl_eqchk_exec = Sugared.(DeclException (Name.Builtin.eqchk_excs_name, Some un_ml_string))
+  in
+  [unloc decl_eqchk_exec]
+
 let builtin_ml_values =
   []
 
@@ -56,5 +62,5 @@ let initial =
   [ unloc decl_list ;
     unloc (Sugared.TopModule
       (Name.Builtin.ml_name,
-       List.concat [builtin_ml_types; builtin_ops; builtin_ml_values]))
+       List.concat [builtin_ml_types; builtin_ops; builtin_excs; builtin_ml_values]))
   ]

--- a/src/parser/desugar.ml
+++ b/src/parser/desugar.ml
@@ -369,6 +369,13 @@ module Ctx = struct
     | None | Some (Bound _ | Value _ | TTConstructor _ | MLConstructor _ | Exception _) ->
        assert false
 
+  (* Get information about the given ML operation. *)
+  let get_ml_exception exc ctx =
+    match find_name exc ctx with
+    | Some (Exception (pth, arity)) -> pth, arity
+    | None | Some (Bound _ | Value _ | TTConstructor _ | MLConstructor _ | Operation _) ->
+       assert false
+
   (* This will be needed if and when there is a builtin global ML value that has to be looked up. *)
   (* let get_ml_value x ctx =
    *   match find_name x ctx with
@@ -1765,4 +1772,6 @@ struct
 
   let equal_type = fst (Ctx.get_ml_operation Name.Builtin.equal_type initial_context)
   let coerce = fst (Ctx.get_ml_operation Name.Builtin.coerce initial_context)
+
+  let eqchk_excs = fst (Ctx.get_ml_exception Name.Builtin.eqchk_excs initial_context)
 end

--- a/src/parser/desugar.mli
+++ b/src/parser/desugar.mli
@@ -60,4 +60,6 @@ sig
 
   val equal_type : Path.t
   val coerce : Path.t
+  
+  val eqchk_excs : Path.t
 end

--- a/src/parser/lexer.ml
+++ b/src/parser/lexer.ml
@@ -63,13 +63,13 @@ let qname =
 let digit = [%sedlex.regexp? '0'..'9']
 let numeral = [%sedlex.regexp? Plus digit]
 
-let symbolchar = [%sedlex.regexp?  ('!' | '$' | '%' | '&' | '*' | '+' | '-' | '.' | '/' | ':' | '<' | '=' | '>' | '?' | '@' | '^' | '|' | '~')]
+let symbolchar = [%sedlex.regexp?  ('!' | '$' | '%' | '&' | '*' | '+' | '-' | '.' | '/' | ':' | '<' | '=' | '>' | '?' | '@' | '^' | '|' | '~' | 215 )]
 
 let prefixop = [%sedlex.regexp? ('~' | '?' | '!'), Star symbolchar ]
 let infixop0 = [%sedlex.regexp? ('=' | '<' | '>' | '|' | '&' | '$'), Star symbolchar]
 let infixop1 = [%sedlex.regexp? ('@' | '^'), Star symbolchar ]
 let infixcons = [%sedlex.regexp? "::"]
-let infixop2 = [%sedlex.regexp? ('+' | '-'), Star symbolchar ]
+let infixop2 = [%sedlex.regexp? ('+' | '-'| 215), Star symbolchar ]
 let infixop3 = [%sedlex.regexp? ('*' | '/' | '%'), Star symbolchar ]
 let infixop4 = [%sedlex.regexp? "**", Star symbolchar ]
 

--- a/src/runtime/external.ml
+++ b/src/runtime/external.ml
@@ -88,10 +88,10 @@ let externals =
                let chk = Eqchk.add_type_computation chk drv in
                Runtime.return (Runtime.(External (EqualityChecker chk)))
              with
-               err -> 
-               let msg = Printexc.to_string err in
-               let trace = Printexc.get_backtrace () in 
-               Reflect.eqchk_exception ~at:Location.unknown (msg, trace)
+               | Eqchk_common.Invalid_rule err
+               | Eqchk_common.Equality_fail err
+               | Eqchk_pattern.Form_fail err ->
+                 Reflect.eqchk_exception ~at:Location.unknown err
            )));
 
     ("Eqchk.add_term_computation",
@@ -103,10 +103,10 @@ let externals =
                let chk =  Eqchk.add_term_computation chk drv in
                Runtime.return Runtime.(External (EqualityChecker chk))
               with
-               err -> 
-               let msg = Printexc.to_string err in
-               let trace = Printexc.get_backtrace () in 
-               Reflect.eqchk_exception ~at:Location.unknown (msg, trace)
+               | Eqchk_common.Invalid_rule err
+               | Eqchk_common.Equality_fail err
+               | Eqchk_pattern.Form_fail err ->
+                 Reflect.eqchk_exception ~at:Location.unknown err
            )));
 
     ("Eqchk.normalize_type",
@@ -146,10 +146,10 @@ let externals =
                let chk = Eqchk.add_extensionality chk drv in
                Runtime.return Runtime.(External (EqualityChecker chk))
              with
-               err -> 
-               let msg = Printexc.to_string err in
-               let trace = Printexc.get_backtrace () in 
-               Reflect.eqchk_exception ~at:Location.unknown (msg, trace)
+               | Eqchk_common.Invalid_rule err
+               | Eqchk_common.Equality_fail err
+               | Eqchk_pattern.Form_fail err ->
+                 Reflect.eqchk_exception ~at:Location.unknown err
     )));
 
     ("Eqchk.add",
@@ -162,10 +162,10 @@ let externals =
                let chk =  Eqchk.add ~quiet:false ~penv chk drv in
                Runtime.return Runtime.(External (EqualityChecker chk))
              with
-               err -> 
-               let msg = Printexc.to_string err in
-               let trace = Printexc.get_backtrace () in 
-               Reflect.eqchk_exception ~at:Location.unknown (msg, trace)
+               | Eqchk_common.Invalid_rule err
+               | Eqchk_common.Equality_fail err
+               | Eqchk_pattern.Form_fail err ->
+                 Reflect.eqchk_exception ~at:Location.unknown err
     )));
 
     ("Eqchk.prove_eq_type_abstraction",
@@ -182,10 +182,10 @@ let externals =
                   let eq = Nucleus.from_eq_type_abstraction eq in
                   Runtime.return Runtime.(Judgement eq)
                 with
-                  err -> 
-                  let msg = Printexc.to_string err in
-                  let trace = Printexc.get_backtrace () in 
-                  Reflect.eqchk_exception ~at:Location.unknown (msg, trace)
+                  | Eqchk_common.Invalid_rule err
+                  | Eqchk_common.Equality_fail err
+                  | Eqchk_pattern.Form_fail err ->
+                    Reflect.eqchk_exception ~at:Location.unknown err
     )));
 
     ("Eqchk.prove_eq_term_abstraction",
@@ -201,11 +201,11 @@ let externals =
                   let eq = Eqchk.prove_eq_term_abstraction chk sgn bdry in
                   let eq = Nucleus.from_eq_term_abstraction eq in
                   Runtime.return Runtime.(Judgement eq)
-                with
-                  err -> 
-                  let msg = Printexc.to_string err in
-                  let trace = Printexc.get_backtrace () in 
-                  Reflect.eqchk_exception ~at:Location.unknown (msg, trace)
+                 with
+                  | Eqchk_common.Invalid_rule err
+                  | Eqchk_common.Equality_fail err
+                  | Eqchk_pattern.Form_fail err ->
+                    Reflect.eqchk_exception ~at:Location.unknown err
     )));
   ]
 

--- a/src/runtime/external.ml
+++ b/src/runtime/external.ml
@@ -84,9 +84,14 @@ let externals =
          Runtime.return_closure (fun der ->
              let chk = Runtime.as_equality_checker ~at:Location.unknown chk
              and drv = Runtime.as_derivation ~at:Location.unknown der in
-             match Eqchk.add_type_computation chk drv with
-             | Some chk -> Runtime.return (Reflect.mk_option (Some Runtime.(External (EqualityChecker chk))))
-             | None -> Runtime.return (Reflect.mk_option None)
+             try
+               let chk = Eqchk.add_type_computation chk drv in
+               Runtime.return (Runtime.(External (EqualityChecker chk)))
+             with
+               err -> 
+               let msg = Printexc.to_string err in
+               let trace = Printexc.get_backtrace () in 
+               Runtime.return (Runtime.(External (EqualityCheckerException (msg, trace))))
            )));
 
     ("Eqchk.add_term_computation",
@@ -94,9 +99,14 @@ let externals =
          Runtime.return_closure (fun der ->
              let chk = Runtime.as_equality_checker ~at:Location.unknown chk
              and drv = Runtime.as_derivation ~at:Location.unknown der in
-             match Eqchk.add_term_computation chk drv with
-             | Some chk -> Runtime.return (Reflect.mk_option (Some Runtime.(External (EqualityChecker chk))))
-             | None -> Runtime.return (Reflect.mk_option None)
+             try
+               let chk =  Eqchk.add_term_computation chk drv in
+               Runtime.return Runtime.(External (EqualityChecker chk))
+              with
+               err -> 
+               let msg = Printexc.to_string err in
+               let trace = Printexc.get_backtrace () in 
+               Runtime.return (Runtime.(External (EqualityCheckerException (msg, trace))))
            )));
 
     ("Eqchk.normalize_type",
@@ -132,9 +142,14 @@ let externals =
          Runtime.return_closure (fun der ->
              let chk = Runtime.as_equality_checker ~at:Location.unknown chk
              and drv = Runtime.as_derivation ~at:Location.unknown der in
-             match Eqchk.add_extensionality chk drv with
-             | Some chk -> Runtime.return (Reflect.mk_option (Some Runtime.(External (EqualityChecker chk))))
-             | None -> Runtime.return (Reflect.mk_option None)
+             try
+               let chk = Eqchk.add_extensionality chk drv in
+               Runtime.return Runtime.(External (EqualityChecker chk))
+             with
+               err -> 
+               let msg = Printexc.to_string err in
+               let trace = Printexc.get_backtrace () in 
+               Runtime.return (Runtime.(External (EqualityCheckerException (msg, trace))))
     )));
 
     ("Eqchk.add",
@@ -143,9 +158,14 @@ let externals =
              Runtime.lookup_nucleus_penv >>= fun penv ->
              let chk = Runtime.as_equality_checker ~at:Location.unknown chk
              and drv = Runtime.as_derivation ~at:Location.unknown der in
-             match Eqchk.add ~quiet:false ~penv chk drv with
-             | Some chk -> Runtime.return (Reflect.mk_option (Some Runtime.(External (EqualityChecker chk))))
-             | None -> Runtime.return (Reflect.mk_option None)
+             try
+               let chk =  Eqchk.add ~quiet:false ~penv chk drv in
+               Runtime.return Runtime.(External (EqualityChecker chk))
+             with
+               err -> 
+               let msg = Printexc.to_string err in
+               let trace = Printexc.get_backtrace () in 
+               Runtime.return (Runtime.(External (EqualityCheckerException (msg, trace))))
     )));
 
     ("Eqchk.prove_eq_type_abstraction",
@@ -157,12 +177,15 @@ let externals =
              match Nucleus.as_eq_type_boundary_abstraction bdry with
              | None -> failwith "some error about wrong use of prove_eq_type_abstraction"
              | Some bdry ->
-                begin match Eqchk.prove_eq_type_abstraction chk sgn bdry with
-                | Some eq ->
-                   let eq = Nucleus.from_eq_type_abstraction eq in
-                   Runtime.return (Reflect.mk_option (Some Runtime.(Judgement eq)))
-                | None -> Runtime.return (Reflect.mk_option None)
-                end
+                try
+                  let eq = Eqchk.prove_eq_type_abstraction chk sgn bdry in
+                  let eq = Nucleus.from_eq_type_abstraction eq in
+                  Runtime.return Runtime.(Judgement eq)
+                with
+                  err -> 
+                  let msg = Printexc.to_string err in
+                  let trace = Printexc.get_backtrace () in 
+                  Runtime.return (Runtime.(External (EqualityCheckerException (msg, trace))))
     )));
 
     ("Eqchk.prove_eq_term_abstraction",
@@ -174,12 +197,15 @@ let externals =
              match Nucleus.as_eq_term_boundary_abstraction bdry with
              | None -> failwith "some error about wrong use of prove_eq_term_abstraction"
              | Some bdry ->
-                begin match Eqchk.prove_eq_term_abstraction chk sgn bdry with
-                | Some eq ->
-                   let eq = Nucleus.from_eq_term_abstraction eq in
-                   Runtime.return (Reflect.mk_option (Some Runtime.(Judgement eq)))
-                | None -> Runtime.return (Reflect.mk_option None)
-                end
+                try
+                  let eq = Eqchk.prove_eq_term_abstraction chk sgn bdry in
+                  let eq = Nucleus.from_eq_term_abstraction eq in
+                  Runtime.return Runtime.(Judgement eq)
+                with
+                  err -> 
+                  let msg = Printexc.to_string err in
+                  let trace = Printexc.get_backtrace () in 
+                  Runtime.return (Runtime.(External (EqualityCheckerException (msg, trace))))
     )));
   ]
 

--- a/src/runtime/external.ml
+++ b/src/runtime/external.ml
@@ -91,7 +91,7 @@ let externals =
                err -> 
                let msg = Printexc.to_string err in
                let trace = Printexc.get_backtrace () in 
-               Runtime.return (Runtime.(External (EqualityCheckerException (msg, trace))))
+               Reflect.eqchk_exception ~at:Location.unknown (msg, trace)
            )));
 
     ("Eqchk.add_term_computation",
@@ -106,7 +106,7 @@ let externals =
                err -> 
                let msg = Printexc.to_string err in
                let trace = Printexc.get_backtrace () in 
-               Runtime.return (Runtime.(External (EqualityCheckerException (msg, trace))))
+               Reflect.eqchk_exception ~at:Location.unknown (msg, trace)
            )));
 
     ("Eqchk.normalize_type",
@@ -149,7 +149,7 @@ let externals =
                err -> 
                let msg = Printexc.to_string err in
                let trace = Printexc.get_backtrace () in 
-               Runtime.return (Runtime.(External (EqualityCheckerException (msg, trace))))
+               Reflect.eqchk_exception ~at:Location.unknown (msg, trace)
     )));
 
     ("Eqchk.add",
@@ -165,7 +165,7 @@ let externals =
                err -> 
                let msg = Printexc.to_string err in
                let trace = Printexc.get_backtrace () in 
-               Runtime.return (Runtime.(External (EqualityCheckerException (msg, trace))))
+               Reflect.eqchk_exception ~at:Location.unknown (msg, trace)
     )));
 
     ("Eqchk.prove_eq_type_abstraction",
@@ -185,7 +185,7 @@ let externals =
                   err -> 
                   let msg = Printexc.to_string err in
                   let trace = Printexc.get_backtrace () in 
-                  Runtime.return (Runtime.(External (EqualityCheckerException (msg, trace))))
+                  Reflect.eqchk_exception ~at:Location.unknown (msg, trace)
     )));
 
     ("Eqchk.prove_eq_term_abstraction",
@@ -205,7 +205,7 @@ let externals =
                   err -> 
                   let msg = Printexc.to_string err in
                   let trace = Printexc.get_backtrace () in 
-                  Runtime.return (Runtime.(External (EqualityCheckerException (msg, trace))))
+                  Reflect.eqchk_exception ~at:Location.unknown (msg, trace)
     )));
   ]
 

--- a/src/runtime/reflect.ml
+++ b/src/runtime/reflect.ml
@@ -74,3 +74,7 @@ let operation_coerce ~at jdg bdry =
   and v2 = Runtime.Boundary bdry in
   Runtime.operation coerce [v1;v2] >>= fun v ->
   return (Runtime.as_judgement_abstraction ~at v)
+
+let eqchk_exception ~at (msg, trace) =
+  let msg' = Runtime.String (String.concat " " [msg; trace]) in
+  return (Runtime.Exc((eqchk_exc, Some msg')))

--- a/src/runtime/reflect.ml
+++ b/src/runtime/reflect.ml
@@ -75,6 +75,6 @@ let operation_coerce ~at jdg bdry =
   Runtime.operation coerce [v1;v2] >>= fun v ->
   return (Runtime.as_judgement_abstraction ~at v)
 
-let eqchk_exception ~at (msg, trace) =
-  let msg' = Runtime.String (String.concat " " [msg; trace]) in
-  return (Runtime.Exc((eqchk_exc, Some msg')))
+let eqchk_exception ~at msg =
+  let msg' = Runtime.String msg in
+  Runtime.raise_exception (eqchk_exc, Some msg')

--- a/src/runtime/reflect.ml
+++ b/src/runtime/reflect.ml
@@ -15,6 +15,8 @@ let tag_mlgreater, _, _ = Typecheck.Builtin.mlgreater
 let equal_type, _ = Typecheck.Builtin.equal_type
 let coerce, _ = Typecheck.Builtin.coerce
 
+let eqchk_exc, _ = Typecheck.Builtin.eqchk_excs
+
 let list_nil = Runtime.mk_tag tag_nil []
 
 let list_cons v lst = Runtime.mk_tag tag_cons [v; lst]

--- a/src/runtime/reflect.mli
+++ b/src/runtime/reflect.mli
@@ -20,3 +20,5 @@ val operation_equal_type :
 (** Invoke the AML [coerce] operation on the given abstracted judgement and boundary. *)
 val operation_coerce :
   at:Location.t -> Nucleus.judgement_abstraction -> Nucleus.boundary_abstraction -> Nucleus.judgement_abstraction Runtime.comp
+
+val eqchk_exception: at:Location.t -> string * string -> Runtime.value Runtime.comp

--- a/src/runtime/reflect.mli
+++ b/src/runtime/reflect.mli
@@ -21,4 +21,4 @@ val operation_equal_type :
 val operation_coerce :
   at:Location.t -> Nucleus.judgement_abstraction -> Nucleus.boundary_abstraction -> Nucleus.judgement_abstraction Runtime.comp
 
-val eqchk_exception: at:Location.t -> string * string -> Runtime.value Runtime.comp
+val eqchk_exception: at:Location.t -> string -> Runtime.value Runtime.comp

--- a/src/runtime/runtime.ml
+++ b/src/runtime/runtime.ml
@@ -171,6 +171,7 @@ and exc = Ident.t * value option
 
 and external_value =
   | EqualityChecker of Eqchk.checker
+  | EqualityCheckerException of string * string
 
 (* It's important not to confuse the closure and the underlying ocaml function *)
 and ('a, 'b) closure = Clos of ('a -> 'b comp)
@@ -362,6 +363,7 @@ let top_as_ml_module (m : unit toplevel) ({top_runtime=({lexical;_} as env);_} a
 
 let name_of_external = function
   | EqualityChecker _ -> "equality checker"
+  | EqualityCheckerException _ -> "and exception from equality checker"
 
 let name_of v =
   match v with
@@ -382,7 +384,7 @@ let name_of v =
 let as_equality_checker ~at = function
   | External (EqualityChecker chk) -> chk
 
-  | (Judgement _ | Boundary _ | Derivation _ | Closure _ | Handler _ | Exc _ | Tag _ | Tuple _ | Ref _ | String _) as v ->
+  | (External (EqualityCheckerException _) |Judgement _ | Boundary _ | Derivation _ | Closure _ | Handler _ | Exc _ | Tag _ | Tuple _ | Ref _ | String _) as v ->
     error ~at (EqualityCheckerExpected v)
 
 let as_derivation ~at = function
@@ -689,6 +691,8 @@ let top_lookup_signature topenv =
 let print_external ?max_level ~penv v ppf =
   match v with
   | EqualityChecker _ -> Format.fprintf ppf "<checker>"
+  | EqualityCheckerException (msg, trace) -> 
+    Format.fprintf ppf "Equality checker exception: %s%s@." msg trace
 
 (** In the future this routine will be type-driven. One consequence is that
     constructor tags will be printed by looking up their names in type
@@ -1069,6 +1073,9 @@ let equal_external_value v1 v2 =
   v1 == v2 ||
   match v1, v2 with
   | EqualityChecker c1, EqualityChecker c2 -> (c1 == c2)
+  | EqualityCheckerException (msg1,trace1), EqualityCheckerException (msg2,trace2) -> (msg1 == msg2)
+  | EqualityCheckerException _, EqualityChecker _
+  | EqualityChecker _, EqualityCheckerException _ -> false
 
 
 let rec equal_value v1 v2 =

--- a/src/runtime/runtime.mli
+++ b/src/runtime/runtime.mli
@@ -22,6 +22,7 @@ and exc = Ident.t * value option
 
 and external_value =
   | EqualityChecker of Eqchk.checker
+  | EqualityCheckerException of string * string
 
 and operation_args = { args : value list; checking : Nucleus.boundary_abstraction option }
 

--- a/src/typing/typecheck.ml
+++ b/src/typing/typecheck.ml
@@ -1063,5 +1063,5 @@ struct
 
   let _, coerce = run (Tyenv.lookup_ml_operation Desugar.Builtin.coerce)
 
-  let _, eqchk_excs = run (Tyenv.lookup_ml_operation Desugar.Builtin.eqchk_excs)
+  let _, eqchk_excs = run (Tyenv.lookup_ml_exception Desugar.Builtin.eqchk_excs)
 end

--- a/src/typing/typecheck.ml
+++ b/src/typing/typecheck.ml
@@ -1062,4 +1062,6 @@ struct
   let _, equal_type = run (Tyenv.lookup_ml_operation Desugar.Builtin.equal_type)
 
   let _, coerce = run (Tyenv.lookup_ml_operation Desugar.Builtin.coerce)
+
+  let _, eqchk_excs = run (Tyenv.lookup_ml_operation Desugar.Builtin.eqchk_excs)
 end

--- a/src/typing/typecheck.mli
+++ b/src/typing/typecheck.mli
@@ -29,6 +29,6 @@ sig
   val equal_type : Ident.t * (Mlty.ty list * Mlty.ty)
   val coerce : Ident.t * (Mlty.ty list * Mlty.ty)
   
-  val eqchk_excs : Ident.t * (Mlty.ty list * Mlty.ty)
+  val eqchk_excs : Ident.t * Mlty.ty option
 
 end

--- a/src/typing/typecheck.mli
+++ b/src/typing/typecheck.mli
@@ -28,5 +28,7 @@ sig
 
   val equal_type : Ident.t * (Mlty.ty list * Mlty.ty)
   val coerce : Ident.t * (Mlty.ty list * Mlty.ty)
+  
+  val eqchk_excs : Ident.t * (Mlty.ty list * Mlty.ty)
 
 end

--- a/src/utils/name.ml
+++ b/src/utils/name.ml
@@ -139,6 +139,9 @@ module Builtin = struct
 
   let hypotheses_name = mk_name "hypotheses"
   let hypotheses = in_ml hypotheses_name
+
+  let eqchk_excs_name = mk_name "EqualityCheckerException"
+  let eqchk_excs = in_ml eqchk_excs_name
 end
 
 (** Split a string into base and an optional numerical suffix, e.g., ["x42"],

--- a/src/utils/name.mli
+++ b/src/utils/name.mli
@@ -174,6 +174,10 @@ module Builtin : sig
   (** The name of the [hypotheses] dynamic variable *)
   val hypotheses_name : t
   val hypotheses : path
+
+  (** The name of the [EqualityCheckerException] exception *)
+  val eqchk_excs_name : t
+  val eqchk_excs : path
 end
 
 module Json :

--- a/stdlib/eq.m31
+++ b/stdlib/eq.m31
@@ -2,6 +2,11 @@
 
 mltype checker ;;
 
+exception Invalid_rule ;;
+exception Equality_fail ;;
+exception Normalization_fail ;;
+exception Match_fail ;;
+exception Form_fail ;;
 exception Invalid_equality_rule ;;
 
 exception Failed_equality of boundary ;;
@@ -9,13 +14,13 @@ exception Failed_equality of boundary ;;
 external empty_checker : checker
   = "Eqchk.empty_checker" ;;
 
-external add_type_computation : checker -> derivation -> ML.option checker
+external add_type_computation : checker -> derivation -> checker
   = "Eqchk.add_type_computation" ;;
 
-external add_term_computation : checker -> derivation -> ML.option checker
+external add_term_computation : checker -> derivation -> checker
   = "Eqchk.add_term_computation" ;;
 
-external add : checker -> derivation -> ML.option checker
+external add : checker -> derivation -> checker
   = "Eqchk.add" ;;
 
 external normalize_type : ML.bool -> checker -> judgement -> judgement * judgement
@@ -24,32 +29,25 @@ external normalize_type : ML.bool -> checker -> judgement -> judgement * judgeme
 external normalize_term : ML.bool -> checker -> judgement -> judgement * judgement
   = "Eqchk.normalize_term" ;;
 
-external add_extensionality : checker -> derivation -> ML.option checker
+external add_extensionality : checker -> derivation -> checker
   = "Eqchk.add_extensionality" ;;
 
-external prove_eqtype_abstraction : checker -> boundary -> ML.option judgement
+external prove_eqtype_abstraction : checker -> boundary -> judgement
   = "Eqchk.prove_eq_type_abstraction" ;;
 
-external prove_eqterm_abstraction : checker -> boundary -> ML.option judgement
+external prove_eqterm_abstraction : checker -> boundary -> judgement
   = "Eqchk.prove_eq_term_abstraction" ;;
 
 let ch = ref empty_checker ;;
 
-let add_rule der =
-  match add !ch der with
-  | ML.Some ?ch' -> (ch := ch')
-  | ML.None -> raise Invalid_equality_rule
-  end
+let add_rule der = 
+  let ch' = add !ch der in
+  ch := ch'
 ;;
 
 exception Coerce_fail ;;
 
-let equalize_type A B =
-  match prove_eqtype_abstraction !ch (A ≡ B by ??) with
-  | ML.Some ?eq -> eq
-  | ML.None -> raise Coerce_fail
-  end
-;;
+let equalize_type A B = prove_eqtype_abstraction !ch (A ≡ B by ??) ;;
 
 let coerce_abstraction jdg bdry =
   let rec fold jdg bdry =
@@ -91,16 +89,8 @@ let compute jdg =
 
 let prove bdry =
   match bdry with
-  | (_ ≡ _ by ??) ->
-    match prove_eqtype_abstraction (!ch) bdry with
-    | ML.Some ?ξ -> ξ
-    | ML.None -> raise (Failed_equality bdry)
-    end
-  | (_ ≡ _ : _ by ??) ->
-    match prove_eqterm_abstraction (!ch) bdry with
-    | ML.Some ?ξ -> ξ
-    | ML.None -> raise (Failed_equality bdry)
-    end
+  | (_ ≡ _ by ??) -> prove_eqtype_abstraction (!ch) bdry 
+  | (_ ≡ _ : _ by ??) -> prove_eqterm_abstraction (!ch) bdry
   end
 
 let add_locally equation cmp =

--- a/stdlib/eq.m31
+++ b/stdlib/eq.m31
@@ -102,3 +102,16 @@ let prove bdry =
     | ML.None -> raise (Failed_equality bdry)
     end
   end
+
+let add_locally equation cmp =
+  let ch' = ref !ch in
+  try
+    add_rule equation ;
+    let result = cmp () in
+    ch := !ch' ;
+    result
+  with
+    | raise ?exc -> 
+        ch := !ch' ;
+        raise exc
+  end

--- a/stdlib/eq.m31
+++ b/stdlib/eq.m31
@@ -31,7 +31,7 @@ external prove_eqterm_abstraction : checker -> boundary -> judgement
 
 let ch = ref empty_checker ;;
 
-let add_rule der = 
+let add_rule der =
   let ch' = add !ch der in
   ch := ch'
 ;;
@@ -80,7 +80,7 @@ let compute jdg =
 
 let prove bdry =
   match bdry with
-  | (_ ≡ _ by ??) -> prove_eqtype_abstraction (!ch) bdry 
+  | (_ ≡ _ by ??) -> prove_eqtype_abstraction (!ch) bdry
   | (_ ≡ _ : _ by ??) -> prove_eqterm_abstraction (!ch) bdry
   end
 
@@ -92,7 +92,7 @@ let add_locally equation cmp =
     ch := !ch' ;
     result
   with
-    | raise ?exc -> 
+    | raise ?exc ->
         ch := !ch' ;
         raise exc
   end

--- a/stdlib/eq.m31
+++ b/stdlib/eq.m31
@@ -2,15 +2,6 @@
 
 mltype checker ;;
 
-exception Invalid_rule ;;
-exception Equality_fail ;;
-exception Normalization_fail ;;
-exception Match_fail ;;
-exception Form_fail ;;
-exception Invalid_equality_rule ;;
-
-exception Failed_equality of boundary ;;
-
 external empty_checker : checker
   = "Eqchk.empty_checker" ;;
 

--- a/tests/equality-checker.m31
+++ b/tests/equality-checker.m31
@@ -38,6 +38,10 @@ eq.normalize (snd U V (pair U V u v));;
 
 eq.prove (p ≡ pair U V (fst U V p) (snd U V p) : prod U V by ??);;
 
+rule unuseful (A type) (B type) : prod A B ≡ U ;;
+eq.add_locally unuseful (fun () -> eq.compute (prod U V)) ;;
+eq.compute (prod U V) ;;
+
 (* Natural numbers *)
 
 rule ℕ type;;
@@ -72,6 +76,7 @@ eq.add_rule ℕ_β_z;;
 let plus = derive (n : ℕ) (m : ℕ) -> ℕ_ind ({_} ℕ) n ({k : ℕ} {c_k : ℕ} s c_k) m ;;
 let foo = plus (z) (s z);;
 eq.normalize foo;;
+eq.compute foo ;;
 eq.normalize (ℕ_ind ({_} ℕ) z ({c_n _} s c_n) z);;
 eq.normalize (s (ℕ_ind ({_} ℕ) z ({c_n _} s c_n) z));;
 eq.prove (plus (s z) (s z) ≡ s (s z) : ℕ by ??)

--- a/tests/equality-checker.m31
+++ b/tests/equality-checker.m31
@@ -26,7 +26,7 @@ rule prod_ext (A type) (B type) (u : prod A B) (v : prod A B)
 eq.add_rule β_fst;;
 eq.add_rule β_snd;;
 eq.add_rule prod_ext;;
-        
+
 rule U type;;
 rule V type;;
 rule p : prod U V;;
@@ -79,4 +79,13 @@ eq.normalize foo;;
 eq.compute foo ;;
 eq.normalize (ℕ_ind ({_} ℕ) z ({c_n _} s c_n) z);;
 eq.normalize (s (ℕ_ind ({_} ℕ) z ({c_n _} s c_n) z));;
-eq.prove (plus (s z) (s z) ≡ s (s z) : ℕ by ??)
+eq.prove (plus (s z) (s z) ≡ s (s z) : ℕ by ??) ;;
+
+rule weird (A type)
+           ({_ : A} B type)
+           (a : A)
+           (b : B{a})
+           (B{a} == A by ξ)
+           (_ :? eq.add_locally (derive -> ξ) (fun () -> a == b : A by ??))
+           type ;;
+

--- a/tests/equality-checker.m31.ref
+++ b/tests/equality-checker.m31.ref
@@ -1,23 +1,20 @@
 Processing module eq
 ML type eq.checker declared.
-Exception eq.Invalid_equality_rule is declared.
-Exception eq.Failed_equality is declared.
 external empty_checker : eq.checker = "Eqchk.empty_checker"
-external add_type_computation : eq.checker → derivation → ML.option
+external add_type_computation : eq.checker → derivation →
   eq.checker = "Eqchk.add_type_computation"
-external add_term_computation : eq.checker → derivation → ML.option
+external add_term_computation : eq.checker → derivation →
   eq.checker = "Eqchk.add_term_computation"
-external add : eq.checker → derivation → ML.option
-  eq.checker = "Eqchk.add"
+external add : eq.checker → derivation → eq.checker = "Eqchk.add"
 external normalize_type : ML.bool → eq.checker → judgement →
   judgement * judgement = "Eqchk.normalize_type"
 external normalize_term : ML.bool → eq.checker → judgement →
   judgement * judgement = "Eqchk.normalize_term"
-external add_extensionality : eq.checker → derivation → ML.option
+external add_extensionality : eq.checker → derivation →
   eq.checker = "Eqchk.add_extensionality"
-external prove_eqtype_abstraction : eq.checker → boundary → ML.option
+external prove_eqtype_abstraction : eq.checker → boundary →
   judgement = "Eqchk.prove_eq_type_abstraction"
-external prove_eqterm_abstraction : eq.checker → boundary → ML.option
+external prove_eqterm_abstraction : eq.checker → boundary →
   judgement = "Eqchk.prove_eq_term_abstraction"
 val ch :> ref eq.checker = ref <checker>
 val add_rule :> derivation → mlunit = <function>
@@ -27,6 +24,8 @@ val coerce_abstraction :> judgement → boundary → judgement = <function>
 val normalize :> judgement → judgement * judgement = <function>
 val compute :> judgement → judgement * judgement = <function>
 val prove :> boundary → judgement = <function>
+val add_locally :> mlforall α, derivation → (mlunit → α) → α =
+  <function>
 Rule unit is postulated.
 Rule tt is postulated.
 Rule unit_ext is postulated.

--- a/tests/equality-checker.m31.ref
+++ b/tests/equality-checker.m31.ref
@@ -107,3 +107,6 @@ val foo :> judgement = ⊢ ℕ_ind ({_} ℕ) z ({c_n _} s c_n) (s z) : ℕ
    : ℕ))
 - :> judgement = ⊢ ℕ_ind ({_} ℕ) (s z) ({c_n _} s c_n) (s z) ≡ s (s
   z) : ℕ
+Type computation rule for B₀ (heads at [0]):
+  derive → ?B₀ {?a₁} ≡ ?A₂
+Rule weird is postulated.

--- a/tests/equality-checker.m31.ref
+++ b/tests/equality-checker.m31.ref
@@ -64,6 +64,12 @@ Rule v is postulated.
 - :> judgement * judgement =
   ((⊢ snd U V (pair U V u v) ≡ v : V), (⊢ v : V))
 - :> judgement = ⊢ p ≡ pair U V (fst U V p) (snd U V p) : prod U V
+Rule unuseful is postulated.
+Type computation rule for prod (heads at []):
+  derive (A type) (B type) → prod A B ≡ U
+- :> judgement * judgement = ((⊢ prod U V ≡ U), (⊢ U type))
+- :> judgement * judgement =
+  ((⊢ prod U V ≡ prod U V), (⊢ prod U V type))
 Rule ℕ is postulated.
 Rule z is postulated.
 Rule s is postulated.
@@ -90,6 +96,9 @@ val foo :> judgement = ⊢ ℕ_ind ({_} ℕ) z ({c_n _} s c_n) (s z) : ℕ
   ((⊢ ℕ_ind ({_} ℕ) z ({c_n _} s c_n) (s z) ≡ s (ℕ_ind ({_} ℕ) z
    ({c_n _} s c_n) z) : ℕ), (⊢ s (ℕ_ind ({_} ℕ) z ({c_n _} s c_n) z)
    : ℕ))
+- :> judgement * judgement =
+  ((⊢ ℕ_ind ({_} ℕ) z ({c_n _} s c_n) (s z) ≡ s z : ℕ), (⊢ s z :
+   ℕ))
 - :> judgement * judgement =
   ((⊢ ℕ_ind ({_} ℕ) z ({_ c_n} s c_n) z ≡ z : ℕ), (⊢ z : ℕ))
 - :> judgement * judgement =

--- a/tests/equality/strong.m31.ref
+++ b/tests/equality/strong.m31.ref
@@ -1,23 +1,20 @@
 Processing module eq
 ML type eq.checker declared.
-Exception eq.Invalid_equality_rule is declared.
-Exception eq.Failed_equality is declared.
 external empty_checker : eq.checker = "Eqchk.empty_checker"
-external add_type_computation : eq.checker → derivation → ML.option
+external add_type_computation : eq.checker → derivation →
   eq.checker = "Eqchk.add_type_computation"
-external add_term_computation : eq.checker → derivation → ML.option
+external add_term_computation : eq.checker → derivation →
   eq.checker = "Eqchk.add_term_computation"
-external add : eq.checker → derivation → ML.option
-  eq.checker = "Eqchk.add"
+external add : eq.checker → derivation → eq.checker = "Eqchk.add"
 external normalize_type : ML.bool → eq.checker → judgement →
   judgement * judgement = "Eqchk.normalize_type"
 external normalize_term : ML.bool → eq.checker → judgement →
   judgement * judgement = "Eqchk.normalize_term"
-external add_extensionality : eq.checker → derivation → ML.option
+external add_extensionality : eq.checker → derivation →
   eq.checker = "Eqchk.add_extensionality"
-external prove_eqtype_abstraction : eq.checker → boundary → ML.option
+external prove_eqtype_abstraction : eq.checker → boundary →
   judgement = "Eqchk.prove_eq_type_abstraction"
-external prove_eqterm_abstraction : eq.checker → boundary → ML.option
+external prove_eqterm_abstraction : eq.checker → boundary →
   judgement = "Eqchk.prove_eq_term_abstraction"
 val ch :> ref eq.checker = ref <checker>
 val add_rule :> derivation → mlunit = <function>
@@ -27,6 +24,8 @@ val coerce_abstraction :> judgement → boundary → judgement = <function>
 val normalize :> judgement → judgement * judgement = <function>
 val compute :> judgement → judgement * judgement = <function>
 val prove :> boundary → judgement = <function>
+val add_locally :> mlforall α, derivation → (mlunit → α) → α =
+  <function>
 Rule N is postulated.
 Rule z is postulated.
 Rule s is postulated.

--- a/theories/dependent_sum.m31
+++ b/theories/dependent_sum.m31
@@ -30,7 +30,7 @@ eq.add_rule Σ_β₂
 rule Σ_ext
   (A type) ({x : A} B type) (s : Σ A B) (t : Σ A B)
   (π₁ A B s ≡ π₁ A B t : A by ξ)
-  (eq.add_locally ξ (fun () -> (ζ :? (π₂ A B s ≡ π₂ A B t : B{π₁ A B t} by ??))) )
+  (_ :? eq.add_locally (derive -> ξ) (fun () -> ((π₂ A B s ≡ π₂ A B t : B{π₁ A B t} by ??))) )
   (* (convert (π₂ A B s) (congruence B{π₁ A B s} B{π₁ A B t} ξ) ≡ π₂ A B t : B{π₁ A B t})*)
   : s ≡ t : Σ A B
 ;;

--- a/theories/dependent_sum.m31
+++ b/theories/dependent_sum.m31
@@ -30,7 +30,7 @@ eq.add_rule Σ_β₂
 rule Σ_ext
   (A type) ({x : A} B type) (s : Σ A B) (t : Σ A B)
   (π₁ A B s ≡ π₁ A B t : A by ξ)
-  (convert (π₂ A B s) (congruence B{π₁ A B s} B{π₁ A B t} ξ) ≡ π₂ A B t : B{π₁ A B t})
+  (_ :? eq.add_locally (derive -> ξ) (fun () -> ((π₂ A B s ≡ π₂ A B t : B{π₁ A B t} by ??))) )
   : s ≡ t : Σ A B
 ;;
 

--- a/theories/dependent_sum.m31
+++ b/theories/dependent_sum.m31
@@ -30,8 +30,7 @@ eq.add_rule Σ_β₂
 rule Σ_ext
   (A type) ({x : A} B type) (s : Σ A B) (t : Σ A B)
   (π₁ A B s ≡ π₁ A B t : A by ξ)
-  (_ :? eq.add_locally (derive -> ξ) (fun () -> ((π₂ A B s ≡ π₂ A B t : B{π₁ A B t} by ??))) )
-  (* (convert (π₂ A B s) (congruence B{π₁ A B s} B{π₁ A B t} ξ) ≡ π₂ A B t : B{π₁ A B t})*)
+  (convert (π₂ A B s) (congruence B{π₁ A B s} B{π₁ A B t} ξ) ≡ π₂ A B t : B{π₁ A B t})
   : s ≡ t : Σ A B
 ;;
 

--- a/theories/dependent_sum.m31
+++ b/theories/dependent_sum.m31
@@ -30,7 +30,8 @@ eq.add_rule Σ_β₂
 rule Σ_ext
   (A type) ({x : A} B type) (s : Σ A B) (t : Σ A B)
   (π₁ A B s ≡ π₁ A B t : A by ξ)
-  (convert (π₂ A B s) (congruence B{π₁ A B s} B{π₁ A B t} ξ) ≡ π₂ A B t : B{π₁ A B t})
+  (eq.add_locally ξ (fun () -> (ζ :? (π₂ A B s ≡ π₂ A B t : B{π₁ A B t} by ??))) )
+  (* (convert (π₂ A B s) (congruence B{π₁ A B s} B{π₁ A B t} ξ) ≡ π₂ A B t : B{π₁ A B t})*)
   : s ≡ t : Σ A B
 ;;
 

--- a/theories/simple_products.m31
+++ b/theories/simple_products.m31
@@ -1,0 +1,20 @@
+require eq;;
+
+rule (×) (A type) (B type) type ;;
+
+rule pair (A type) (B type) (a : A) (b : B) : A × B ;; 
+
+rule fst (A type) (B type) (u : A × B) : A ;;
+rule snd (A type) (B type) (u : A × B) : B ;;
+
+rule β_fst (A type) (B type) (s : A) (t : B) : fst A B (pair A B s t) ≡ s : A ;;
+eq.add_rule β_fst ;;
+rule β_snd (A type) (B type) (s : A) (t : B) : snd A B (pair A B s t) ≡ t : B ;;
+eq.add_rule β_snd ;;
+
+rule ext (A type) (B type) 
+         (p : A × B) (q : A × B) 
+         (fst A B p ≡ fst A B q : A)
+         (snd A B p ≡ snd A B q : B)
+         : p ≡ q : A × B ;;
+eq.add_rule ext ;;


### PR DESCRIPTION
This pull request relies on #530.
It adds to equality checker patterns abstracted constructors, without introducing and new metavariables under abstraction.
