### PR TITLE
Linear patterns

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ SEDLEX=$(shell if [ "$(SEDLEX_VERSION)" \< "2.0" ] ; then echo "sedlex" ; else e
 # Use this to not die on all warnings
 #OCAMLBUILD_FLAGS = -j 4 -lib unix -cflags -g,-annot,-w,+a-4-27-29-50 -use-ocamlfind -pkg menhirLib -pkg $(SEDLEX)
 
-OCAMLBUILD_FLAGS = -j 4 -lib unix -cflags -g,-annot,-w,+a-4-27-29-50,"-warn-error +a" -use-ocamlfind -pkg menhirLib -pkg $(SEDLEX)
+OCAMLBUILD_FLAGS = -j 4 -lib unix -cflags -g,-annot,-w,+a-4-27-29-50-70-32,"-warn-error +a" -use-ocamlfind -pkg menhirLib -pkg $(SEDLEX)
 
 # The --strict flag prevents --explain, so we make a separate Makefile target to get
 # menhir explanations

--- a/tests/malformed-unicode.m31.ref
+++ b/tests/malformed-unicode.m31.ref
@@ -1,2 +1,2 @@
-File "./malformed-unicode.m31", line 1, characters 1-0:
+File "./malformed-unicode.m31", line 1, characters 7-7:
 Parsing error: malformed UTF8

--- a/tests/syntax/malformed-unicode.m31.ref
+++ b/tests/syntax/malformed-unicode.m31.ref
@@ -1,2 +1,2 @@
-File "./syntax/malformed-unicode.m31", line 1, characters 1-0:
+File "./syntax/malformed-unicode.m31", line 1, characters 7-7:
 Parsing error: malformed UTF8

--- a/theories/dependent_product.m31
+++ b/theories/dependent_product.m31
@@ -7,15 +7,19 @@ rule λ (A type) ({x : A} B type) ({x : A} e : B{x}) : Π A B
 rule app (A type) ({x : A} B type) (s : Π A B) (a : A)
   : B{a}
 
-rule Π_β (A type) ({x : A} B type) ({x : A} s : B{x}) (a : A)
-  : app A B (λ A B s) a ≡ s{a} : B{a} ;;
+rule Π_β (A type) ({x:A} B type)
+         (A' type) ({x:A'} B' type)
+         ({x:A'} s : B'{x}) (a : A)
+         (A' ≡ A by ξ) ({x : A'} B'{x} ≡ B{convert x ξ} by ζ)
+         :?
+         (eq.add_locally (derive -> ξ) (fun () ->
+           eq.add_locally (derive (x : A') -> ζ{x}) (fun () ->
+           app A B (λ A' B' s) a ≡ s{a} : B{a} by ??
+           )));;
+eq.add_rule Π_β ;;
 
-eq.add_rule Π_β;;
-
-rule Π_ext (A type) ({x : A} B type)
+rule Π_ext (A type) ({x:A} B type)
            (f : Π A B) (g : Π A B)
-           ({x : A} app A B f x ≡ app A B g x : B{x})
-           :
-           f ≡ g : Π A B;;
-
-eq.add_rule Π_ext;;
+           ({x:A} app A B f x ≡ app A B g x : B{x})
+           : f ≡ g : Π A B ;;
+eq.add_rule Π_ext ;;

--- a/theories/dependent_sum.m31
+++ b/theories/dependent_sum.m31
@@ -14,25 +14,33 @@ rule π₂ (A type) ({x : A} B type) (s : Σ A B)
   : B{π₁ A B s}
 ;;
 
-rule Σ_β₁ (A type) ({x : A} B type) (a : A) (b : B{a})
-  : π₁ A B (pair A B a b) ≡ a : A
-;;
+rule Σ_β₁ (A type) ({x : A} B type)
+          (A' type) ({x : A'} B' type)
+          (a : A') (b : B'{a})
+          (A' ≡ A by ξ) ({x : A'} B'{x} ≡ B{convert x ξ} by ζ)
+          :?
+          (eq.add_locally (derive -> ξ) (fun () ->
+           eq.add_locally (derive (x : A') -> ζ{x}) (fun () ->
+           π₁ A B (pair A' B' a b) ≡ a : A by ?? ))) ;;
+eq.add_rule Σ_β₁ ;;
 
-eq.add_rule Σ_β₁
-;;
 
-rule Σ_β₂ (A type) ({x : A} B type) (a : A) (b : B{a})
-  : π₂ A B (pair A B a b) ≡ b : B{a} ;;
+rule Σ_β₂ (A type) ({x : A} B type)
+          (A' type) ({x : A'} B' type)
+          (a : A') (b : B'{a})
+          (A' ≡ A by ξ) ({x : A'} B'{x} ≡ B{convert x ξ} by ζ)
+          :?
+          (eq.add_locally (derive -> ξ) (fun () ->
+           eq.add_locally (derive (x : A') -> ζ{x}) (fun () ->
+           π₂ A B (pair A' B' a b) ≡  b  : B{a} by ??))) ;;
+eq.add_rule Σ_β₂ ;;
 
-eq.add_rule Σ_β₂
-;;
-
-rule Σ_ext
-  (A type) ({x : A} B type) (s : Σ A B) (t : Σ A B)
+rule Σ_ext (A type) ({x:A} B type) (s : Σ A B) (t : Σ A B)
   (π₁ A B s ≡ π₁ A B t : A by ξ)
-  (_ :? eq.add_locally (derive -> ξ) (fun () -> ((π₂ A B s ≡ π₂ A B t : B{π₁ A B t} by ??))) )
-  : s ≡ t : Σ A B
-;;
+  (convert (π₂ A B s) (congruence B{π₁ A B s} B{π₁ A B t} ξ) ≡
+   π₂ A B t : B{π₁ A B t} by ζ)
+  : s ≡ t : Σ A B ;;
+eq.add_rule Σ_ext ;;
 
 eq.add_rule Σ_ext
 ;;

--- a/theories/identity_type.m31
+++ b/theories/identity_type.m31
@@ -1,5 +1,11 @@
 require eq ;;
 
+require judgemental_equality_type;;
+
+require judgemental_equality_term;;
+
+
+
 rule Id (A type) (a : A) (b : A) type
 ;;
 
@@ -18,10 +24,29 @@ rule J
 
 rule J_β
   (A type)
+  (A' type)
   ({x y : A} {p : Id A x y} C type)
   ({x : A} c : C{x, x, refl A x})
   (a : A)
-  : J A C c a a (refl A a) ≡ c{a} : C{a, a, refl A a}
+  (a' : A')
+  (a'' : A)
+  (A' ≡ A by ξ)
+  (a' ≡  convert a (judgemental_equality_type.eq_type_sym A' A ξ) : A' by ζ)
+  (a' ≡  convert a'' (judgemental_equality_type.eq_type_sym A' A ξ) : A' by ρ)
+  (a'' ≡ a : A by ω)
+  :?
+  (* J A C c a a'' (refl A' a') ≡  c{a} :  C{a, a, refl A a} by ?? *)
+  (eq.add_locally (derive -> ξ) (fun () ->
+   eq.add_locally (derive -> ζ) (fun () ->
+   eq.add_locally (derive -> ω) (fun () ->
+   convert (J A C c a a'' (convert (refl A' a') (congruence (Id A' a' a') (Id A a a'') ξ ζ ρ)))
+    (congruence
+    (C{a, a'', (convert (refl A' a') (congruence (Id A' a' a') (Id A a a'') ξ ζ ρ)) })
+    (C{a, a, refl A a})
+    (judgemental_equality_term.eq_term_refl A a)
+    ω
+    (convert (congruence (refl A' a') (refl A a) ξ ζ) (congruence (Id A' a' a') (Id A a a'') ξ ζ ρ)))
+   ≡ c{a} : C{a, a, refl A a} by ??))))
 ;;
 
 eq.add_rule J_β

--- a/theories/simple_products.m31
+++ b/theories/simple_products.m31
@@ -2,18 +2,33 @@ require eq;;
 
 rule (×) (A type) (B type) type ;;
 
-rule pair (A type) (B type) (a : A) (b : B) : A × B ;; 
+rule pair (A type) (B type) (a : A) (b : B) : A × B ;;
 
 rule fst (A type) (B type) (u : A × B) : A ;;
 rule snd (A type) (B type) (u : A × B) : B ;;
 
-rule β_fst (A type) (B type) (s : A) (t : B) : fst A B (pair A B s t) ≡ s : A ;;
+rule β_fst (A₁ type) (A₂ type)
+           (B₁ type) (B₂ type)
+           (s : A₂) (t : B₂)
+           (A₂ ≡ A₁ by ξ) (B₂ ≡ B₁ by ζ)
+           :?
+           (eq.add_locally (derive -> ξ) (fun () ->
+            (eq.add_locally (derive -> ζ) (fun () ->
+              fst A₁ B₁ (pair A₂ B₂ s t) ≡ s : A₁ by ?? )))) ;;
 eq.add_rule β_fst ;;
-rule β_snd (A type) (B type) (s : A) (t : B) : snd A B (pair A B s t) ≡ t : B ;;
+
+rule β_snd (A₁ type) (A₂ type)
+           (B₁ type) (B₂ type)
+           (s : A₂) (t : B₂)
+           (A₂ ≡ A₁ by ξ) (B₂ ≡ B₁ by ζ)
+           :?
+           (eq.add_locally (derive -> ξ) (fun () ->
+            (eq.add_locally (derive -> ζ) (fun () ->
+              snd A₁ B₁ (pair A₂ B₂ s t) ≡ t : B₁ by ?? )))) ;;
 eq.add_rule β_snd ;;
 
-rule ext (A type) (B type) 
-         (p : A × B) (q : A × B) 
+rule ext (A type) (B type)
+         (p : A × B) (q : A × B)
          (fst A B p ≡ fst A B q : A)
          (snd A B p ≡ snd A B q : B)
          : p ≡ q : A × B ;;


### PR DESCRIPTION
The theories are fixed such that the computation rules adhere to the linear patterns. 
This is implemented using the `eq.add_locally(...)` trick whenever possible (rather than a bunch of manual `convert` and `congruence` rules), to improve human-readability of the rules. 