### PR TITLE
bug fix in metavar args in rewrite + tests

### DIFF
--- a/src/nucleus/rewrite.ml
+++ b/src/nucleus/rewrite.ml
@@ -101,7 +101,7 @@ let is_type sgn t jdg_lst =
         match bdry, args, jdg_lst with
         | NotAbstract (BoundaryIsType ()), [], [] ->
           let asmp = asmps in
-          let t' = Mk.type_meta m es in
+          let t' = Mk.type_meta m (List.rev es) in
           (Mk.eq_type asmp t t'),  t'
 
         | Abstract (_, t', abstr), arg :: args, jdg :: jdg_lst  ->
@@ -178,7 +178,7 @@ let rec is_term sgn e jdg_lst =
       match bdry, args, jdg_lst with
       | NotAbstract (BoundaryIsTerm t), [], [] ->
         let asmp = asmps in
-        let e' = Mk.term_meta m es in
+        let e' = Mk.term_meta m (List.rev es) in
         let e' = Form_convert.is_term_convert sgn e' (Mk.eq_type asmps (Sanity.type_of_term sgn e') t) in
         (Mk.eq_term asmp e e' t), e'
 

--- a/tests/equality/equality-checker.m31
+++ b/tests/equality/equality-checker.m31
@@ -95,3 +95,23 @@ rule weird (A type)
            (B{a} == A by ξ)
            (_ :? eq.add_locally (derive -> ξ) (fun () -> a == b : A by ??))
            type ;;
+
+let d = derive
+    (A type)
+    (B type)
+    ({a : A}{b : B} op : A)
+    (e : B)
+    ({a : A} op{a}{e} ≡ a : A by ξ)
+    (e' : B)
+    (e' ≡ e : B by η)
+    (x : A)
+    ->
+    eq.add_locally
+        (derive (y : A) -> ξ{y})
+        (fun () ->
+            eq.add_locally (derive -> η)
+             (fun () ->
+                eq.prove(op{x}{e'} ≡ x : A by ??)
+            )
+        )
+    ;;

--- a/tests/equality/equality-checker.m31.ref
+++ b/tests/equality/equality-checker.m31.ref
@@ -117,3 +117,12 @@ val foo :> judgement = ⊢ ℕ_ind ({_} ℕ) z ({c_n _} s c_n) (s z) : ℕ
 Type computation rule for B₀ (heads at [0]):
   derive → ?B₀ {?a₁} ≡ ?A₂
 Rule weird is postulated.
+Term computation rule for op₃ (heads at [1]):
+  derive (y : ?A₄) → ?op₃ {y} {?e₅} ≡ y : ?A₄
+
+Term computation rule for e'₆ (heads at []):
+  derive → ?e'₆ ≡ ?e₅ : ?B₇
+
+val d :> derivation = derive (A type) (B type) ({_ : A} {_ : B} op : A) (e :
+  B) ({a : A} op {a} {e} ≡ a : A by ξ) (e' : B) (e' ≡ e : B by η) (x :
+  A) → op {x} {e'} ≡ x : A

--- a/tests/nucleus/rewrite.m31
+++ b/tests/nucleus/rewrite.m31
@@ -25,4 +25,18 @@ rewrite ((Π A ({x : A} B x))) A_eq_A' ({x : A} β x);;
 
 rule F (X type) ({x : X} y : A) : A ;;
 let fa = rewrite (F A ({_ : A} a)) A_eq_A' ({x : A} a_eq_a')  ;;
-match fa with | (?e, F ?arg1 ?arg2) -> arg2 end
+match fa with | (?e, F ?arg1 ?arg2) -> arg2 end ;;
+
+rule refl_tm (X type) (x : X) : x ≡ x : X ;;
+let der = derive
+            (M type)
+            (N type)
+            ({x : M}{y : N} op : M)
+            (m : M)
+            (m' : M)
+            (m' ≡ m : M by ξ)
+            (n : N)
+            ->
+            let (?e, _) = rewrite op{m'}{n} ξ (refl_tm N n) in
+            e
+            ;;

--- a/tests/nucleus/rewrite.m31.ref
+++ b/tests/nucleus/rewrite.m31.ref
@@ -29,3 +29,7 @@ Rule F is postulated.
 val fa :> judgement * judgement =
   ((⊢ F A ({_} a) ≡ F A' ({_} a') : A), (⊢ F A' ({_} a') : A))
 - :> judgement = ⊢ {_ : A'} a' : A
+Rule refl_tm is postulated.
+val der :> derivation = derive (M type) (N type) ({_ : M} {_ : N} op : M) (m
+  : M) (m' : M) (m' ≡ m : M by ξ) (n : N) → op {m'} {n} ≡ op {m} {n} :
+  M


### PR DESCRIPTION
In rewriting along equalities, the arguments for metavariables in the output were in the wrong order. 
This is fixed and a few tests are added, that capture this particular bug. 