### PR TITLE
a global handler for holes in prelude.

### DIFF
--- a/prelude.m31
+++ b/prelude.m31
@@ -1,2 +1,10 @@
 require base
 (* require "std/equal.m31" *)
+
+(* A global operation (?) to make holes and a metavariable is generated with the correct boundary *)
+
+operation (?) : judgement;;
+
+with
+    | operation (?) : ML.Some (?bdry) -> meta hole :? bdry
+end ;;

--- a/src/parser/parser.mly
+++ b/src/parser/parser.mly
@@ -418,6 +418,12 @@ op_name:
   | NAME
     { $1 }
 
+  | LPAREN op=infix RPAREN
+    { fst op }
+
+  | LPAREN op=prefix RPAREN
+    { fst op }
+
 (* ML exception name *)
 exc_name:
   | NAME

--- a/tests/runtime/holes.m31
+++ b/tests/runtime/holes.m31
@@ -1,0 +1,12 @@
+operation (?) : judgement;;
+
+with
+    | operation (?) : ML.Some (?bdry) -> meta hole :? bdry
+end ;;
+
+rule A type ;;
+rule B (_ : A) type ;;
+rule Σ (X type) ({_: X} Y type) type ;;
+
+B (?) ;;
+Σ (?) (?) ;;

--- a/tests/runtime/holes.m31.ref
+++ b/tests/runtime/holes.m31.ref
@@ -1,0 +1,7 @@
+Operation ( ? ) is declared.
+Rule A is postulated.
+Rule B is postulated.
+Rule Σ is postulated.
+- :> judgement = ?hole₀ : A ⊢ B ?hole₀ type
+- :> judgement = ?hole₁ type, {_ : ?hole₁} ?hole₂ type ⊢ Σ ?hole₁
+  ({x₀} ?hole₂ {x₀}) type


### PR DESCRIPTION
In prelude I have installed a global handler for holes, so the user can write
```
rule A type ;;
rule B (x : A) type ;;
B (?) ;;
```
and gets a fresh metavariable with the preferred name `hole` with the correct boundary:
```
- :> judgement = ?hole₀ : A ⊢ B ?hole₀ type
```
