### PR TITLE
Provide an interface for unchecked nested converts.

### DIFF
--- a/src/nucleus/form_convert.ml
+++ b/src/nucleus/form_convert.ml
@@ -17,7 +17,7 @@ let is_term_convert_opt sgn e (EqType (asmp, t1, t2)) =
        *)
        in
        (* [e] itself is not a [TermConvert] by the maintained invariant. *)
-       Some (Mk.term_convert e asmp t2)
+       Some (Mk.term_convert_panic e asmp t2)
      else
        None
 
@@ -27,7 +27,7 @@ let is_term_convert_opt sgn e (EqType (asmp, t1, t2)) =
        (* We need not include assumptions of [t1] because [t0] is alpha-equal
             to [t1] so we can use [t0] in place of [t1] if so desired. *)
        (* [e] is not a [TermConvert] by the above pattern-check *)
-       Some (Mk.term_convert e asmp t2)
+       Some (Mk.term_convert_panic e asmp t2)
      else
        None
 

--- a/src/nucleus/instantiate_bound.ml
+++ b/src/nucleus/instantiate_bound.ml
@@ -41,8 +41,7 @@ and is_term e0 ?(lvl=0) = function
        let e = is_term e0 ~lvl e
        and asmp = assumptions e0 ~lvl asmp
        and t = is_type e0 ~lvl t in
-       (* does not create a doubly nested [TermConvert] because original input does not either *)
-       TermConvert (e, asmp, t)
+       Mk.term_convert_join e asmp t
 
 (* there are no bound variables in the type of a meta *)
 and meta e0 ?(lvl=0) mv = mv
@@ -174,8 +173,7 @@ and is_term_fully ?(lvl=0) es = function
      let e = is_term_fully ~lvl es e
      and asmp = assumptions_fully ~lvl es asmp
      and t = is_type_fully ~lvl es t
-     (* does not create a doubly nested [TermConvert] because original input does not either *)
-     in TermConvert (e, asmp, t)
+     in Mk.term_convert_join e asmp t
 
 and eq_type_fully ?(lvl=0) es (EqType (asmp, t1, t2)) =
   let asmp = assumptions_fully ~lvl es asmp

--- a/src/nucleus/instantiate_meta.ml
+++ b/src/nucleus/instantiate_meta.ml
@@ -46,7 +46,7 @@ and is_term ~lvl (metas : argument list) = function
      let e = is_term ~lvl metas e
      and asmp = assumptions ~lvl metas asmp
      and t = is_type ~lvl metas t in
-     Mk.term_convert e asmp t
+     Mk.term_convert_join e asmp t
 
   | TermAtom _ as atm ->
      (** The type of an atom cannot contain bound meta-variables. *)

--- a/src/nucleus/mk.ml
+++ b/src/nucleus/mk.ml
@@ -20,11 +20,19 @@ let term_constructor c args = TermConstructor (c, args)
 
 let term_meta m args = TermMeta (m, args)
 
-(** Make a term conversion. It is illegal to pile a term conversion on top of another term
-   conversion. *)
-let term_convert e asmp t =
+(** Make a term conversion, failing if a nested conversion would arise. *)
+let term_convert_panic e asmp t =
   match e with
   | TermConvert _ -> assert false
+  | _ -> TermConvert (e, asmp, t)
+
+(** Make a term conversion, joining together a nested term conversion *without* checking types. *)
+let term_convert_join e asmp t =
+  match e with
+  | TermConvert (e', asmp', t') ->
+     let asmp'' = Assumption.(union (union asmp' asmp) (of_is_type ~lvl:0 t)) in
+     TermConvert (e', asmp'', t)
+
   | _ -> TermConvert (e, asmp, t)
 
 let arg_is_type t = JudgementIsType t

--- a/src/nucleus/rewrite.ml
+++ b/src/nucleus/rewrite.ml
@@ -41,7 +41,8 @@ let convert_argument sgn es asmps prem arg jdg =
         and jdg' = Instantiate_bound.(abstraction judgement atm_jdg jdg') in
         let asmp', abstr' = fold prem' arg1 jdg' in
         let a = Mk.fresh_atom x t' in
-        let a_conv = Mk.term_convert (Mk.atom a) asmps t in (*XXX: Here the converts are not piled, because we convert an atom *)
+        (* Here the converts are not piled, because we convert an atom *)
+        let a_conv = Mk.term_convert_panic (Mk.atom a) asmps t in
         let abstr = Abstract.judgement_abstraction atm abstr' in
         let abstr = Apply_abstraction.apply_judgement_abstraction sgn abstr a_conv in
         let asmp' = Abstract.assumptions atm.atom_nonce asmp' in
@@ -241,4 +242,3 @@ let judgement sgn jdg jdg_lst =
     JudgementEqTerm e_eq_e', JudgementIsTerm e'
 
   | JudgementEqType _ | JudgementEqTerm _ -> Error.raise InvalidRewrite
-


### PR DESCRIPTION
The `Mk.convert` is now split into `Mk.term_convert_panic` which disallows nested converts
and `Mk.term_convert_join` which joins nested converts (without checking that type match,
so this is not to be exposed outside of the nucleus).