### PR TITLE
fixed normalizing types before extensionality phase

### DIFF
--- a/src/equality/eqchk.ml
+++ b/src/equality/eqchk.ml
@@ -105,6 +105,17 @@ and prove_eq_term ~ext chk sgn bdry =
   if not ext then
     normalization_phase bdry
   else
+    let (e1, e2, t) = Nucleus.invert_eq_term_boundary bdry in
+    let t_eq_t', Normal t' = Eqchk_normalizer.normalize_type ~strong:false sgn chk.normalizer t in
+    let e1' = Nucleus.(form_is_term_convert sgn e1 t_eq_t')
+    and e2' = Nucleus.(form_is_term_convert sgn e2 t_eq_t')in
+    let bdry' = Nucleus.(form_eq_term_boundary sgn e1' e2') in
+    let bdry =
+    match Nucleus.(as_eq_term_boundary bdry' ) with
+    | Some bdry -> bdry
+    | None -> assert false
+    in
+    let eq_jdg =
     match Eqchk_extensionality.find chk.ext_rules sgn bdry with
 
     | Some rap ->
@@ -112,6 +123,11 @@ and prove_eq_term ~ext chk sgn bdry =
        resolve_rap chk sgn IntSet.empty rap
 
     | None -> normalization_phase bdry
+
+    in
+    let t'_eq_t = Nucleus.(symmetry_type t_eq_t') in
+    Nucleus.(form_eq_term_convert eq_jdg t'_eq_t)
+
 
 
 and check_normal_type chk sgn (Normal ty1) (Normal ty2) =

--- a/src/nucleus/form_convert.ml
+++ b/src/nucleus/form_convert.ml
@@ -17,7 +17,7 @@ let is_term_convert_opt sgn e (EqType (asmp, t1, t2)) =
        *)
        in
        (* [e] itself is not a [TermConvert] by the maintained invariant. *)
-       Some (Mk.term_convert_panic e asmp t2)
+       Some (Mk.term_convert_join e asmp t2) (* XXX: this may not be true, this is why we use join here!! *)
      else
        None
 

--- a/tests/equality/equality-checker.m31
+++ b/tests/equality/equality-checker.m31
@@ -38,6 +38,13 @@ eq.normalize (snd U V (pair U V u v));;
 
 eq.prove (p ≡ pair U V (fst U V p) (snd U V p) : (U × V) by ??);;
 
+(* Test type is normalized before applying extensionality rules *)
+rule P type ;;
+rule P_eq_prodUV : P ≡ (U × V) ;;
+eq.add_rule (derive -> P_eq_prodUV) ;;
+rule p' : P ;;
+eq.prove (p' ≡ pair U V (fst U V p') (snd U V p') : P by ??);;
+
 rule unuseful (A type) (B type) : (A × B) ≡ U ;;
 eq.add_locally unuseful (fun () -> eq.compute (U × V)) ;;
 eq.compute (U × V) ;;

--- a/tests/equality/equality-checker.m31.ref
+++ b/tests/equality/equality-checker.m31.ref
@@ -64,6 +64,13 @@ Rule v is postulated.
 - :> judgement * judgement =
   ((⊢ snd U V (pair U V u v) ≡ v : V), (⊢ v : V))
 - :> judgement = ⊢ p ≡ pair U V (fst U V p) (snd U V p) : ( × ) U V
+Rule P is postulated.
+Rule P_eq_prodUV is postulated.
+Type computation rule for P (heads at []):
+  derive → P ≡ ( × ) U V
+- :> mlunit = ()
+Rule p' is postulated.
+- :> judgement = ⊢ p' ≡ pair U V (fst U V p') (snd U V p') : P
 Rule unuseful is postulated.
 Type computation rule for × (heads at []):
   derive (A type) (B type) → ( × ) A B ≡ U


### PR DESCRIPTION
We forgot to normalize types of equality boundaries before entering type-directed phase. 
This is fixed, but some issues arised with stacking converts, whish were avoided by calling the function that joins them together (without re-checking that types match). 

Since types had to match while making the converts, this should not be a problem.