### PR TITLE
Eqchk error reports

### DIFF
--- a/src/equality/eqchk.ml
+++ b/src/equality/eqchk.ml
@@ -133,7 +133,7 @@ and prove_eq_term ~ext chk sgn bdry =
 and check_normal_type chk sgn (Normal ty1) (Normal ty2) =
   match Nucleus.congruence_is_type sgn ty1 ty2 with
 
-  | None -> raise (Equality_fail ("cannot find a congruence rule for given types") )
+  | None -> raise (EqchkError(Equality_fail (NoCongruenceTypes (ty1, ty2)) ))
 
   | Some rap ->
      let sym = head_symbol_type (Nucleus.expose_is_type ty1) in
@@ -144,7 +144,7 @@ and check_normal_type chk sgn (Normal ty1) (Normal ty2) =
 and check_normal_term chk sgn (Normal e1) (Normal e2) =
   match Nucleus.congruence_is_term sgn e1 e2 with
 
-  | None -> raise (Equality_fail "cannot find a congruence rule for given terms")
+  | None -> raise (EqchkError (Equality_fail (NoCongruenceTerms (e1, e2))))
 
   | Some rap ->
      let sym = head_symbol_term (Nucleus.expose_is_term e1) in
@@ -185,7 +185,7 @@ and prove_boundary_abstraction ~ext chk sgn bdry =
      Nucleus.abstract_judgement atm eq_abstr
 
   | Nucleus.(Stump_NotAbstract (BoundaryIsTerm _ | BoundaryIsType _)) ->
-     raise (Fatal_error "cannot prove an object boundary")
+    raise (Fatal_error (Fatal "cannot prove an object boundary"))
 
   in
   prove bdry
@@ -217,7 +217,7 @@ let add ~quiet ~penv chk drv =
       chk
 
   with
-    | Invalid_rule _ ->
+    | EqchkError ( Invalid_rule _ ) ->
       try
         begin match add_type_computation' chk drv with
 
@@ -233,7 +233,7 @@ let add ~quiet ~penv chk drv =
         end
 
      with
-      | Invalid_rule _ ->
+      | EqchkError ( Invalid_rule _ ) ->
           begin match add_term_computation' chk drv with
             | (sym, ((patt, _), _), chk) ->
               let heads = heads_term patt in

--- a/src/equality/eqchk.ml
+++ b/src/equality/eqchk.ml
@@ -185,7 +185,7 @@ and prove_boundary_abstraction ~ext chk sgn bdry =
      Nucleus.abstract_judgement atm eq_abstr
 
   | Nucleus.(Stump_NotAbstract (BoundaryIsTerm _ | BoundaryIsType _)) ->
-    raise (Fatal_error (Fatal "cannot prove an object boundary"))
+    raise (Fatal_error ("cannot prove an object boundary"))
 
   in
   prove bdry

--- a/src/equality/eqchk_common.ml
+++ b/src/equality/eqchk_common.ml
@@ -58,13 +58,95 @@ type symbol =
   | Ident of Ident.t
   | Nonce of Nonce.t
 
-exception Equality_fail of string
+(** Reporting Equality Checker errors. *)
+type invalid_rule =
+  | WrongMetavariable of int * int
+  | BoundMetavariableExpected of int * (Nucleus_types.is_term)
+  | TermBoundaryExpected of Nucleus_types.boundary
+  | TermBoundaryExpectedGotAbstraction of Nucleus_types.boundary_abstraction
+  | TermBoundaryNotGiven
+  | EquationLHSnotCorrect of Nucleus.eq_term * int
+  | EquationRHSnotCorrect of Nucleus.eq_term * int
+  | TypeOfEquationMismatch of Nucleus.eq_term * Nucleus_types.is_type * Nucleus_types.is_type
+  | ObjectPremiseAfterEqualityPremise of Nucleus_types.meta
+  | DerivationWrongForm of (Nucleus.derivation)
+  | ObjectBoundaryExpected of Nucleus_types.meta * Nucleus_types.boundary_abstraction
+  | TypeEqualityConclusionExpected
+  | TermEqualityConclusionExpected
 
-exception Invalid_rule of string
+type equality_fail =
+  | NoCongruenceTypes of Nucleus.is_type * Nucleus.is_type
+  | NoCongruenceTerms of Nucleus.is_term * Nucleus.is_term
 
-exception Normalization_fail of string
+type eqchk_error =
+  | Invalid_rule of invalid_rule
+  | Equality_fail of equality_fail
 
-exception Fatal_error of string
+type normalization_error =
+  | General of string
+
+type fatal_error =
+  | Normalization_fail of normalization_error
+  | Fatal of string
+
+exception EqchkError of eqchk_error
+
+exception Fatal_error of fatal_error
+
+let print_eqchk_error ~penv err ppf =
+  match err with
+  | Invalid_rule e ->
+    begin
+    match e with
+    | WrongMetavariable (k,j) ->
+      Format.fprintf ppf "expected a bound metavaribale %d, but got %d" k j
+    | BoundMetavariableExpected (k, e) ->
+      Format.fprintf ppf "expected a bound metavariable %d, but got %t" k (Nucleus_print.thesis_is_term ~penv e)
+    | TermBoundaryExpected b ->
+      Format.fprintf ppf "expected a term boundary, but got %t"
+      (Nucleus_print.thesis_boundary ~penv ~print_head:(Nucleus_print.print_qqmark) b)
+    | TermBoundaryExpectedGotAbstraction abstr ->
+      Format.fprintf ppf "expected a term boundary, but got %t"
+      (Nucleus_print.boundary_abstraction ~penv abstr)
+    | TermBoundaryNotGiven ->
+      Format.fprintf ppf "expected a term boundary, but got None"
+    | EquationLHSnotCorrect (eq, k) ->
+      Format.fprintf ppf "LHS of equation %t not a correct metavariable %d"
+      Nucleus_print.(thesis_eq_term ~penv (Nucleus.expose_eq_term eq))
+      k
+    | EquationRHSnotCorrect (eq, k) ->
+      Format.fprintf ppf "RHS of equation %t not a correct metavariable %d"
+      Nucleus_print.(thesis_eq_term ~penv (Nucleus.expose_eq_term eq))
+      k
+    | TypeOfEquationMismatch (eq, t1, t2) ->
+      Format.fprintf ppf "Type at equation %t should be equal to both types of metavariabels %t and %t" Nucleus_print.(thesis_eq_term ~penv (Nucleus.expose_eq_term eq))
+      Nucleus_print.(thesis_is_type ~penv t1)
+      Nucleus_print.(thesis_is_type ~penv t2)
+    | ObjectPremiseAfterEqualityPremise p ->
+      Format.fprintf ppf "Object premise %t appears after equality premise"
+      Nucleus_print.(premise ~penv p)
+    | DerivationWrongForm drv ->
+      Format.fprintf ppf "Derivation not in a required form"
+    | ObjectBoundaryExpected (prem, bdry) ->
+      Format.fprintf ppf
+      "Premise %t of a computation rule does not have an object boundary %t"
+      Nucleus_print.(premise ~penv prem) Nucleus_print.(boundary_abstraction ~penv bdry)
+    | TypeEqualityConclusionExpected ->
+      Format.fprintf ppf "Conclusion not a type equality boundary"
+    | TermEqualityConclusionExpected ->
+      Format.fprintf ppf "Conclusion not a type equality boundary"
+
+    end
+  | Equality_fail (NoCongruenceTypes (ty1, ty2)) ->
+    Format.fprintf ppf "Cannot find a congruence rule for types %t and %t"
+    Nucleus_print.(thesis_is_type ~penv (Nucleus.expose_is_type ty1))
+    Nucleus_print.(thesis_is_type ~penv (Nucleus.expose_is_type ty2))
+
+  | Equality_fail (NoCongruenceTerms (e1, e2)) ->
+    Format.fprintf ppf "Cannot find a congruence rule for terms %t and %t"
+    Nucleus_print.(thesis_is_term ~penv (Nucleus.expose_is_term e1))
+    Nucleus_print.(thesis_is_term ~penv (Nucleus.expose_is_term e2))
+
 
 (** A tag to indicate that a term or a type is normalized *)
 type 'a normal = Normal of 'a
@@ -100,7 +182,7 @@ let head_symbol_term e =
     | Nucleus_types.(TermAtom {atom_nonce=n; _}) -> Nonce n
     | Nucleus_types.TermConstructor (c, _) -> Ident c
     | Nucleus_types.(TermMeta (MetaFree {meta_nonce;_}, _)) -> Nonce meta_nonce
-    | Nucleus_types.(TermMeta (MetaBound _, _)) -> raise (Fatal_error "head symbol of a bound term metavariable does not exist")
+    | Nucleus_types.(TermMeta (MetaBound _, _)) -> raise (Fatal_error (Fatal "head symbol of a bound term metavariable does not exist"))
     | Nucleus_types.TermConvert (e, _, _) -> fold e
   in
   fold e
@@ -110,20 +192,19 @@ let head_symbol_term e =
 let head_symbol_type = function
   | Nucleus_types.TypeConstructor (c, _) -> Ident c
   | Nucleus_types.(TypeMeta (MetaFree {meta_nonce=n;_}, _)) -> Nonce n
-  | Nucleus_types.(TypeMeta (MetaBound _, _)) -> raise (Fatal_error "head symbol of a bound type metavariable does not exist")
-
+  | Nucleus_types.(TypeMeta (MetaBound _, _)) -> raise (Fatal_error (Fatal"head symbol of a bound type metavariable does not exist"))
 (** Apply rap to a list of arguments *)
 let rap_apply rap args =
   let rec fold rap args =
   match rap, args with
   | rap, [] -> rap
   | Nucleus.RapMore (_bdry, f), arg :: args -> fold (f arg) args
-  | Nucleus.RapDone _, _::_ -> raise (Fatal_error "Applying the rule to too many arguments")
+  | Nucleus.RapDone _, _::_ -> raise (Fatal_error (Fatal "Applying the rule to too many arguments"))
   in
   try
     fold rap args
   with
-  | Nucleus.Error err -> raise (Fatal_error "Nucleus error")
+  | Nucleus.Error err -> raise (Fatal_error (Fatal "Nucleus error"))
 
 (** Apply rap to a list of arguments, return the judgement *)
 let rap_fully_apply rap args =
@@ -134,8 +215,8 @@ let rap_fully_apply rap args =
     ();
     let tmp = f (arg) in
     fold tmp args
-  | Nucleus.RapDone _, _::_ -> raise (Fatal_error "Applying the rule to too many arguments")
-  | Nucleus.RapMore _, [] -> raise (Fatal_error "Applying the rule to too few arguments")
+  | Nucleus.RapDone _, _::_ -> raise (Fatal_error (Fatal "Applying the rule to too many arguments"))
+  | Nucleus.RapMore _, [] -> raise (Fatal_error (Fatal "Applying the rule to too few arguments"))
   in
   try
     Some (fold rap args)

--- a/src/equality/eqchk_common.ml
+++ b/src/equality/eqchk_common.ml
@@ -70,7 +70,7 @@ type invalid_rule =
   | TypeOfEquationMismatch of Nucleus.eq_term * Nucleus_types.is_type * Nucleus_types.is_type
   | ObjectPremiseAfterEqualityPremise of Nucleus_types.meta
   | DerivationWrongForm of (Nucleus.derivation)
-  | ObjectBoundaryExpected of Nucleus_types.meta * Nucleus_types.boundary_abstraction
+  | ObjectBoundaryExpected of Nucleus_types.boundary_abstraction
   | TypeEqualityConclusionExpected
   | TermEqualityConclusionExpected
 
@@ -127,10 +127,10 @@ let print_eqchk_error ~penv err ppf =
       Nucleus_print.(premise ~penv p)
     | DerivationWrongForm drv ->
       Format.fprintf ppf "Derivation not in a required form"
-    | ObjectBoundaryExpected (prem, bdry) ->
+    | ObjectBoundaryExpected (bdry) ->
       Format.fprintf ppf
-      "Premise %t of a computation rule does not have an object boundary %t"
-      Nucleus_print.(premise ~penv prem) Nucleus_print.(boundary_abstraction ~penv bdry)
+      "Premise %t of a computation rule does not have an object boundary"
+      Nucleus_print.(boundary_abstraction ~penv bdry)
     | TypeEqualityConclusionExpected ->
       Format.fprintf ppf "Conclusion not a type equality boundary"
     | TermEqualityConclusionExpected ->

--- a/src/equality/eqchk_common.ml
+++ b/src/equality/eqchk_common.ml
@@ -88,22 +88,20 @@ type form_fail =
   | CaptureMetasNotCorrectType of Nucleus_types.is_type
   | CaptureMetasNotCorrectTerm of Nucleus_types.is_term
 
+type normalization_error =
+  | EqualityTypeArguement of Nucleus.eq_type
+  | EqualityTermArguement of Nucleus.eq_term
+  | EqualityArgument of Nucleus.judgement_abstraction
 
 type eqchk_error =
   | Invalid_rule of invalid_rule
   | Equality_fail of equality_fail
   | Form_fail of form_fail
-
-type normalization_error =
-  | General of string
-
-type fatal_error =
   | Normalization_fail of normalization_error
-  | Fatal of string
 
 exception EqchkError of eqchk_error
 
-exception Fatal_error of fatal_error
+exception Fatal_error of string
 
 let print_eqchk_error ~penv err ppf =
   match err with
@@ -113,7 +111,8 @@ let print_eqchk_error ~penv err ppf =
     | WrongMetavariable (k,j) ->
       Format.fprintf ppf "expected a bound metavaribale %d, but got %d" k j
     | BoundMetavariableExpected (k, e) ->
-      Format.fprintf ppf "expected a bound metavariable %d, but got %t" k (Nucleus_print.thesis_is_term ~penv e)
+      Format.fprintf ppf "expected a bound metavariable %d, but got %t"
+      k (Nucleus_print.thesis_is_term ~penv e)
     | TermBoundaryExpected b ->
       Format.fprintf ppf "expected a term boundary, but got %t"
       (Nucleus_print.thesis_boundary ~penv ~print_head:(Nucleus_print.print_qqmark) b)
@@ -131,7 +130,9 @@ let print_eqchk_error ~penv err ppf =
       Nucleus_print.(thesis_eq_term ~penv (Nucleus.expose_eq_term eq))
       k
     | TypeOfEquationMismatch (eq, t1, t2) ->
-      Format.fprintf ppf "Type at equation %t should be equal to both types of metavariabels %t and %t" Nucleus_print.(thesis_eq_term ~penv (Nucleus.expose_eq_term eq))
+      Format.fprintf ppf
+      "Type at equation %t should be equal to both types of metavariabels %t and %t"
+      Nucleus_print.(thesis_eq_term ~penv (Nucleus.expose_eq_term eq))
       Nucleus_print.(thesis_is_type ~penv t1)
       Nucleus_print.(thesis_is_type ~penv t2)
     | ObjectPremiseAfterEqualityPremise p ->
@@ -147,8 +148,8 @@ let print_eqchk_error ~penv err ppf =
       Format.fprintf ppf "Conclusion not a type equality boundary"
     | TermEqualityConclusionExpected ->
       Format.fprintf ppf "Conclusion not a term equality boundary"
-
     end
+
   | Equality_fail (NoCongruenceTypes (ty1, ty2)) ->
     Format.fprintf ppf "Cannot find a congruence rule for types %t and %t"
     Nucleus_print.(thesis_is_type ~penv (Nucleus.expose_is_type ty1))
@@ -162,18 +163,51 @@ let print_eqchk_error ~penv err ppf =
   | Form_fail er ->
     begin
       match er with
-      | NewTypeMetaCheckingMode i -> Format.fprintf ppf "Cannot introduce a new type metavariable with index %d in checking mode" i
-      | NewTermMetaCheckingMode i -> Format.fprintf ppf "Cannot introduce a new term metavariable with index %d in checking mode" i
-      | MetaBoundTypeInPatt i -> Format.fprintf ppf "Cannot make a pattern from a bound type metavariable with index %d" i
-      | MetaBoundTermInPatt i -> Format.fprintf ppf "Cannot make a pattern from a bound term metavariable with index %d" i
-      | EqualityTypeArgumentInPatt eqty -> Format.fprintf ppf "Cannot form a pattern out of a type equality argument %t"
+      | NewTypeMetaCheckingMode i ->
+        Format.fprintf ppf
+        "Cannot introduce a new type metavariable with index %d in checking mode" i
+      | NewTermMetaCheckingMode i ->
+        Format.fprintf ppf
+        "Cannot introduce a new term metavariable with index %d in checking mode" i
+      | MetaBoundTypeInPatt i ->
+        Format.fprintf ppf
+        "Cannot make a pattern from a bound type metavariable with index %d" i
+      | MetaBoundTermInPatt i ->
+        Format.fprintf ppf
+        "Cannot make a pattern from a bound term metavariable with index %d" i
+      | EqualityTypeArgumentInPatt eqty ->
+        Format.fprintf ppf
+        "Cannot form a pattern out of a type equality argument %t"
         Nucleus_print.(thesis_eq_type ~penv eqty)
-      | EqualityTermArgumentInPatt eqtm -> Format.fprintf ppf "Cannot form a pattern out of a term equality argument %t"
+      | EqualityTermArgumentInPatt eqtm ->
+        Format.fprintf ppf
+        "Cannot form a pattern out of a term equality argument %t"
         Nucleus_print.(thesis_eq_term ~penv eqtm)
-      | CaptureMetasNotCorrectType ty -> Format.fprintf ppf "Pattern type %t does not capture correct metavariables"
+      | CaptureMetasNotCorrectType ty ->
+        Format.fprintf ppf
+        "Pattern type %t does not capture correct metavariables"
         Nucleus_print.(thesis_is_type ~penv ty)
-      | CaptureMetasNotCorrectTerm e -> Format.fprintf ppf "Pattern term %t does not capture correct metavariables"
+      | CaptureMetasNotCorrectTerm e ->
+        Format.fprintf ppf
+        "Pattern term %t does not capture correct metavariables"
         Nucleus_print.(thesis_is_term ~penv e)
+    end
+
+  | Normalization_fail er ->
+    begin
+      match er with
+      | EqualityTypeArguement eqty ->
+        Format.fprintf ppf
+        "Cannot normalize type equality argument %t"
+        Nucleus_print.(thesis_eq_type ~penv (Nucleus.expose_eq_type eqty))
+      | EqualityTermArguement eqtm ->
+        Format.fprintf ppf
+        "Cannot normalize term equality argument %t"
+        Nucleus_print.(thesis_eq_term ~penv (Nucleus.expose_eq_term eqtm))
+      | EqualityArgument jdg_abstr ->
+        Format.fprintf ppf
+        "Cannot normalize equality argument %t"
+        Nucleus_print.(judgement_abstraction ~penv (Nucleus.expose_judgement_abstraction jdg_abstr))
     end
 
 
@@ -211,7 +245,7 @@ let head_symbol_term e =
     | Nucleus_types.(TermAtom {atom_nonce=n; _}) -> Nonce n
     | Nucleus_types.TermConstructor (c, _) -> Ident c
     | Nucleus_types.(TermMeta (MetaFree {meta_nonce;_}, _)) -> Nonce meta_nonce
-    | Nucleus_types.(TermMeta (MetaBound _, _)) -> raise (Fatal_error (Fatal "head symbol of a bound term metavariable does not exist"))
+    | Nucleus_types.(TermMeta (MetaBound _, _)) -> raise (Fatal_error ("head symbol of a bound term metavariable does not exist"))
     | Nucleus_types.TermConvert (e, _, _) -> fold e
   in
   fold e
@@ -221,19 +255,19 @@ let head_symbol_term e =
 let head_symbol_type = function
   | Nucleus_types.TypeConstructor (c, _) -> Ident c
   | Nucleus_types.(TypeMeta (MetaFree {meta_nonce=n;_}, _)) -> Nonce n
-  | Nucleus_types.(TypeMeta (MetaBound _, _)) -> raise (Fatal_error (Fatal"head symbol of a bound type metavariable does not exist"))
+  | Nucleus_types.(TypeMeta (MetaBound _, _)) -> raise (Fatal_error ("head symbol of a bound type metavariable does not exist"))
 (** Apply rap to a list of arguments *)
 let rap_apply rap args =
   let rec fold rap args =
   match rap, args with
   | rap, [] -> rap
   | Nucleus.RapMore (_bdry, f), arg :: args -> fold (f arg) args
-  | Nucleus.RapDone _, _::_ -> raise (Fatal_error (Fatal "Applying the rule to too many arguments"))
+  | Nucleus.RapDone _, _::_ -> raise (Fatal_error ("Applying the rule to too many arguments"))
   in
   try
     fold rap args
   with
-  | Nucleus.Error err -> raise (Fatal_error (Fatal "Nucleus error"))
+  | Nucleus.Error err -> raise (Fatal_error ("Nucleus error"))
 
 (** Apply rap to a list of arguments, return the judgement *)
 let rap_fully_apply rap args =
@@ -244,8 +278,8 @@ let rap_fully_apply rap args =
     ();
     let tmp = f (arg) in
     fold tmp args
-  | Nucleus.RapDone _, _::_ -> raise (Fatal_error (Fatal "Applying the rule to too many arguments"))
-  | Nucleus.RapMore _, [] -> raise (Fatal_error (Fatal "Applying the rule to too few arguments"))
+  | Nucleus.RapDone _, _::_ -> raise (Fatal_error ("Applying the rule to too many arguments"))
+  | Nucleus.RapMore _, [] -> raise (Fatal_error ("Applying the rule to too few arguments"))
   in
   try
     Some (fold rap args)

--- a/src/equality/eqchk_normalizer.ml
+++ b/src/equality/eqchk_normalizer.ml
@@ -42,11 +42,11 @@ let make_type_computation drv =
        let s = head_symbol_type t1 in
        (s, patt)
 
-    | Nucleus_types.(Premise ({meta_boundary=bdry;_}as premise, drv)) ->
+    | Nucleus_types.(Premise ({meta_boundary=bdry;_}, drv)) ->
        if is_object_premise bdry then
          fold (k+1) drv
        else
-         raise (EqchkError (Invalid_rule (ObjectBoundaryExpected(premise, bdry))))
+         raise (EqchkError (Invalid_rule (ObjectBoundaryExpected(bdry))))
   in
   let drv =
     match Nucleus.as_eq_type_rule drv with
@@ -66,11 +66,11 @@ let make_term_computation drv =
        let s = head_symbol_term e1 in
        (s, patt)
 
-    | Nucleus_types.(Premise ({meta_boundary=bdry;_} as p, drv)) ->
+    | Nucleus_types.(Premise ({meta_boundary=bdry;_}, drv)) ->
        if is_object_premise bdry then
          fold (k+1) drv
        else
-       raise (EqchkError (Invalid_rule (ObjectBoundaryExpected(p, bdry))))
+       raise (EqchkError (Invalid_rule (ObjectBoundaryExpected(bdry))))
   in
   let drv =
     match Nucleus.as_eq_term_rule drv with
@@ -350,4 +350,4 @@ and normalize_argument ~strong sgn nrm arg =
       Normal (Nucleus.(abstract_not_abstract (JudgementIsTerm e')))
 
   | Nucleus.(Stump_NotAbstract (JudgementEqType _ | JudgementEqTerm _)) ->
-  raise (Fatal_error (Normalization_fail (General "cannot normalize equality judgements")))
+      raise (Fatal_error (Normalization_fail (General "cannot normalize equality judgements")))

--- a/src/equality/eqchk_normalizer.ml
+++ b/src/equality/eqchk_normalizer.ml
@@ -2,10 +2,10 @@
 
 open Eqchk_common
 
-(** Extract an optional value, or declare an equality failure *)
-let deopt x msg =
+(** Extract an optional value, or declare a normalization fail *)
+let deopt x err =
   match x with
-  | None -> raise (Fatal_error (Normalization_fail ( General msg)))
+  | None -> raise (EqchkError (Normalization_fail err))
   | Some x -> x
 
 (** The types of beta rules. *)
@@ -119,61 +119,6 @@ let get_term_heads nrm sym =
   | Some hs -> hs
 
 (** Functions that apply rewrite rules *)
-
-let is_alpha_equal_type_arg arg t =
-  try
-  begin
-  match Nucleus.(as_is_type (deopt (as_not_abstract arg) "")) with
-  | Some arg_ty -> Nucleus.(alpha_equal_type arg_ty t)
-  | None -> false
-  end
-  with
-    Fatal_error (Normalization_fail _) -> false
-
-let is_alpha_equal_term_arg arg e =
-  try
-  begin
-  match Nucleus.(as_is_term (deopt (as_not_abstract arg) "")) with
-  | Some arg_e -> Nucleus.(alpha_equal_term arg_e e)
-  | None -> false
-  end
-  with
-     Fatal_error (Normalization_fail _) -> false
-
-let rec is_alpha_equal_type_args sgn args args' args_eq_args' ty0 =
-  match args, args', args_eq_args' with
-    | [], [], [] -> None
-    | arg :: args, arg' :: args', arg_eq_arg' :: args_eq_args' ->
-      if is_alpha_equal_type_arg arg ty0 then
-        let arg_eq_arg' = deopt Nucleus.(as_eq_type (deopt (as_not_abstract arg_eq_arg') "")) ""
-        and arg' = deopt Nucleus.(as_is_type (deopt (as_not_abstract arg') "")) "" in
-        Some (arg_eq_arg', arg')
-      else
-      is_alpha_equal_type_args sgn args args' args_eq_args' ty0
-    | [], _ :: _, _ :: _
-    | _ :: _, [], _ :: _
-    | _ :: _, _ :: _, []
-    | [], [], _ :: _
-    | [], _ :: _, []
-    | _ :: _, [], [] -> None
-
-let rec is_alpha_equal_term_args sgn args args' args_eq_args' e0 =
-  match args, args', args_eq_args' with
-    | [], [], [] -> None
-    | arg :: args, arg' :: args', arg_eq_arg' :: args_eq_args' ->
-      if is_alpha_equal_term_arg arg e0 then
-        let arg_eq_arg' = deopt Nucleus.(as_eq_term (deopt (as_not_abstract arg_eq_arg') "")) ""
-        and arg' = deopt Nucleus.(as_is_term (deopt (as_not_abstract arg') "")) "" in
-        Some (arg_eq_arg', arg')
-      else
-      is_alpha_equal_term_args sgn args args' args_eq_args' e0
-    | [], _ :: _, _ :: _
-    | _ :: _, [], _ :: _
-    | _ :: _, _ :: _, []
-    | [], [], _ :: _
-    | [], _ :: _, []
-    | _ :: _, [], [] -> None
-
 
 (** Find a type computation rule and apply it to [t]. *)
 let rec apply_type_beta betas sgn t =
@@ -324,7 +269,7 @@ and normalize_arguments ~strong sgn nrm heads args =
        let arg_eq_arg', Normal arg' = normalize_argument ~strong sgn nrm arg in
        fold (k+1) (arg' :: args') (arg_eq_arg' :: args_eq_args') args_rest
       else
-        let arg_eq_arg' = deopt (Nucleus.reflexivity_judgement_abstraction sgn arg) "unexpected equality judgement" in
+        let arg_eq_arg' = deopt (Nucleus.reflexivity_judgement_abstraction sgn arg) (EqualityArgument arg) in
         fold (k+1) (arg :: args') (arg_eq_arg' :: args_eq_args') args_rest
   in
   fold 0 [] [] args
@@ -349,5 +294,7 @@ and normalize_argument ~strong sgn nrm arg =
       Nucleus.(abstract_not_abstract (JudgementEqTerm  e_eq_e')),
       Normal (Nucleus.(abstract_not_abstract (JudgementIsTerm e')))
 
-  | Nucleus.(Stump_NotAbstract (JudgementEqType _ | JudgementEqTerm _)) ->
-      raise (Fatal_error (Normalization_fail (General "cannot normalize equality judgements")))
+  | Nucleus.(Stump_NotAbstract (JudgementEqType eqty)) ->
+      raise (EqchkError (Normalization_fail (EqualityTypeArguement eqty)))
+  | Nucleus.(Stump_NotAbstract (JudgementEqTerm eqtm)) ->
+      raise (EqchkError (Normalization_fail (EqualityTermArguement eqtm)))

--- a/src/nucleus/nucleus.ml
+++ b/src/nucleus/nucleus.ml
@@ -15,6 +15,7 @@ let expose_eq_term eq = eq
 let expose_judgement jdg = jdg
 let expose_rule rl = rl
 let expose_judgement_abstraction abstr = abstr
+let expose_penv penv = penv
 
 (** Exports from [Sanity] *)
 let type_of_term = Sanity.type_of_term

--- a/src/nucleus/nucleus.mli
+++ b/src/nucleus/nucleus.mli
@@ -134,6 +134,7 @@ val expose_eq_term : eq_term -> Nucleus_types.eq_term
 val expose_judgement : judgement -> Nucleus_types.judgement
 val expose_rule : 'a rule -> 'a Nucleus_types.rule
 val expose_judgement_abstraction : judgement_abstraction -> Nucleus_types.judgement_abstraction
+val expose_penv : print_environment -> Nucleus_types.print_environment
 
 (** When we apply a rule application to one more argument two things may happen.
    Either we are done and we get a result, or more arguments are needed, in

--- a/src/runtime/external.ml
+++ b/src/runtime/external.ml
@@ -12,9 +12,6 @@ let catch_eqchk_exceptions cmp =
       let s = Format.fprintf Format.str_formatter "%t" (Eqchk_common.print_eqchk_error ~penv err) ; Format.flush_str_formatter () in
       Reflect.eqchk_exception ~at:Location.unknown s
 
-    | Eqchk_pattern.Form_fail err ->
-      Reflect.eqchk_exception ~at:Location.unknown err
-
 let externals =
   [
     ("print", (* forall a, a -> mlunit *)

--- a/src/runtime/external.ml
+++ b/src/runtime/external.ml
@@ -119,11 +119,12 @@ let externals =
        let strong = Runtime.as_bool ~at:Location.unknown strong
        and chk = Runtime.as_equality_checker ~at:Location.unknown chk
        and t = Runtime.as_is_type ~at:Location.unknown t in
-       let (t_eq_t', t') = Eqchk.normalize_type ~strong chk sgn t in
-       let t_eq_t' = Nucleus.(abstract_not_abstract (JudgementEqType t_eq_t'))
-       and t' = Nucleus.(abstract_not_abstract (JudgementIsType t')) in
-       Runtime.(return (Tuple [Judgement t_eq_t'; Judgement t']))
-       ))));
+       catch_eqchk_exceptions (fun () ->
+          let (t_eq_t', t') = Eqchk.normalize_type ~strong chk sgn t in
+          let t_eq_t' = Nucleus.(abstract_not_abstract (JudgementEqType t_eq_t'))
+          and t' = Nucleus.(abstract_not_abstract (JudgementIsType t')) in
+          Runtime.(return (Tuple [Judgement t_eq_t'; Judgement t']))
+       )))));
 
     ("Eqchk.normalize_term",
      Runtime.mk_closure_external (fun strong ->
@@ -133,11 +134,12 @@ let externals =
        let strong = Runtime.as_bool ~at:Location.unknown strong
        and chk = Runtime.as_equality_checker ~at:Location.unknown chk
        and e = Runtime.as_is_term ~at:Location.unknown e in
-       let (e_eq_e', e') = Eqchk.normalize_term ~strong chk sgn e in
-       let e_eq_e' = Nucleus.(abstract_not_abstract (JudgementEqTerm e_eq_e'))
-       and e' = Nucleus.(abstract_not_abstract (JudgementIsTerm e')) in
-       Runtime.(return (Tuple [Judgement e_eq_e'; Judgement e']))
-    ))));
+       catch_eqchk_exceptions (fun () ->
+          let (e_eq_e', e') = Eqchk.normalize_term ~strong chk sgn e in
+          let e_eq_e' = Nucleus.(abstract_not_abstract (JudgementEqTerm e_eq_e'))
+          and e' = Nucleus.(abstract_not_abstract (JudgementIsTerm e')) in
+          Runtime.(return (Tuple [Judgement e_eq_e'; Judgement e']))
+    )))));
 
     ("Eqchk.add_extensionality",
      Runtime.mk_closure_external (fun chk ->

--- a/stdlib/eq.m31
+++ b/stdlib/eq.m31
@@ -37,6 +37,8 @@ let add_rule der =
 ;;
 
 exception Coerce_fail ;;
+exception Not_equality_boundary of boundary ;;
+exception Not_object_judgement of judgement ;;
 
 let equalize_type A B = prove_eqtype_abstraction !ch (A ≡ B by ??) ;;
 
@@ -68,6 +70,9 @@ let normalize jdg =
   match jdg with
   | (?A type) -> normalize_type ML.false (!ch) A
   | (?a : _) -> normalize_term ML.false (!ch) a
+  | (_ ≡ _) -> raise (Not_object_judgement jdg)
+  | (_ ≡ _ : _) -> raise (Not_object_judgement jdg)
+
   end
 ;;
 
@@ -75,11 +80,15 @@ let compute jdg =
   match jdg with
   | (?A type) -> normalize_type ML.true (!ch) A
   | (?a : _) -> normalize_term ML.true (!ch) a
+  | (_ ≡ _) -> raise (Not_object_judgement jdg)
+  | (_ ≡ _ : _) -> raise (Not_object_judgement jdg)
   end
 ;;
 
 let prove bdry =
   match bdry with
+  | (?? type) -> raise (Not_equality_boundary bdry)
+  | (?? : _) -> raise (Not_equality_boundary bdry)
   | (_ ≡ _ by ??) -> prove_eqtype_abstraction (!ch) bdry
   | (_ ≡ _ : _ by ??) -> prove_eqterm_abstraction (!ch) bdry
   end

--- a/tests/equality/eqchk_exceptions.m31
+++ b/tests/equality/eqchk_exceptions.m31
@@ -1,0 +1,186 @@
+(* Testing Exceptions in equality checker *)
+require eq ;;
+
+(* Proving non-object boundaries *)
+rule U type;;
+let jdg1 =
+    try
+        eq.prove (?? : U)
+    with
+        | raise (eq.Not_equality_boundary (?? : ?A)) -> base.print "passed test non-object boundaries" ; A
+    end ;;
+
+(* Adding extensionality rules *)
+
+rule U' (x : U) : U ;;
+rule x_eq_y_U (x : U) (y : U) : y ≡ x : U ;;
+let nothing1 =
+    try
+        eq.add_extensionality (!eq.ch) x_eq_y_U ; ()
+    with
+        | raise ML.EqualityCheckerException "LHS of equation [0] ≡ [1] :
+U not a correct metavariable 1" -> base.print "passed test extensionality LHS" ; ()
+    end ;;
+
+rule x_eq_y_U1 (x : U) (y : U) : x ≡ U' y : U ;;
+let nothing2 =
+    try
+        eq.add_extensionality (!eq.ch) x_eq_y_U1 ; ()
+    with
+        | raise ML.EqualityCheckerException "RHS of equation [1] ≡ U' [0] :
+U not a correct metavariable 0" -> base.print "passed test extensionality RHS" ; ()
+    end ;;
+
+rule x_eq_y_U2 (x : U) (y : U) (x ≡ x : U by ξ) (a : U) : x ≡ y : U ;;
+let nothing3 =
+    try
+        eq.add_extensionality (!eq.ch) x_eq_y_U2 ; ()
+    with
+        | raise ML.EqualityCheckerException "Object premise a :
+U appears after equality premise" -> base.print "passed test extensionality object after equality premise" ; ()
+    end ;;
+
+rule x_eq_y_U3 (x : U) (y : U) : U ≡ U ;;
+let nothing4 =
+    try
+        eq.add_extensionality (!eq.ch) x_eq_y_U3 ; ()
+    with
+        | raise ML.EqualityCheckerException "Derivation not in a required form" -> base.print "passed test extensionality derivation wrong from" ; ()
+    end ;;
+
+rule V type ;;
+rule V_eq_U : V ≡ U ;;
+rule x_eq_y_U4 (x : U) (y : V) :?
+               (eq.add_locally (derive -> V_eq_U) (fun () -> x ≡ y : U by ??)) ;;
+let nothing4' =
+    try
+        eq.add_extensionality (!eq.ch) x_eq_y_U4 ; ()
+    with
+        | raise ML.EqualityCheckerException "RHS of equation [1] ≡ [0] :
+U not a correct metavariable 0" -> base.print "passed test extensionality type mismatch in metavars" ; ()
+    end ;;
+
+(* Adding computation rules *)
+
+(* Term computation rule with equality premises *)
+rule u : U ;;
+rule v : U ;;
+rule u_eq_v (U ≡ U by ξ) : u ≡ v : U ;;
+let jdg3 =
+    try
+        eq.add_rule u_eq_v
+    with
+        | raise ML.EqualityCheckerException "Premise ⊢ U ≡
+U by ⁇ of a computation rule does not have an object boundary"-> base.print "passed test term computation rule equality prems" ; ()
+    end ;;
+
+rule U_is_everything (X type) : U ≡ X ;;
+let nothing5 =
+    try
+       eq.add_rule U_is_everything ; ()
+    with
+        | raise ML.EqualityCheckerException "Pattern type U does not capture correct metavariables" -> base.print "passed test adding type computation not correct metas" ; ()
+    end ;;
+
+rule u_is_everything (x : U) : u ≡ x : U ;;
+let nothing6 =
+    try
+       eq.add_rule u_is_everything ; ()
+    with
+        | raise ML.EqualityCheckerException "Pattern term u does not capture correct metavariables" -> base.print "passed test adding term computation not correct metas" ; ()
+    end ;;
+
+rule refl (A type) : A ≡ A ;;
+rule w (U ≡ U) : U ;;
+rule all_eq_u (x : U) : x ≡ u : U ;;
+let w_eq_u = derive -> all_eq_u (w (refl U)) ;;
+let nothing7 =
+    try
+       eq.add_rule w_eq_u ; ()
+    with
+        | raise ML.EqualityCheckerException "Cannot form a pattern out of a type equality argument U ≡
+U" -> base.print "passed test adding computation equality argument" ; ()
+    end ;;
+
+rule R ({x : U} B type) type ;;
+rule R_eq_U ({x : U} B type) : B{u} ≡ U ;;
+let nothing8 =
+    try
+       eq.add_rule R_eq_U ; ()
+    with
+        | raise ML.EqualityCheckerException "Cannot make a pattern from a bound type metavariable with index 0" -> base.print "passed test adding computation bound type metavariable" ; ()
+    end ;;
+
+rule r ({x : U} b : U) : U ;;
+rule r_eq_u ({x : U} b : U) : b {u} ≡ u : U ;;
+let nothing9 =
+    try
+       eq.add_rule r_eq_u ; ()
+    with
+        | raise ML.EqualityCheckerException "Cannot make a pattern from a bound term metavariable with index 0" -> base.print "passed test adding computation bound term metavariable" ; ()
+    end ;;
+
+
+rule S (x : U) type ;;
+rule S_eq_U ({x : U} b : U) : S (b{u}) ≡ U ;;
+let nothing10 =
+    try
+       eq.add_rule S_eq_U ; ()
+    with
+        | raise ML.EqualityCheckerException "Cannot make a pattern from a bound term metavariable with index 0" -> base.print "passed test adding computation bound term metavariable as argument" ; ()
+    end ;;
+
+rule S_eq_U_again (x : U) : S x ≡ U ;;
+let nothing11 =
+    try
+        eq.add_term_computation (!eq.ch) S_eq_U_again ; ()
+    with
+        | raise ML.EqualityCheckerException "Conclusion not a term equality boundary" -> base.print "passed test adding term computation conclusion" ; ()
+    end ;;
+
+rule s (x : U) : U ;;
+rule s_eq_u (x : U) : s x ≡ u : U ;;
+let nothing12 =
+    try
+        eq.add_type_computation (!eq.ch) s_eq_u ; ()
+    with
+        | raise ML.EqualityCheckerException "Conclusion not a type equality boundary" -> base.print "passed test adding type computation conclusion" ; ()
+    end ;;
+
+(* Normalizing equations *)
+let jdg2 =
+    try
+        eq.normalize( refl U )
+    with
+        | raise eq.Not_object_judgement (?A ≡ ?B) -> base.print "passed test normalizing equalities" ; (A, B)
+    end ;;
+
+(* Normalizing judgements with equality arguments *)
+rule W (U ≡ U by ξ) type ;;
+let nothing13 =
+    try
+        eq.normalize(W (refl U)) ; ()
+    with
+        | raise ML.EqualityCheckerException "Cannot normalize equality argument ⊢ U ≡
+U" -> base.print "passed test normalizing equality argument" ; ()
+    end ;;
+
+(* Proving equality *)
+
+rule UU type ;;
+rule VV type ;;
+let nothing14 =
+    try
+        eq.prove (UU ≡ VV by ??) ; ()
+    with
+        | raise ML.EqualityCheckerException "Cannot find a congruence rule for types UU and VV" -> base.print "passed test proving bdry no congruence type" ; ()
+    end ;;
+
+rule uu : UU ;;
+rule vv : UU ;;
+let nothing15 =
+    try
+        eq.prove (uu ≡ vv : UU by ??) ; ()
+    with
+        | raise ML.EqualityCheckerException "Cannot find a congruence rule for terms uu and vv" -> base.print "passed test proving bdry no congruence term" ; ()
+    end ;;

--- a/tests/equality/eqchk_exceptions.m31.ref
+++ b/tests/equality/eqchk_exceptions.m31.ref
@@ -1,0 +1,2 @@
+File "./equality/eqchk_exceptions.m31", line 10, characters 57-102:
+Type error: unknown name base.print

--- a/tests/equality/equality-checker.m31.ref
+++ b/tests/equality/equality-checker.m31.ref
@@ -19,6 +19,8 @@ external prove_eqterm_abstraction : eq.checker → boundary →
 val ch :> ref eq.checker = ref <checker>
 val add_rule :> derivation → mlunit = <function>
 Exception eq.Coerce_fail is declared.
+Exception eq.Not_equality_boundary is declared.
+Exception eq.Not_object_judgement is declared.
 val equalize_type :> judgement → judgement → judgement = <function>
 val coerce_abstraction :> judgement → boundary → judgement = <function>
 val normalize :> judgement → judgement * judgement = <function>

--- a/tests/equality/normalization_boundaries.m31.ref
+++ b/tests/equality/normalization_boundaries.m31.ref
@@ -19,6 +19,8 @@ external prove_eqterm_abstraction : eq.checker → boundary →
 val ch :> ref eq.checker = ref <checker>
 val add_rule :> derivation → mlunit = <function>
 Exception eq.Coerce_fail is declared.
+Exception eq.Not_equality_boundary is declared.
+Exception eq.Not_object_judgement is declared.
 val equalize_type :> judgement → judgement → judgement = <function>
 val coerce_abstraction :> judgement → boundary → judgement = <function>
 val normalize :> judgement → judgement * judgement = <function>

--- a/tests/equality/strong.m31.ref
+++ b/tests/equality/strong.m31.ref
@@ -19,6 +19,8 @@ external prove_eqterm_abstraction : eq.checker → boundary →
 val ch :> ref eq.checker = ref <checker>
 val add_rule :> derivation → mlunit = <function>
 Exception eq.Coerce_fail is declared.
+Exception eq.Not_equality_boundary is declared.
+Exception eq.Not_object_judgement is declared.
 val equalize_type :> judgement → judgement → judgement = <function>
 val coerce_abstraction :> judgement → boundary → judgement = <function>
 val normalize :> judgement → judgement * judgement = <function>


### PR DESCRIPTION
Error reporting in equality checker is improved by adding a pretty-printer for the equality checking module. 
Tests for most of the errors, that can be raised by users, are also added.